### PR TITLE
remove Variable which is deprecated

### DIFF
--- a/beginner_source/blitz/autograd_tutorial.py
+++ b/beginner_source/blitz/autograd_tutorial.py
@@ -185,5 +185,5 @@ with torch.no_grad():
 ###############################################################
 # **Read Later:**
 #
-# Documentation of ``autograd`` and ``Function`` is at
-# https://pytorch.org/docs/autograd
+# Document about ``autograd.Function`` is at
+# https://pytorch.org/docs/stable/autograd.html#function


### PR DESCRIPTION
Removed mention of `Variable` which is deprecated.
Also, modified a link to the `Function` more detail.