### PR TITLE
Fix epoch accuracy (avoiding integer division)

### DIFF
--- a/beginner_source/transfer_learning_tutorial.py
+++ b/beginner_source/transfer_learning_tutorial.py
@@ -187,7 +187,7 @@ def train_model(model, criterion, optimizer, scheduler, num_epochs=25):
                 running_corrects += torch.sum(preds == labels.data)
 
             epoch_loss = running_loss / dataset_sizes[phase]
-            epoch_acc = running_corrects / dataset_sizes[phase]
+            epoch_acc = running_corrects.double() / dataset_sizes[phase]
 
             print('{} Loss: {:.4f} Acc: {:.4f}'.format(
                 phase, epoch_loss, epoch_acc))


### PR DESCRIPTION

Fixes the constant 0 accuracy I get running this tutorial since v0.4
Epoch 0/24
train Loss: 0.8934 Acc: 0.0000
val Loss: 0.7645 Acc: 0.0000

Epoch 1/24
train Loss: 0.6792 Acc: 0.0000
val Loss: 0.2288 Acc: 0.0000