### PR TITLE
fix CrossEntropy size in chatbot to align with the mask

### DIFF
--- a/beginner_source/chatbot_tutorial.py
+++ b/beginner_source/chatbot_tutorial.py
@@ -890,7 +890,7 @@ class LuongAttnDecoderRNN(nn.Module):
 
 def maskNLLLoss(inp, target, mask):
     nTotal = mask.sum()
-    crossEntropy = -torch.log(torch.gather(inp, 1, target.view(-1, 1)))
+    crossEntropy = -torch.log(torch.gather(inp, 1, target.view(-1, 1)).squeeze(1))
     loss = crossEntropy.masked_select(mask).mean()
     loss = loss.to(device)
     return loss, nTotal.item()


### PR DESCRIPTION
I feel how the following filter loss through mask is queationable

assume `batch_size` is `64`, then
`mask` size is `(64)`
`crossEntropy` size is `(64, 1)`

I know you can take use of **[Broadcasting](https://pytorch.org/docs/stable/notes/broadcasting.html#broadcasting-semantics)**. That's why it can run without exceptions.
However, i guess Broadcasting changes `mask` to `(1, 64)` to work.

Below is sample test how it's wrong
<img width="425" alt="screenshot 2018-12-13 at 12 38 31 am" src="https://user-images.githubusercontent.com/5113450/49917996-73a7c580-fe6f-11e8-85f2-bd84397c63b4.png">

Here I simply squeeze the added dim for `gather`, so their sizes are both `(64)`