### PR TITLE
Use variable instead of magic number in data_parallel_tutorial.py

### DIFF
--- a/beginner_source/blitz/data_parallel_tutorial.py
+++ b/beginner_source/blitz/data_parallel_tutorial.py
@@ -79,7 +79,7 @@ class RandomDataset(Dataset):
     def __len__(self):
         return self.len
 
-rand_loader = DataLoader(dataset=RandomDataset(input_size, 100),
+rand_loader = DataLoader(dataset=RandomDataset(input_size, data_size),
                          batch_size=batch_size, shuffle=True)
 
 


### PR DESCRIPTION
Uses the variable that was defined already in the header, but not used in the source code.