### PR TITLE
rnn was initialized twice

### DIFF
--- a/intermediate_source/char_rnn_classification_tutorial.py
+++ b/intermediate_source/char_rnn_classification_tutorial.py
@@ -349,7 +349,7 @@ n_epochs = 100000
 print_every = 5000
 plot_every = 1000
 
-rnn = RNN(n_letters, n_hidden, n_categories)
+
 
 # Keep track of losses for plotting
 current_loss = 0


### PR DESCRIPTION
rnn has already been initialized before. it's not necessary to reinitialize here. 
Also, this might lead to a bug if using optimizer.step() to update weights without noticing there're two rnn.