### PR TITLE
Updating the imports to avoid error

### DIFF
--- a/Reinforcement (Q-)Learning with PyTorch.ipynb
+++ b/Reinforcement (Q-)Learning with PyTorch.ipynb
@@ -53,6 +53,7 @@
     "from copy import deepcopy\n",
     "from PIL import Image\n",
     "\n",
+    "import torch\n"
     "import torch.nn as nn\n",
     "import torch.optim as optim\n",
     "import torch.autograd as autograd\n",


### PR DESCRIPTION
By adding "import torch" then we avoid having an error raised when attempting to call:
screen = torch.from_numpy(screen)