### PR TITLE
Fix typo in blitz nn tutorial.

### DIFF
--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -7,7 +7,7 @@ Neural networks can be constructed using the ``torch.nn`` package.
 
 Now that you had a glimpse of ``autograd``, ``nn`` depends on
 ``autograd`` to define models and differentiate them.
-An ``nn.Module`` contains layers, and a method ``forward(input)``\ that
+An ``nn.Module`` contains layers, and a method ``forward(input)`` that
 returns the ``output``.
 
 For example, look at this network that classifies digit images:
@@ -90,7 +90,7 @@ print(len(params))
 print(params[0].size())  # conv1's .weight
 
 ########################################################################
-# Let try a random 32x32 input
+# Let's try a random 32x32 input.
 # Note: Expected input size to this net(LeNet) is 32x32. To use this net on
 # MNIST dataset, please resize the images from the dataset to 32x32.
 


### PR DESCRIPTION
- Remove extra backslash.
- Add missing punctuation.