### PR TITLE
change pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ torch
 # to run examples
 pandas
 scikit-image
-pillow
+pillow=4.1.1


### PR DESCRIPTION
latest pillow version will cause an error(` cannot write mode RGBA as JPEG`) when executing "make docs"