### PR TITLE
fix some reST syntax warnings (#393)

### DIFF
--- a/advanced_source/torch_script_custom_ops.rst
+++ b/advanced_source/torch_script_custom_ops.rst
@@ -23,7 +23,7 @@ Python and in their serialized form directly in C++.
 The following paragraphs give an example of writing a TorchScript custom op to
 call into `OpenCV <https://www.opencv.org>`_, a computer vision library written
 in C++. We will discuss how to work with tensors in C++, how to efficiently
-convert them to third party tensor formats (in this case, OpenCV ``Mat``s), how
+convert them to third party tensor formats (in this case, OpenCV ``Mat`` s), how
 to register your operator with the TorchScript runtime and finally how to
 compile the operator and use it in Python and C++.
 
@@ -1018,7 +1018,7 @@ expects from a module), this route can be slightly quirky. That said, all you
 need is a ``setup.py`` file in place of the ``CMakeLists.txt`` which looks like
 this:
 
-.. code-block::
+.. code-block:: python
 
   from setuptools import setup
   from torch.utils.cpp_extension import BuildExtension, CppExtension
@@ -1081,7 +1081,7 @@ This will produce a shared library called ``warp_perspective.so``, which we can
 pass to ``torch.ops.load_library`` as we did earlier to make our operator
 visible to TorchScript:
 
-.. code-block::
+.. code-block:: python
 
   >>> import torch
   >>> torch.ops.load_library("warp_perspective.so")

--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -108,7 +108,7 @@ print(' '.join('%5s' % classes[labels[j]] for j in range(4)))
 
 ########################################################################
 # 2. Define a Convolutional Neural Network
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Copy the neural network from the Neural Networks section before and modify it to
 # take 3-channel images (instead of 1-channel images as it was defined).
 

--- a/beginner_source/nn_tutorial.py
+++ b/beginner_source/nn_tutorial.py
@@ -322,6 +322,7 @@ print(loss_func(model(xb), yb))
 # Previously for our training loop we had to update the values for each parameter
 # by name, and manually zero out the grads for each parameter separately, like this:
 # ::
+#
 #   with torch.no_grad():
 #       weights -= weights.grad * lr
 #       bias -= bias.grad * lr
@@ -334,6 +335,7 @@ print(loss_func(model(xb), yb))
 # and less prone to the error of forgetting some of our parameters, particularly
 # if we had a more complicated model:
 # ::
+#
 #   with torch.no_grad():
 #       for p in model.parameters(): p -= p.grad * lr
 #       model.zero_grad()
@@ -408,12 +410,14 @@ print(loss_func(model(xb), yb))
 #
 # This will let us replace our previous manually coded optimization step:
 # ::
+#
 #   with torch.no_grad():
 #       for p in model.parameters(): p -= p.grad * lr
 #       model.zero_grad()
 #
 # and instead use just:
 # ::
+#
 #   opt.step()
 #   opt.zero_grad()
 #
@@ -476,12 +480,14 @@ train_ds = TensorDataset(x_train, y_train)
 ###############################################################################
 # Previously, we had to iterate through minibatches of x and y values separately:
 # ::
+#
 #     xb = x_train[start_i:end_i]
 #     yb = y_train[start_i:end_i]
 #
 #
 # Now, we can do these two steps together:
 # ::
+#
 #     xb,yb = train_ds[i*bs : i*bs+bs]
 #
 
@@ -516,12 +522,14 @@ train_dl = DataLoader(train_ds, batch_size=bs)
 ###############################################################################
 # Previously, our loop iterated over batches (xb, yb) like this:
 # ::
+#
 #       for i in range((n-1)//bs + 1):
 #           xb,yb = train_ds[i*bs : i*bs+bs]
 #           pred = model(xb)
 #
 # Now, our loop is much cleaner, as (xb, yb) are loaded automatically from the data loader:
 # ::
+#
 #       for xb,yb in train_dl:
 #           pred = model(xb)
 


### PR DESCRIPTION
fix some reST syntax warnings while building html (using `make html` or `make html-noplot`).

Now, syntax warnings  that occur are as below:
```
...
reading sources... [100%] intermediate/spatial_transformer_tutorial
/Users/reserve/Workspace/tutorials/advanced/cpp_extension.rst:2: WARNING: Duplicate explicit target name: "here".
/Users/reserve/Workspace/tutorials/advanced/cpp_extension.rst:2: WARNING: Duplicate explicit target name: "here".
/Users/reserve/Workspace/tutorials/advanced/torch_script_custom_ops.rst:2: WARNING: Duplicate explicit target name: "here".
/Users/reserve/Workspace/tutorials/beginner/audio_classifier_tutorial.rst:11: WARNING: Duplicate explicit target name: "here".
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/reserve/Workspace/tutorials/beginner/audio_classifier_tutorial.rst: WARNING: document isn't included in any toctree
/Users/reserve/Workspace/tutorials/beginner/former_torchies_tutorial.rst: WARNING: document isn't included in any toctree
/Users/reserve/Workspace/tutorials/beginner/hybrid_frontend_tutorial.rst: WARNING: document isn't included in any toctree
/Users/reserve/Workspace/tutorials/beginner/nn_basics.rst: WARNING: document isn't included in any toctree
/Users/reserve/Workspace/tutorials/beginner/ptcheat.rst: WARNING: document isn't included in any toctree
done
...
```

The remained 4 `Duplicate explicit target name` warnings cannot fix because of their cause.
Please see [this issue(sphinx #3921)](https://github.com/sphinx-doc/sphinx/issues/3921#issuecomment-315581557) for more information about this warning.

Thanks.
