### PR TITLE
fixed link for "Train neural nets to play video games"

### DIFF
--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -300,7 +300,7 @@ for i in range(10):
 # Where do I go next?
 # -------------------
 #
-# -  `Train neural nets to play video games`_
+# -  :doc:`Train neural nets to play video games </intermediate/reinforcement_q_learning>`
 # -  `Train a state-of-the-art ResNet network on imagenet`_
 # -  `Train an face generator using Generative Adversarial Networks`_
 # -  `Train a word-level language model using Recurrent LSTM networks`_
@@ -309,7 +309,6 @@ for i in range(10):
 # -  `Discuss PyTorch on the Forums`_
 # -  `Chat with other users on Slack`_
 #
-# .. _Train neural nets to play video games: https://goo.gl/uGOksc
 # .. _Train a state-of-the-art ResNet network on imagenet: https://github.com/pytorch/examples/tree/master/imagenet
 # .. _Train an face generator using Generative Adversarial Networks: https://github.com/pytorch/examples/tree/master/dcgan
 # .. _Train a word-level language model using Recurrent LSTM networks: https://github.com/pytorch/examples/tree/master/word_language_model

--- a/beginner_source/former_torchies/parallelism_tutorial.py
+++ b/beginner_source/former_torchies/parallelism_tutorial.py
@@ -107,7 +107,7 @@ class DistributedModel(nn.Module):
 #
 # Also look at
 #
-# -  `Train neural nets to play video games`_
+# -  :doc:`Train neural nets to play video games </intermediate/reinforcement_q_learning>`
 # -  `Train a state-of-the-art ResNet network on imagenet`_
 # -  `Train an face generator using Generative Adversarial Networks`_
 # -  `Train a word-level language model using Recurrent LSTM networks`_
@@ -117,7 +117,6 @@ class DistributedModel(nn.Module):
 # -  `Chat with other users on Slack`_
 #
 # .. _`Deep Learning with PyTorch: a 60-minute blitz`: https://github.com/pytorch/tutorials/blob/master/Deep%20Learning%20with%20PyTorch.ipynb
-# .. _Train neural nets to play video games: https://goo.gl/uGOksc
 # .. _Train a state-of-the-art ResNet network on imagenet: https://github.com/pytorch/examples/tree/master/imagenet
 # .. _Train an face generator using Generative Adversarial Networks: https://github.com/pytorch/examples/tree/master/dcgan
 # .. _Train a word-level language model using Recurrent LSTM networks: https://github.com/pytorch/examples/tree/master/word_language_model


### PR DESCRIPTION
now pointing directly to /intermediate/reinforcement_q_learning

Fixes the issue reported in #100 .