### PR TITLE
typo fix & fix hyper link

### DIFF
--- a/advanced_source/numpy_extensions_tutorial.py
+++ b/advanced_source/numpy_extensions_tutorial.py
@@ -4,7 +4,7 @@ Creating Extensions Using numpy and scipy
 =========================================
 **Author**: `Adam Paszke <https://github.com/apaszke>`_
 
-**Updated by**: `Adam Dziedzic` [https://github.com/adam-dziedzic](https://github.com/adam-dziedzic)
+**Updated by**: `Adam Dziedzic <https://github.com/adam-dziedzic>`_
 
 In this tutorial, we shall go through two tasks:
 

--- a/beginner_source/data_loading_tutorial.py
+++ b/beginner_source/data_loading_tutorial.py
@@ -111,7 +111,7 @@ plt.show()
 # stored in the memory at once but read as required.
 #
 # Sample of our dataset will be a dict
-# ``{'image': image, 'landmarks': landmarks}``. Our datset will take an
+# ``{'image': image, 'landmarks': landmarks}``. Our dataset will take an
 # optional argument ``transform`` so that any required processing can be
 # applied on the sample. We will see the usefulness of ``transform`` in the
 # next section.


### PR DESCRIPTION
the hyperlink in [restructured text](http://docutils.sourceforge.net/docs/user/rst/quickref.html#hyperlink-targets)  is not the same as markdown. Currently, the rendering is wrong. ( check [here](https://pytorch.org/tutorials/advanced/numpy_extensions_tutorial.html))