### PR TITLE
[v1.0.1] cpp tutorial fix

### DIFF
--- a/advanced_source/cpp_export.rst
+++ b/advanced_source/cpp_export.rst
@@ -105,13 +105,13 @@ method::
 
       @torch.jit.script_method
       def forward(self, input):
-          if input.sum() > 0:
+          if bool(input.sum() > 0):
             output = self.weight.mv(input)
           else:
             output = self.weight + input
           return output
 
-  my_script_module = MyModule()
+  my_script_module = MyModule(2, 3)
 
 Creating a new ``MyModule`` object now directly produces an instance of
 ``ScriptModule`` that is ready for serialization.

--- a/advanced_source/cpp_frontend.rst
+++ b/advanced_source/cpp_frontend.rst
@@ -899,7 +899,7 @@ stacks them into a single tensor along the first dimension:
 .. code-block:: cpp
 
   auto dataset = torch::data::datasets::MNIST("./mnist")
-      .map(torch::data::transforms::Normalize(0.5, 0.5))
+      .map(torch::data::transforms::Normalize<>(0.5, 0.5))
       .map(torch::data::transforms::Stack<>());
 
 Note that the MNIST dataset should be located in the ``./mnist`` directory

--- a/advanced_source/cpp_frontend.rst
+++ b/advanced_source/cpp_frontend.rst
@@ -914,7 +914,7 @@ dataset, the type of the sampler and some other implementation details):
 
 .. code-block:: cpp
 
-  auto dataloader = torch::data::make_data_loader(std::move(dataset));
+  auto data_loader = torch::data::make_data_loader(std::move(dataset));
 
 The data loader does come with a lot of options. You can inspect the full set
 `here
@@ -928,7 +928,7 @@ let's create a ``DataLoaderOptions`` object and set the appropriate properties:
 
 .. code-block:: cpp
 
-  auto dataloader = torch::data::make_data_loader(
+  auto data_loader = torch::data::make_data_loader(
       std::move(dataset),
       torch::data::DataLoaderOptions().batch_size(kBatchSize).workers(2));
 

--- a/advanced_source/torch_script_custom_ops.rst
+++ b/advanced_source/torch_script_custom_ops.rst
@@ -90,8 +90,8 @@ in Python). The return type of our ``warp_perspective`` function will also be a
   The TorchScript compiler understands a fixed number of types. Only these types
   can be used as arguments to your custom operator. Currently these types are:
   ``torch::Tensor``, ``torch::Scalar``, ``double``, ``int64_t`` and
-  ``std::vector``s of these types. Note that __only__ ``double`` and __not__
-  ``float``, and __only__ ``int64_t`` and __not__ other integral types such as
+  ``std::vector`` s of these types. Note that *only* ``double`` and *not*
+  ``float``, and *only* ``int64_t`` and *not* other integral types such as
   ``int``, ``short`` or ``long`` are supported.
 
 Inside of our function, the first thing we need to do is convert our PyTorch
@@ -1018,7 +1018,7 @@ expects from a module), this route can be slightly quirky. That said, all you
 need is a ``setup.py`` file in place of the ``CMakeLists.txt`` which looks like
 this:
 
-.. code-block::
+.. code-block:: python
 
   from setuptools import setup
   from torch.utils.cpp_extension import BuildExtension, CppExtension
@@ -1081,7 +1081,7 @@ This will produce a shared library called ``warp_perspective.so``, which we can
 pass to ``torch.ops.load_library`` as we did earlier to make our operator
 visible to TorchScript:
 
-.. code-block::
+.. code-block:: python
 
   >>> import torch
   >>> torch.ops.load_library("warp_perspective.so")


### PR DESCRIPTION
Fixed a few C++ API callsites to work with v1.0.1.

TODO: Go through the following two tutorials and find anything that needs to be fixed:
1. https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html
2. https://pytorch.org/tutorials/advanced/cpp_extension.html

