### PR TITLE
Update download tracking

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -38,18 +38,18 @@
   fbq('init', '243028289693773');
   fbq('track', 'PageView');
 
-  $("a.reference.download").on('click', function(){
+  $("[data-behavior='call-to-action-event']").on('click', function(){
     fbq('trackCustom', "Download", {
       tutorialTitle: $('h1:first').text(),
       downloadLink: this.href,
       tutorialLink: window.location.href,
-      downloadTitle: this.innerText
+      downloadTitle: $(this).attr("data-response")
     });
     ga('send', {
       hitType: 'event',
       eventCategory: 'Download',
       eventAction: 'click',
-      eventLabel: this.innerText
+      eventLabel: $(this).attr("data-response")
     });
    });
 


### PR DESCRIPTION
This PR updates the FB Pixel and Google Analytics event tracking to deal with the changes from this sphinx theme PR, which adds new download buttons to the tutorials site: https://github.com/pytorch/pytorch_sphinx_theme/pull/43.