### PR TITLE
Fixed some issues

### DIFF
--- a/beginner_source/blitz/autograd_tutorial.py
+++ b/beginner_source/blitz/autograd_tutorial.py
@@ -86,7 +86,7 @@ print(b.grad_fn)
 ###############################################################
 # Gradients
 # ---------
-# Let's backprop now
+# Let's backprop now.
 # Because ``out`` contains a single scalar, ``out.backward()`` is
 # equivalent to ``out.backward(torch.tensor(1))``.
 

--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -43,7 +43,7 @@ Training an image classifier
 
 We will do the following steps in order:
 
-1. Load and normalizing the CIFAR10 training and test datasets using
+1. Load and normalize the CIFAR10 training and test datasets using
    ``torchvision``
 2. Define a Convolution Neural Network
 3. Define a loss function

--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -58,7 +58,7 @@ class Net(nn.Module):
     def forward(self, x):
         # Max pooling over a (2, 2) window
         x = F.max_pool2d(F.relu(self.conv1(x)), (2, 2))
-        # If the size is a square you can only specify a single number
+        # If the size is a square you can specify a single number also
         x = F.max_pool2d(F.relu(self.conv2(x)), 2)
         x = x.view(-1, self.num_flat_features(x))
         x = F.relu(self.fc1(x))


### PR DESCRIPTION
Some small fixes. Reasons:

 In file [beginner_source/blitz/autograd_tutorial.py](beginner_source/blitz/autograd_tutorial.py)
The two sentences are rendered on the same line. See [this](https://pytorch.org/tutorials/beginner/blitz/autograd_tutorial.html#gradients)

In file [beginner_source/blitz/cifar10_tutorial.py](beginner_source/blitz/cifar10_tutorial.py)
Grammatical error

In file [beginner_source/blitz/neural_networks_tutorial.py](beginner_source/blitz/neural_networks_tutorial.py)
"you can only specify a single number" may imply it is the only way to do it