### PR TITLE
Add `LC_ALL` to force a default locale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Minimal makefile for Sphinx documentation
 #
 
+# Locale
+export LC_ALL=C
+
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build

--- a/README.md
+++ b/README.md
@@ -22,5 +22,8 @@ In case you prefer to write your tutorial in jupyter, you can use [this script](
 ## Building
 
 - Start with installing torch, torchvision, and your GPUs latest drivers. Install other requirements using `pip install -r requirements.txt`
+
+> If you want to use `virtualenv`, make your environment in a `venv` directory like: `virtualenv ./venv`, then `source ./venv/bin/activate`.
+
 - Then you can build using `make docs`. This will download the data, execute the tutorials and build the documentation to `docs/` directory. This will take about 60-120 min for systems with GPUs. If you do not have a GPU installed on your system, then see next step.
 - You can skip the computationally intensive graph generation by running `make html-noplot` to build basic html documentation to `_build/html`. This way, you can quickly preview your tutorial.


### PR DESCRIPTION
Last run of the build, I saw:

```
02:15:55 make html
02:15:55 make[1]: Entering directory '/var/lib/jenkins/workspace'
02:15:56 Traceback (most recent call last):
02:15:56   File "/opt/conda/bin/sphinx-build", line 11, in <module>
02:15:56     sys.exit(main())
02:15:56   File "/opt/conda/lib/python3.6/site-packages/sphinx/cmd/build.py", line 313, in main
02:15:56     locale.setlocale(locale.LC_ALL, '')
02:15:56   File "/opt/conda/lib/python3.6/locale.py", line 598, in setlocale
02:15:56     return _setlocale(category, locale)
02:15:56 locale.Error: unsupported locale setting
02:15:56 make[1]: *** [html] Error 1
02:15:56 Makefile:21: recipe for target 'html' failed
```

So trying to fix it with an explicit locale set