### PR TITLE
Blitz tutorial code will now actually display an image

### DIFF
--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -93,6 +93,7 @@ def imshow(img):
     img = img / 2 + 0.5     # unnormalize
     npimg = img.numpy()
     plt.imshow(np.transpose(npimg, (1, 2, 0)))
+    plt.show()
 
 
 # get some random training images


### PR DESCRIPTION
Tutorial says an image should be displayed so I added a line that will actually display an image. However, if the line `plt.show()` is intentionally missing, then as a beginner who's unfamiliar with Matplotlib, it has caused me to wonder what's wrong with my code for a long time.