### PR TITLE
fixed link to slack in former_torchies/parallelism_tutorial.py

### DIFF
--- a/beginner_source/former_torchies/parallelism_tutorial.py
+++ b/beginner_source/former_torchies/parallelism_tutorial.py
@@ -124,4 +124,4 @@ class DistributedModel(nn.Module):
 # .. _More examples: https://github.com/pytorch/examples
 # .. _More tutorials: https://github.com/pytorch/tutorials
 # .. _Discuss PyTorch on the Forums: https://discuss.pytorch.org/
-# .. _Chat with other users on Slack: pytorch.slack.com/messages/beginner/
+# .. _Chat with other users on Slack: http://pytorch.slack.com/messages/beginner/


### PR DESCRIPTION
as described by @jnhwkim [here](https://github.com/pytorch/tutorials/issues/100#issuecomment-311296355), similar to #9 .