### PR TITLE
Fix line endings in csvwriter for windows machine

### DIFF
--- a/beginner_source/chatbot_tutorial.py
+++ b/beginner_source/chatbot_tutorial.py
@@ -250,7 +250,7 @@ conversations = loadConversations(os.path.join(corpus, "movie_conversations.txt"
 # Write new csv file
 print("\nWriting newly formatted file...")
 with open(datafile, 'w', encoding='utf-8') as outputfile:
-    writer = csv.writer(outputfile, delimiter=delimiter)
+    writer = csv.writer(outputfile, delimiter=delimiter, lineterminator='\n')
     for pair in extractSentencePairs(conversations):
         writer.writerow(pair)
 


### PR DESCRIPTION
On windows machines the default line endings are \r\n instead of \n. This causes code to fail in the filterPair function. Fix details here https://stackoverflow.com/questions/8746908/why-does-csv-file-contain-a-blank-line-in-between-each-data-line-when-outputting