### PR TITLE
fix image show error

### DIFF
--- a/beginner_source/transfer_learning_tutorial.py
+++ b/beginner_source/transfer_learning_tutorial.py
@@ -111,8 +111,7 @@ def imshow(inp, title=None):
     mean = np.array([0.485, 0.456, 0.406])
     std = np.array([0.229, 0.224, 0.225])
     inp = std * inp + mean
-    inp = np.maximum(inp, 0)
-    inp = np.minimum(inp, 1)
+    inp = np.clip(inp, 0, 1)
     plt.imshow(inp)
     if title is not None:
         plt.title(title)

--- a/beginner_source/transfer_learning_tutorial.py
+++ b/beginner_source/transfer_learning_tutorial.py
@@ -111,6 +111,8 @@ def imshow(inp, title=None):
     mean = np.array([0.485, 0.456, 0.406])
     std = np.array([0.229, 0.224, 0.225])
     inp = std * inp + mean
+    inp = np.maximum(inp, 0)
+    inp = np.minimum(inp, 1)
     plt.imshow(inp)
     if title is not None:
         plt.title(title)


### PR DESCRIPTION
since it normalized the channel value to specific std and mean, when show the image and reverse its value to [0, 1], sometimes it got error of **Floating point image RGB values must be in the 0..1 range.**

use np.maximum() and np.minimum() to restrict the value to [0,1]