### PR TITLE
add comment about default value of requres_grad

### DIFF
--- a/beginner_source/examples_autograd/two_layer_net_autograd.py
+++ b/beginner_source/examples_autograd/two_layer_net_autograd.py
@@ -27,6 +27,7 @@ N, D_in, H, D_out = 64, 1000, 100, 10
 # Create random Tensors to hold input and outputs.
 # Setting requires_grad=False indicates that we do not need to compute gradients
 # with respect to these Tensors during the backward pass.
+# (But by default, requres_grad has False so we do not need to specify in the code below.)
 x = torch.randn(N, D_in, device=device, dtype=dtype)
 y = torch.randn(N, D_out, device=device, dtype=dtype)
 


### PR DESCRIPTION
In [this tutorial](https://pytorch.org/tutorials/beginner/examples_autograd/two_layer_net_autograd.html), there is a need to set requires_grad = False, but this is not reflected in the below code.

It looks like the old content is still there, and since it's a beginner tutorial, I added a comment that highlights the default value of requires_grad.