### PR TITLE
Update text_sentiment_ngrams_tutorial.py

### DIFF
--- a/beginner_source/text_sentiment_ngrams_tutorial.py
+++ b/beginner_source/text_sentiment_ngrams_tutorial.py
@@ -234,7 +234,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=4.0)
 scheduler = torch.optim.lr_scheduler.StepLR(optimizer, 1, gamma=0.9)
 
 train_len = int(len(train_dataset) * 0.95)
-sub_train_, sub_valid_ = \
+sub_train_, sub_valid_ = 
     random_split(train_dataset, [train_len, len(train_dataset) - train_len])
 
 for epoch in range(N_EPOCHS):


### PR DESCRIPTION
We have an error of this:
`sub_train_, sub_valid_ = \( why do we have a slash after the equal side? To test the reader paying attention or not?)` 🤣
This merge is for fixing this that causes a compiler error.

![image](https://user-images.githubusercontent.com/21982975/71737783-8c33a680-2e09-11ea-9327-63cbb522e22b.png)
https://pytorch.org/tutorials/beginner/text_sentiment_ngrams_tutorial.html