### PR TITLE
Fix arange in blitz tutorial

### DIFF
--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -156,7 +156,7 @@ out.backward(torch.randn(1, 10))
 # For example:
 
 output = net(input)
-target = torch.arange(1, 11)  # a dummy target, for example
+target = torch.randn(10)  # a dummy target, for example
 target = target.view(1, -1)  # make it the same shape as output
 criterion = nn.MSELoss()
 


### PR DESCRIPTION
In [the tutorial](https://pytorch.org/tutorials/beginner/blitz/neural_networks_tutorial.html),
`torch.arange` is being used as a FloatTensor. This behavior was changed
in https://github.com/pytorch/pytorch/pull/7016 to return a LongTensor.
I removed the `torch.arange` usage and instead construct a tensor with
`torch.randn`

cc @SsnL 