### PR TITLE
Reorder text tutorials

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -131,14 +131,14 @@ Text
    :description: :doc:`beginner/chatbot_tutorial`
 
 .. customgalleryitem::
+   :figure: /_static/img/rnnclass.png
+   :tooltip: Build and train a basic character-level RNN to classify words
+   :description: :doc:`intermediate/char_rnn_classification_tutorial`   
+
+.. customgalleryitem::
    :figure: /_static/img/char_rnn_generation.png
    :tooltip: Generate names from languages
    :description: :doc:`intermediate/char_rnn_generation_tutorial`
-
-.. customgalleryitem::
-   :figure: /_static/img/rnnclass.png
-   :tooltip: Build and train a basic character-level RNN to classify words
-   :description: :doc:`intermediate/char_rnn_classification_tutorial`
 
 .. customgalleryitem::
     :tooltip: Explore the key concepts of deep learning programming using Pytorch
@@ -313,8 +313,8 @@ PyTorch in Other Languages
    :caption: Text
 
    beginner/chatbot_tutorial
+   intermediate/char_rnn_classification_tutorial   
    intermediate/char_rnn_generation_tutorial
-   intermediate/char_rnn_classification_tutorial
    beginner/deep_learning_nlp_tutorial
    intermediate/seq2seq_translation_tutorial
    beginner/text_sentiment_ngrams_tutorial


### PR DESCRIPTION
The [Generating Names... tutorial](https://pytorch.org/tutorials/intermediate/char_rnn_generation_tutorial.html) references the classification tutorial as "the last tutorial", but the classification tutorial is listed after it in the TOC. This fixes that. 