### PR TITLE
Fix broken https URL back to http

### DIFF
--- a/beginner_source/nlp/advanced_tutorial.py
+++ b/beginner_source/nlp/advanced_tutorial.py
@@ -97,7 +97,7 @@ where in this second expression, we think of the tags as being assigned
 unique non-negative indices.
 
 If the above discussion was too brief, you can check out
-`this <https://www.cs.columbia.edu/%7Emcollins/crf.pdf>`__ write up from
+`this <http://www.cs.columbia.edu/%7Emcollins/crf.pdf>`__ write up from
 Michael Collins on CRFs.
 
 Implementation Notes


### PR DESCRIPTION
- http link works: http://www.cs.columbia.edu/%7Emcollins/crf.pdf 
- but https doesn't: https://www.cs.columbia.edu/%7Emcollins/crf.pdf