### PR TITLE
rm useless init_hidden in BiLSTM_CRF

### DIFF
--- a/beginner_source/nlp/advanced_tutorial.py
+++ b/beginner_source/nlp/advanced_tutorial.py
@@ -277,14 +277,12 @@ class BiLSTM_CRF(nn.Module):
         return path_score, best_path
 
     def neg_log_likelihood(self, sentence, tags):
-        self.hidden = self.init_hidden()
         feats = self._get_lstm_features(sentence)
         forward_score = self._forward_alg(feats)
         gold_score = self._score_sentence(feats, tags)
         return forward_score - gold_score
 
     def forward(self, sentence):  # dont confuse this with _forward_alg above.
-        self.hidden = self.init_hidden()
         # Get the emission scores from the BiLSTM
         lstm_feats = self._get_lstm_features(sentence)
 


### PR DESCRIPTION
These two init_hidden are useless. Because they will be called in the _get_lstm_features function.