### PR TITLE
Enabling tensor index from random_split

### DIFF
--- a/beginner_source/data_loading_tutorial.py
+++ b/beginner_source/data_loading_tutorial.py
@@ -136,6 +136,9 @@ class FaceLandmarksDataset(Dataset):
         return len(self.landmarks_frame)
 
     def __getitem__(self, idx):
+        if torch.is_tensor(idx):
+            idx = idx.tolist()
+
         img_name = os.path.join(self.root_dir,
                                 self.landmarks_frame.iloc[idx, 0])
         image = io.imread(img_name)


### PR DESCRIPTION
Converting the index from `random_split` given in tensor form requested in #540. It seems like a good place to show how a user could enable tensor index.
