### PR TITLE
Correction of line 111, removed error caused by ambiguity

### DIFF
--- a/advanced_source/cpp_export.rst
+++ b/advanced_source/cpp_export.rst
@@ -108,13 +108,13 @@ method::
 
       @torch.jit.script_method
       def forward(self, input):
-          if input.sum() > 0:
+          if int(input.sum()) > 0:
             output = self.weight.mv(input)
           else:
             output = self.weight + input
           return output
-
-  my_script_module = MyModule()
+  
+  my_script_module = MyModule(10, 10)
 
 Creating a new ``MyModule`` object now directly produces an instance of
 ``ScriptModule`` that is ready for serialization.


### PR DESCRIPTION
Corrected following error caused due to ambiguity around "if input.sum() > 0;" as to whether there was a bool or integer comparison

```
expected a boolean expression for condition but found Tensor, to use a tensor in a boolean expression, explicitly cast it with `bool()`:
@torch.jit.script_method
def forward(self, input):
    if input.sum() > 0:
       ~~~~~~~~~~~~~~~ <--- HERE
        output = self.weight.mv(input)
    else:
        output = self.weight + input
    return output
```