### PR TITLE
make some variable and function names more accurate in intermediate RNN tutorials

### DIFF
--- a/intermediate_source/char_rnn_classification_tutorial.py
+++ b/intermediate_source/char_rnn_classification_tutorial.py
@@ -274,7 +274,7 @@ import random
 def randomChoice(l):
     return l[random.randint(0, len(l) - 1)]
 
-def randomTrainingPair():                                                                                                               
+def randomTrainingExample():
     category = randomChoice(all_categories)
     line = randomChoice(category_lines[category])
     category_tensor = Variable(torch.LongTensor([all_categories.index(category)]))
@@ -282,7 +282,7 @@ def randomTrainingPair():
     return category, line, category_tensor, line_tensor
 
 for i in range(10):
-    category, line, category_tensor, line_tensor = randomTrainingPair()
+    category, line, category_tensor, line_tensor = randomTrainingExample()
     print('category =', category, '/ line =', line)
 
 
@@ -338,14 +338,14 @@ def train(category_tensor, line_tensor):
 # Now we just have to run that with a bunch of examples. Since the
 # ``train`` function returns both the output and loss we can print its
 # guesses and also keep track of loss for plotting. Since there are 1000s
-# of examples we print only every ``print_every`` time steps, and take an
+# of examples we print only every ``print_every`` examples, and take an
 # average of the loss.
 # 
 
 import time
 import math
 
-n_epochs = 100000
+n_iters = 100000
 print_every = 5000
 plot_every = 1000
 
@@ -364,19 +364,19 @@ def timeSince(since):
 
 start = time.time()
 
-for epoch in range(1, n_epochs + 1):
-    category, line, category_tensor, line_tensor = randomTrainingPair()
+for iter in range(1, n_iters + 1):
+    category, line, category_tensor, line_tensor = randomTrainingExample()
     output, loss = train(category_tensor, line_tensor)
     current_loss += loss
 
-    # Print epoch number, loss, name and guess
-    if epoch % print_every == 0:
+    # Print iter number, loss, name and guess
+    if iter % print_every == 0:
         guess, guess_i = categoryFromOutput(output)
         correct = '✓' if guess == category else '✗ (%s)' % category
-        print('%d %d%% (%s) %.4f %s / %s %s' % (epoch, epoch / n_epochs * 100, timeSince(start), loss, line, guess, correct))
+        print('%d %d%% (%s) %.4f %s / %s %s' % (iter, iter / n_iters * 100, timeSince(start), loss, line, guess, correct))
 
     # Add current loss avg to list of losses
-    if epoch % plot_every == 0:
+    if iter % plot_every == 0:
         all_losses.append(current_loss / plot_every)
         current_loss = 0
 
@@ -422,7 +422,7 @@ def evaluate(line_tensor):
 
 # Go through a bunch of examples and record which are correctly guessed
 for i in range(n_confusion):
-    category, line, category_tensor, line_tensor = randomTrainingPair()
+    category, line, category_tensor, line_tensor = randomTrainingExample()
     output = evaluate(line_tensor)
     guess, guess_i = categoryFromOutput(output)
     category_i = all_categories.index(category)

--- a/intermediate_source/char_rnn_generation_tutorial.py
+++ b/intermediate_source/char_rnn_generation_tutorial.py
@@ -236,13 +236,13 @@ def targetTensor(line):
 
 
 ######################################################################
-# For convenience during training we'll make a ``randomTrainingSet``
+# For convenience during training we'll make a ``randomTrainingExample``
 # function that fetches a random (category, line) pair and turns them into
 # the required (category, input, target) tensors.
 # 
 
 # Make category, input, and target tensors from a random category, line pair
-def randomTrainingSet():
+def randomTrainingExample():
     category, line = randomTrainingPair()
     category_tensor = Variable(categoryTensor(category))
     input_line_tensor = Variable(inputTensor(line))
@@ -259,8 +259,7 @@ def randomTrainingSet():
 # every step.
 # 
 # The magic of autograd allows you to simply sum these losses at each step
-# and call backward at the end. But don't ask me why initializing loss
-# with 0 works.
+# and call backward at the end.
 # 
 
 criterion = nn.NLLLoss()
@@ -305,28 +304,28 @@ def timeSince(since):
 ######################################################################
 # Training is business as usual - call train a bunch of times and wait a
 # few minutes, printing the current time and loss every ``print_every``
-# epochs, and keeping store of an average loss per ``plot_every`` epochs
+# examples, and keeping store of an average loss per ``plot_every`` examples
 # in ``all_losses`` for plotting later.
 # 
 
 rnn = RNN(n_letters, 128, n_letters)
 
-n_epochs = 100000
+n_iters = 100000
 print_every = 5000
 plot_every = 500
 all_losses = []
-total_loss = 0 # Reset every plot_every epochs
+total_loss = 0 # Reset every plot_every iters
 
 start = time.time()
 
-for epoch in range(1, n_epochs + 1):
-    output, loss = train(*randomTrainingSet())
+for iter in range(1, n_iters + 1):
+    output, loss = train(*randomTrainingExample())
     total_loss += loss
     
-    if epoch % print_every == 0:
-        print('%s (%d %d%%) %.4f' % (timeSince(start), epoch, epoch / n_epochs * 100, loss))
+    if iter % print_every == 0:
+        print('%s (%d %d%%) %.4f' % (timeSince(start), iter, iter / n_iters * 100, loss))
 
-    if epoch % plot_every == 0:
+    if iter % plot_every == 0:
         all_losses.append(total_loss / plot_every)
         total_loss = 0
 

--- a/intermediate_source/seq2seq_translation_tutorial.py
+++ b/intermediate_source/seq2seq_translation_tutorial.py
@@ -650,10 +650,10 @@ def timeSince(since, percent):
 # -  Start empty losses array for plotting
 #
 # Then we call ``train`` many times and occasionally print the progress (%
-# of epochs, time so far, estimated time) and average loss.
+# of examples, time so far, estimated time) and average loss.
 #
 
-def trainEpochs(encoder, decoder, n_epochs, print_every=1000, plot_every=100, learning_rate=0.01):
+def trainIters(encoder, decoder, n_iters, print_every=1000, plot_every=100, learning_rate=0.01):
     start = time.time()
     plot_losses = []
     print_loss_total = 0  # Reset every print_every
@@ -662,11 +662,11 @@ def trainEpochs(encoder, decoder, n_epochs, print_every=1000, plot_every=100, le
     encoder_optimizer = optim.SGD(encoder.parameters(), lr=learning_rate)
     decoder_optimizer = optim.SGD(decoder.parameters(), lr=learning_rate)
     training_pairs = [variablesFromPair(random.choice(pairs))
-                      for i in range(n_epochs)]
+                      for i in range(n_iters)]
     criterion = nn.NLLLoss()
 
-    for epoch in range(1, n_epochs + 1):
-        training_pair = training_pairs[epoch - 1]
+    for iter in range(1, n_iters + 1):
+        training_pair = training_pairs[iter - 1]
         input_variable = training_pair[0]
         target_variable = training_pair[1]
  
@@ -675,13 +675,13 @@ def trainEpochs(encoder, decoder, n_epochs, print_every=1000, plot_every=100, le
         print_loss_total += loss
         plot_loss_total += loss
 
-        if epoch % print_every == 0:
+        if iter % print_every == 0:
             print_loss_avg = print_loss_total / print_every
             print_loss_total = 0
-            print('%s (%d %d%%) %.4f' % (timeSince(start, epoch / n_epochs),
-                                         epoch, epoch / n_epochs * 100, print_loss_avg))
+            print('%s (%d %d%%) %.4f' % (timeSince(start, iter / n_iters),
+                                         iter, iter / n_iters * 100, print_loss_avg))
 
-        if epoch % plot_every == 0:
+        if iter % plot_every == 0:
             plot_loss_avg = plot_loss_total / plot_every
             plot_losses.append(plot_loss_avg)
             plot_loss_total = 0
@@ -793,7 +793,7 @@ def evaluateRandomly(encoder, decoder, n=10):
 # .. Note:: 
 #    If you run this notebook you can train, interrupt the kernel,
 #    evaluate, and continue training later. Comment out the lines where the
-#    encoder and decoder are initialized and run ``trainEpochs`` again.
+#    encoder and decoder are initialized and run ``trainIters`` again.
 #
 
 hidden_size = 256
@@ -805,7 +805,7 @@ if use_cuda:
     encoder1 = encoder1.cuda()
     attn_decoder1 = attn_decoder1.cuda()
 
-trainEpochs(encoder1, attn_decoder1, 75000, print_every=5000)
+trainIters(encoder1, attn_decoder1, 75000, print_every=5000)
 
 ######################################################################
 #


### PR DESCRIPTION
Previously, processing a single training example was referred to as an "epoch".  I changed this to "step".  A downside of the change is that sometimes "step" is used to refer to a single step of the RNN in processing a training example.  But I don't think there will be too much confusion.

Previously, a function called "randomTrainingSet" in the generation tutorial returned the prepared tensors for a single training example.  I changed the name to "randomTrainingExample".

Previously, a function called "randomTrainingPair" in the classification tutorial returned the prepared tensors for a single training example.  I changed the name to "randomTrainingExample".  The old name also clashed with the use of the name "randomTrainingPair" in the generation tutorial.

A small remaining inconsistency is that both the classification and generation tutorials define functions called "train" but this function is invoked (after my name change) "train(*randomTrainingExample())" in the generation tutorial but cannot be invoked this way in the classification tutorial.