### PR TITLE
fixing gradient of ReLU operation

### DIFF
--- a/beginner_source/examples_tensor/two_layer_net_tensor.py
+++ b/beginner_source/examples_tensor/two_layer_net_tensor.py
@@ -53,7 +53,7 @@ for t in range(500):
     grad_w2 = h_relu.t().mm(grad_y_pred)
     grad_h_relu = grad_y_pred.mm(w2.t())
     grad_h = grad_h_relu.clone()
-    grad_h[h < 0] = 0
+    grad_h[h <= 0] = 0
     grad_w1 = x.t().mm(grad_h)
 
     # Update weights using gradient descent


### PR DESCRIPTION
If a = ReLU(b) then grad_a = signum(a) . Therefore, the existing line 56  grad_h[h < 0] = 0 misses to set grad_h[h = 0] = 0.