### PR TITLE
Updating colab information link from home page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -8,7 +8,7 @@ starting point, and provides a broad view into how to use PyTorch from the basic
 Some considerations:
 
 * We’ve added a new feature to tutorials that allows users to open the notebook associated with a tutorial in Google Colab. 
-  Visit `this page </beginner/colab.html>`_ for more information.
+  Visit `this page <https://pytorch.org/tutorials/beginner/colab.html>`_ for more information.
 * If you would like to do the tutorials interactively via IPython / Jupyter,
   each tutorial has a download link for a Jupyter Notebook and Python source code.
 * Additional high-quality examples are available, including image classification,


### PR DESCRIPTION
Path was causing a broken link.