### PR TITLE
Add PyTorch version to seq2seq tutorial

### DIFF
--- a/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
+++ b/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
@@ -3,6 +3,7 @@
 Deploying a Seq2Seq Model with TorchScript
 ==================================================
 **Author:** `Matthew Inkawhich <https://github.com/MatthewInkawhich>`_
+1.2, this tutorial was updated to work with PyTorch 1.2
 """
 
 


### PR DESCRIPTION
The feedback we got on some other tutorials that we should probably specify the version of PyTorch the tutorial was updated for