### PR TITLE
fix bug when using cuda in ubuntu

### DIFF
--- a/intermediate_source/reinforcement_q_learning.py
+++ b/intermediate_source/reinforcement_q_learning.py
@@ -310,12 +310,12 @@ if USE_CUDA:
     model.cuda()
 
 
-class Variable(autograd.Variable):
+def Variable(data, volatile=False):
+    if USE_CUDA:
+        return autograd.Variable(data.cuda(),volatile=volatile)
+    else:
+        return autograd.Variable(data, volatile=volatile)
 
-    def __init__(self, data, *args, **kwargs):
-        if USE_CUDA:
-            data = data.cuda()
-        super(Variable, self).__init__(data, *args, **kwargs)
 
 
 steps_done = 0


### PR DESCRIPTION
The Class Variable's __init__() doesn't return a cuda Variable because the 'data' would be released later. This bug results in free(): invalid pointer error.