### PR TITLE
Remove pillow exact dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ torch
 # to run examples
 pandas
 scikit-image
-pillow==4.1.1


### PR DESCRIPTION
That exact dependency was added in #261 at Jun 19. It's unclear to me what version conflicted because it appeared to be the latest released version at that date ( https://pypi.org/project/Pillow/#history ).

The problem is that `scikit-image==0.14.0` requires `pillow [required: >=4.3.0]` (got with `pipenv graph`). So this rule makes it impossible to install the requirements: `Could not find a version that matches Pillow==4.1.1,>=4.1.1,>=4.3.0`.

I started running `make docs` but after 15min it didn't finish the first build so I don't really know how to reproduce the initial error.