### PR TITLE
Fix blitz neural networks shape mismatch

### DIFF
--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -160,6 +160,7 @@ out.backward(torch.randn(1, 10))
 
 output = net(input)
 target = Variable(torch.arange(1, 11))  # a dummy target, for example
+target = target.view(1, -1)  # make it the same shape as output
 criterion = nn.MSELoss()
 
 loss = criterion(output, target)


### PR DESCRIPTION
When running the actual tutorial code as:

```python
 output = net(input)
 target = Variable(torch.arange(1, 11))  # a dummy target, for example
 criterion = nn.MSELoss()

loss = criterion(output, target)
```

It results in an error:

```
...

RuntimeError: input and target shapes do not match: input [1 x 10], target [10] at /tmp/pip-l72ec2wl-build/aten/src/THNN/generic/MSECriterion.c:13
```

Due to the fact that the shape of the `output` is `(1, 10)` and the shape of the `target` is `(10,)`.

This PR updates the shape of the target to be compatible with the output, fixing the error.
