### PR TITLE
Update autograd_tutorial.py

### DIFF
--- a/beginner_source/blitz/autograd_tutorial.py
+++ b/beginner_source/blitz/autograd_tutorial.py
@@ -88,7 +88,7 @@ print(b.grad_fn)
 # ---------
 # Let's backprop now
 # Because ``out`` contains a single scalar, ``out.backward()`` is
-# equivalent to ``out.backward(torch.tensor(1))``.
+# equivalent to ``out.backward(torch.tensor(1, dtype=torch.float))``.
 
 out.backward()
 


### PR DESCRIPTION
Fix so the statement is valid. Otherwise it results in:

```
E       RuntimeError: invalid gradient at index 0 - expected type torch.FloatTensor but got torch.LongTensor
../../../anaconda3/envs/phd/lib/python3.6/site-packages/torch/autograd/__init__.py:90: RuntimeError
```