### PR TITLE
fix typo in PyTorch with examples

### DIFF
--- a/beginner_source/examples_nn/dynamic_net.py
+++ b/beginner_source/examples_nn/dynamic_net.py
@@ -5,7 +5,7 @@ PyTorch: Control Flow + Weight Sharing
 
 To showcase the power of PyTorch dynamic graphs, we will implement a very strange
 model: a fully-connected ReLU network that on each forward pass randomly chooses
-a number between 1 and 4 and has that many hidden layers, reusing the same
+a number between 0 and 3 and has that many hidden layers, reusing the same
 weights multiple times to compute the innermost hidden layers.
 """
 import random

--- a/beginner_source/examples_nn/two_layer_net_optim.py
+++ b/beginner_source/examples_nn/two_layer_net_optim.py
@@ -33,7 +33,7 @@ loss_fn = torch.nn.MSELoss(reduction='sum')
 
 # Use the optim package to define an Optimizer that will update the weights of
 # the model for us. Here we will use Adam; the optim package contains many other
-# optimization algoriths. The first argument to the Adam constructor tells the
+# optimization algorithms. The first argument to the Adam constructor tells the
 # optimizer which Tensors it should update.
 learning_rate = 1e-4
 optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)

--- a/beginner_source/pytorch_with_examples.rst
+++ b/beginner_source/pytorch_with_examples.rst
@@ -233,7 +233,7 @@ PyTorch: Control Flow + Weight Sharing
 
 As an example of dynamic graphs and weight sharing, we implement a very
 strange model: a fully-connected ReLU network that on each forward pass
-chooses a random number between 1 and 4 and uses that many hidden
+chooses a random number between 0 and 3 and uses that many hidden
 layers, reusing the same weights multiple times to compute the innermost
 hidden layers.
 


### PR DESCRIPTION
To fix trivial typo.

It's `0 to 3` rather than `1 to 4`.