### PR TITLE
Missing space character for an example

### DIFF
--- a/intermediate_source/seq2seq_translation_tutorial.py
+++ b/intermediate_source/seq2seq_translation_tutorial.py
@@ -240,7 +240,7 @@ MAX_LENGTH = 10
 eng_prefixes = (
     "i am ", "i m ",
     "he is", "he s ",
-    "she is", "she s",
+    "she is", "she s ",
     "you are", "you re ",
     "we are", "we re ",
     "they are", "they re "


### PR DESCRIPTION
All the other apostrophe-containing prefixes have a space after the last character except for "she s" (should be "she s ").