### PR TITLE
Load the weights to CPU if CUDA is not available

### DIFF
--- a/advanced_source/super_resolution_with_caffe2.py
+++ b/advanced_source/super_resolution_with_caffe2.py
@@ -89,7 +89,10 @@ model_url = 'https://s3.amazonaws.com/pytorch/test_data/export/superres_epoch100
 batch_size = 1    # just a random number
 
 # Initialize model with the pretrained weights
-torch_model.load_state_dict(model_zoo.load_url(model_url))
+map_location = lambda storage, loc: storage
+if torch.cuda.is_available():
+    map_location = None
+torch_model.load_state_dict(model_zoo.load_url(model_url, map_location=map_location))
 
 # set the train mode to false since we will only run the forward pass.
 torch_model.train(False)


### PR DESCRIPTION
We can use map_location to indicate where we should load the data.
If CUDA is unavailable, we should load weights to CPU.