### PR TITLE
Fix maskNLLLoss in chatbot_tutorial.py

### DIFF
--- a/beginner_source/chatbot_tutorial.py
+++ b/beginner_source/chatbot_tutorial.py
@@ -894,7 +894,9 @@ class LuongAttnDecoderRNN(nn.Module):
 
 def maskNLLLoss(inp, target, mask):
     nTotal = mask.sum()
-    crossEntropy = -torch.log(torch.gather(inp, 1, target.view(-1, 1)))
+    # The following line is equivalent to
+    # crossEntropy = -torch.log(inp[torch.arange(inp.shape[0]), target])
+    crossEntropy = -torch.log(torch.gather(inp, 1, target.view(-1, 1))).view(-1)
     loss = crossEntropy.masked_select(mask).mean()
     loss = loss.to(device)
     return loss, nTotal.item()


### PR DESCRIPTION
The original `crossEntropy` has shape `[batch_size, 1]` and `mask` has shape `[batch_size]`. Calling `crossEntropy.masked_select(mask)` will get `crossEntropy.expand(-1, nTotal).flatten()`.

This patch flatten `crossEntropy` so that `crossEntropy.masked_select(mask)` will only contain the elements corresponding to 1 in the `mask`.