### PR TITLE
Fixed clamp not being applied to parameters

### DIFF
--- a/Reinforcement (Q-)Learning with PyTorch.ipynb
+++ b/Reinforcement (Q-)Learning with PyTorch.ipynb
@@ -367,7 +367,7 @@
     "    optimizer.zero_grad()\n",
     "    loss.backward()\n",
     "    for param in model.parameters():\n",
-    "        param.grad.data.clamp(-1, 1)\n",
+    "        param.grad.data.clamp_(-1, 1)\n",
     "    optimizer.step()\n",
     "\n",
     "\n",


### PR DESCRIPTION
I'm just learning about PyTorch, but I think the line `param.grad.data.clamp(-1, 1)` has no effect. I guess you wanted to do it *in-place*, which is `clamp_` if I'm not mistaken.