### PR TITLE
Fix wrong parameter.

### DIFF
--- a/advanced_source/cpp_extension.rst
+++ b/advanced_source/cpp_extension.rst
@@ -954,7 +954,7 @@ on it:
     const int threads = 1024;
     const dim3 blocks((state_size + threads - 1) / threads, batch_size);
 
-    AT_DISPATCH_FLOATING_TYPES(X.type(), "lltm_forward_cuda", ([&] {
+    AT_DISPATCH_FLOATING_TYPES(X.type(), "lltm_backward_cuda", ([&] {
       lltm_cuda_backward_kernel<scalar_t><<<blocks, threads>>>(
           d_old_cell.data<scalar_t>(),
           d_gates.data<scalar_t>(),


### PR DESCRIPTION
The second parameter was wrong which means the name (for error messages) of the kernal. It is repeated with the name of the forward kernel and should be backward kernal.