### PR TITLE
fix link to pytorch slack

### DIFF
--- a/Deep Learning with PyTorch.ipynb
+++ b/Deep Learning with PyTorch.ipynb
@@ -1238,7 +1238,7 @@
     "- [More examples](https://github.com/pytorch/examples)\n",
     "- [More tutorials](https://github.com/pytorch/tutorials)\n",
     "- [Discuss PyTorch on the Forums](https://discuss.pytorch.org/)\n",
-    "- [Chat with other users on Slack](pytorch.slack.com/messages/beginner/)"
+    "- [Chat with other users on Slack](http://pytorch.slack.com/messages/beginner/)"
    ]
   },
   {


### PR DESCRIPTION
Fix for broken link in deep learning tutorial (issue #9 )