### PR TITLE
Update index.rst

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -147,7 +147,7 @@ Text
 .. customgalleryitem::
     :tooltip: Language Translation with Torchtext
     :figure: /_static/img/thumbnails/torchtext.png
-    :description: :doc:`/beginner/translation_torchtext_tutorial`
+    :description: :doc:`/beginner/torchtext_translation_tutorial`
 
 .. customgalleryitem::
     :tooltip: Sentiment Ngrams with Torchtext


### PR DESCRIPTION
"Language Translation with TorchText" tutorial was misnamed "translation_torchtext_tutorial". This fixes it to "torchtext_translation_tutorial".