### PR TITLE
Update autograd_tutorial.py

### DIFF
--- a/beginner_source/blitz/autograd_tutorial.py
+++ b/beginner_source/blitz/autograd_tutorial.py
@@ -174,7 +174,7 @@ print(x.grad)
 
 ###############################################################
 # You can also stop autograd from tracking history on Tensors
-# with ``.requires_grad=True`` either by wrapping the code block in
+# with ``.requires_grad=False`` either by wrapping the code block in
 # ``with torch.no_grad():``
 print(x.requires_grad)
 print((x ** 2).requires_grad)


### PR DESCRIPTION
Fixed typo for explaining how to stop autograd from tracking history on Tensors