### PR TITLE
Change to 3x3 conv filters, for ease of reading dimension in net

### DIFF
--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -46,12 +46,12 @@ class Net(nn.Module):
 
     def __init__(self):
         super(Net, self).__init__()
-        # 1 input image channel, 6 output channels, 5x5 square convolution
+        # 1 input image channel, 6 output channels, 3x3 square convolution
         # kernel
-        self.conv1 = nn.Conv2d(1, 6, 5)
-        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.conv1 = nn.Conv2d(1, 6, 3)
+        self.conv2 = nn.Conv2d(6, 16, 3)
         # an affine operation: y = Wx + b
-        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc1 = nn.Linear(16 * 6 * 6, 120)  # 6*6 from image dimension 
         self.fc2 = nn.Linear(120, 84)
         self.fc3 = nn.Linear(84, 10)
 


### PR DESCRIPTION
See here for the original comment.

https://github.com/pytorch/tutorials/issues/503

With 5x5 filters and 5*5 dimension from the number of filters that "span" the 32x32 image (after two layers with maxpooling) those numbers were confusing. Hence the filters are changed to 3x3 size.

Possible downsides of this solution:
 - We do not cover the image as well, as on the final 2x2 maxpool layer goes over an image of size 13x13, and hence cuts it to 12x12. 
 - the comment on line 54 isn't terribly illuminating (but is it kept to a single line).