### PR TITLE
Drop all words after generating the EOS token.

### DIFF
--- a/beginner_source/chatbot_tutorial.py
+++ b/beginner_source/chatbot_tutorial.py
@@ -1226,7 +1226,7 @@ def evaluateInput(encoder, decoder, searcher, voc):
             # Evaluate sentence
             output_words = evaluate(encoder, decoder, searcher, voc, input_sentence)
             # Format and print response sentence
-            output_words[:] = [x for x in output_words if not (x == 'EOS' or x == 'PAD')]
+            output_words[:] = itertools.takewhile(lambda word: word != 'EOS', output_words)
             print('Bot:', ' '.join(output_words))
 
         except KeyError:


### PR DESCRIPTION
Just a small observation: if you keep the tokens after the EOS token, usually you get garbage.

If I understood correctly, during training, everything after the EOS token is just padding and it is masked out.
So I think during evaluation, the tokens generated after the EOS token are not meant to be kept.

Example before change:

> how are you?
Bot: fine . **you . fine . fine**
> what is wrong with you?
Bot: nothing . **you re a cop .**
> why do you say that?
Bot: because i m here . **it .**
> that makes no sense
Bot: no . **it . it !**
> are you drunk?
Bot: no . **you . . .**
> you sound like a ten year old
Bot: yes . **that . that .**
> do you want candy?
Bot: yes . **you . it . !**
> here you go
Bot: what ? **what ? ! !**
> wow don t get mad
Bot: i don t want to help you . **it**
> I just need to know the address
Bot: i ll be in there . **it !**
> so we should follow you?
Bot: yes . **it . it .**
> just play it cool
Bot: it s a good story . **it !**
> I am not lying, we will protect you
Bot: you re not going to **this ?**
> we ll do our best
Bot: yeah . **you re a great fool .**

Some answers look fine, but most don't.

Example after change:

> how are you?
Bot: fine . 
> what is wrong with you?
Bot: nothing . 
> why do you say that?
Bot: because i m here . 
> that makes no sense
Bot: no . 
> are you drunk?
Bot: no . 
> you sound like a ten year old
Bot: yes . 
> do you want candy?
Bot: yes . 
> here you go
Bot: what ? 
> wow don t get mad
Bot: i don t want to help you . 
> I just need to know the address
Bot: i ll be in there . 
> so we should follow you?
Bot: yes . 
> just play it cool
Bot: it s a good story . 
> I am not lying, we will protect you
Bot: you re not going to 
> we ll do our best
Bot: yeah . 

They are shorter answers but at least they all make some sense.