### PR TITLE
Create separate build jobs for PR CI and master CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,20 +307,20 @@ workflows:
     jobs:
       # Build jobs that only run on PR
       - pytorch_tutorial_build_worker_0_pr
-          filters:
-            branches:
-              ignore:
-                - master
+        filters:
+          branches:
+            ignore:
+              - master
       - pytorch_tutorial_build_worker_1_pr
-          filters:
-            branches:
-              ignore:
-                - master
+        filters:
+          branches:
+            ignore:
+              - master
       - pytorch_tutorial_build_worker_2_pr
-          filters:
-            branches:
-              ignore:
-                - master
+        filters:
+          branches:
+            ignore:
+              - master
       - pytorch_tutorial_build_worker_3_pr
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,233 +306,233 @@ workflows:
   build:
     jobs:
       # Build jobs that only run on PR
-      - pytorch_tutorial_build_worker_0_pr
-        filters:
-          branches:
-            ignore:
-              - master
-      - pytorch_tutorial_build_worker_1_pr
-        filters:
-          branches:
-            ignore:
-              - master
-      - pytorch_tutorial_build_worker_2_pr
-        filters:
-          branches:
-            ignore:
-              - master
-      - pytorch_tutorial_build_worker_3_pr
+      - pytorch_tutorial_build_worker_0_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_4_pr
+      - pytorch_tutorial_build_worker_1_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_5_pr
+      - pytorch_tutorial_build_worker_2_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_6_pr
+      - pytorch_tutorial_build_worker_3_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_7_pr
+      - pytorch_tutorial_build_worker_4_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_8_pr
+      - pytorch_tutorial_build_worker_5_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_9_pr
+      - pytorch_tutorial_build_worker_6_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_10_pr
+      - pytorch_tutorial_build_worker_7_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_11_pr
+      - pytorch_tutorial_build_worker_8_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_12_pr
+      - pytorch_tutorial_build_worker_9_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_13_pr
+      - pytorch_tutorial_build_worker_10_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_14_pr
+      - pytorch_tutorial_build_worker_11_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_15_pr
+      - pytorch_tutorial_build_worker_12_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_16_pr
+      - pytorch_tutorial_build_worker_13_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_17_pr
+      - pytorch_tutorial_build_worker_14_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_18_pr
+      - pytorch_tutorial_build_worker_15_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_19_pr
+      - pytorch_tutorial_build_worker_16_pr:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_manager_pr
+      - pytorch_tutorial_build_worker_17_pr:
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_18_pr:
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_19_pr:
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_manager_pr:
           filters:
             branches:
               ignore:
                 - master
       # Build jobs that only run on master
-      - pytorch_tutorial_build_worker_0_master
+      - pytorch_tutorial_build_worker_0_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_1_master
+      - pytorch_tutorial_build_worker_1_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_2_master
+      - pytorch_tutorial_build_worker_2_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_3_master
+      - pytorch_tutorial_build_worker_3_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_4_master
+      - pytorch_tutorial_build_worker_4_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_5_master
+      - pytorch_tutorial_build_worker_5_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_6_master
+      - pytorch_tutorial_build_worker_6_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_7_master
+      - pytorch_tutorial_build_worker_7_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_8_master
+      - pytorch_tutorial_build_worker_8_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_9_master
+      - pytorch_tutorial_build_worker_9_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_10_master
+      - pytorch_tutorial_build_worker_10_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_11_master
+      - pytorch_tutorial_build_worker_11_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_12_master
+      - pytorch_tutorial_build_worker_12_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_13_master
+      - pytorch_tutorial_build_worker_13_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_14_master
+      - pytorch_tutorial_build_worker_14_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_15_master
+      - pytorch_tutorial_build_worker_15_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_16_master
+      - pytorch_tutorial_build_worker_16_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_17_master
+      - pytorch_tutorial_build_worker_17_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_18_master
+      - pytorch_tutorial_build_worker_18_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_19_master
+      - pytorch_tutorial_build_worker_19_master:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_manager_master
+      - pytorch_tutorial_build_manager_master:
           context: org-member
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,127 +176,127 @@ pytorch_tutorial_build_manager_defaults: &pytorch_tutorial_build_manager_default
   <<: *pytorch_tutorial_build_defaults
 
 jobs:
-  pytorch_tutorial_build_worker_0_pr:
+  pytorch_tutorial_pr_build_worker_0:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_1_pr:
+  pytorch_tutorial_pr_build_worker_1:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_2_pr:
+  pytorch_tutorial_pr_build_worker_2:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_3_pr:
+  pytorch_tutorial_pr_build_worker_3:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_4_pr:
+  pytorch_tutorial_pr_build_worker_4:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_5_pr:
+  pytorch_tutorial_pr_build_worker_5:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_6_pr:
+  pytorch_tutorial_pr_build_worker_6:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_7_pr:
+  pytorch_tutorial_pr_build_worker_7:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_8_pr:
+  pytorch_tutorial_pr_build_worker_8:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_9_pr:
+  pytorch_tutorial_pr_build_worker_9:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_10_pr:
+  pytorch_tutorial_pr_build_worker_10:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_11_pr:
+  pytorch_tutorial_pr_build_worker_11:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_12_pr:
+  pytorch_tutorial_pr_build_worker_12:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_13_pr:
+  pytorch_tutorial_pr_build_worker_13:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_14_pr:
+  pytorch_tutorial_pr_build_worker_14:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_15_pr:
+  pytorch_tutorial_pr_build_worker_15:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_16_pr:
+  pytorch_tutorial_pr_build_worker_16:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_17_pr:
+  pytorch_tutorial_pr_build_worker_17:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_18_pr:
+  pytorch_tutorial_pr_build_worker_18:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_19_pr:
+  pytorch_tutorial_pr_build_worker_19:
     <<: *pytorch_tutorial_build_worker_defaults
 
   pytorch_tutorial_build_manager_pr:
     <<: *pytorch_tutorial_build_manager_defaults
 
-  pytorch_tutorial_build_worker_0_master:
+  pytorch_tutorial_master_build_worker_0:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_1_master:
+  pytorch_tutorial_master_build_worker_1:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_2_master:
+  pytorch_tutorial_master_build_worker_2:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_3_master:
+  pytorch_tutorial_master_build_worker_3:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_4_master:
+  pytorch_tutorial_master_build_worker_4:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_5_master:
+  pytorch_tutorial_master_build_worker_5:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_6_master:
+  pytorch_tutorial_master_build_worker_6:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_7_master:
+  pytorch_tutorial_master_build_worker_7:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_8_master:
+  pytorch_tutorial_master_build_worker_8:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_9_master:
+  pytorch_tutorial_master_build_worker_9:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_10_master:
+  pytorch_tutorial_master_build_worker_10:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_11_master:
+  pytorch_tutorial_master_build_worker_11:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_12_master:
+  pytorch_tutorial_master_build_worker_12:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_13_master:
+  pytorch_tutorial_master_build_worker_13:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_14_master:
+  pytorch_tutorial_master_build_worker_14:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_15_master:
+  pytorch_tutorial_master_build_worker_15:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_16_master:
+  pytorch_tutorial_master_build_worker_16:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_17_master:
+  pytorch_tutorial_master_build_worker_17:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_18_master:
+  pytorch_tutorial_master_build_worker_18:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_19_master:
+  pytorch_tutorial_master_build_worker_19:
     <<: *pytorch_tutorial_build_worker_defaults
 
   pytorch_tutorial_build_manager_master:
@@ -306,102 +306,102 @@ workflows:
   build:
     jobs:
       # Build jobs that only run on PR
-      - pytorch_tutorial_build_worker_0_pr:
+      - pytorch_tutorial_pr_build_worker_0:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_1_pr:
+      - pytorch_tutorial_pr_build_worker_1:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_2_pr:
+      - pytorch_tutorial_pr_build_worker_2:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_3_pr:
+      - pytorch_tutorial_pr_build_worker_3:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_4_pr:
+      - pytorch_tutorial_pr_build_worker_4:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_5_pr:
+      - pytorch_tutorial_pr_build_worker_5:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_6_pr:
+      - pytorch_tutorial_pr_build_worker_6:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_7_pr:
+      - pytorch_tutorial_pr_build_worker_7:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_8_pr:
+      - pytorch_tutorial_pr_build_worker_8:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_9_pr:
+      - pytorch_tutorial_pr_build_worker_9:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_10_pr:
+      - pytorch_tutorial_pr_build_worker_10:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_11_pr:
+      - pytorch_tutorial_pr_build_worker_11:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_12_pr:
+      - pytorch_tutorial_pr_build_worker_12:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_13_pr:
+      - pytorch_tutorial_pr_build_worker_13:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_14_pr:
+      - pytorch_tutorial_pr_build_worker_14:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_15_pr:
+      - pytorch_tutorial_pr_build_worker_15:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_16_pr:
+      - pytorch_tutorial_pr_build_worker_16:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_17_pr:
+      - pytorch_tutorial_pr_build_worker_17:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_18_pr:
+      - pytorch_tutorial_pr_build_worker_18:
           filters:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_worker_19_pr:
+      - pytorch_tutorial_pr_build_worker_19:
           filters:
             branches:
               ignore:
@@ -412,121 +412,121 @@ workflows:
               ignore:
                 - master
       # Build jobs that only run on master
-      - pytorch_tutorial_build_worker_0_master:
+      - pytorch_tutorial_master_build_worker_0:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_1_master:
+      - pytorch_tutorial_master_build_worker_1:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_2_master:
+      - pytorch_tutorial_master_build_worker_2:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_3_master:
+      - pytorch_tutorial_master_build_worker_3:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_4_master:
+      - pytorch_tutorial_master_build_worker_4:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_5_master:
+      - pytorch_tutorial_master_build_worker_5:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_6_master:
+      - pytorch_tutorial_master_build_worker_6:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_7_master:
+      - pytorch_tutorial_master_build_worker_7:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_8_master:
+      - pytorch_tutorial_master_build_worker_8:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_9_master:
+      - pytorch_tutorial_master_build_worker_9:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_10_master:
+      - pytorch_tutorial_master_build_worker_10:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_11_master:
+      - pytorch_tutorial_master_build_worker_11:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_12_master:
+      - pytorch_tutorial_master_build_worker_12:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_13_master:
+      - pytorch_tutorial_master_build_worker_13:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_14_master:
+      - pytorch_tutorial_master_build_worker_14:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_15_master:
+      - pytorch_tutorial_master_build_worker_15:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_16_master:
+      - pytorch_tutorial_master_build_worker_16:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_17_master:
+      - pytorch_tutorial_master_build_worker_17:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_18_master:
+      - pytorch_tutorial_master_build_worker_18:
           context: org-member
           filters:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_worker_19_master:
+      - pytorch_tutorial_master_build_worker_19:
           context: org-member
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+version: 2.1
+
 install_official_git_client: &install_official_git_client
   name: Install Official Git Client
   no_output_timeout: "1h"
@@ -173,7 +175,6 @@ pytorch_tutorial_build_manager_defaults: &pytorch_tutorial_build_manager_default
   resource_class: medium
   <<: *pytorch_tutorial_build_defaults
 
-version: 2.1
 jobs:
   pytorch_tutorial_build_worker_0_pr:
     <<: *pytorch_tutorial_build_worker_defaults
@@ -302,7 +303,6 @@ jobs:
     <<: *pytorch_tutorial_build_manager_defaults
 
 workflows:
-  version: 2.1
   build:
     jobs:
       # Build jobs that only run on PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ jobs:
   pytorch_tutorial_pr_build_worker_19:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_manager_pr:
+  pytorch_tutorial_pr_build_manager:
     <<: *pytorch_tutorial_build_manager_defaults
 
   pytorch_tutorial_master_build_worker_0:
@@ -299,7 +299,7 @@ jobs:
   pytorch_tutorial_master_build_worker_19:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_manager_master:
+  pytorch_tutorial_master_build_manager:
     <<: *pytorch_tutorial_build_manager_defaults
 
 workflows:
@@ -406,7 +406,7 @@ workflows:
             branches:
               ignore:
                 - master
-      - pytorch_tutorial_build_manager_pr:
+      - pytorch_tutorial_pr_build_manager:
           filters:
             branches:
               ignore:
@@ -532,7 +532,7 @@ workflows:
             branches:
               only:
                 - master
-      - pytorch_tutorial_build_manager_master:
+      - pytorch_tutorial_master_build_manager:
           context: org-member
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ pytorch_tutorial_build_defaults: &pytorch_tutorial_build_defaults
         export pyTorchDockerImageTag=291
         echo "PyTorchDockerImageTag: "${pyTorchDockerImageTag}
 
-        cat >/home/circleci/project/ci_build_script.sh <<EOL
+        cat >/home/circleci/project/ci_build_script.sh \<<EOL
         # =================== The following code will be executed inside Docker container ===================
         set -ex
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,93 +173,368 @@ pytorch_tutorial_build_manager_defaults: &pytorch_tutorial_build_manager_default
   resource_class: medium
   <<: *pytorch_tutorial_build_defaults
 
-version: 2
+version: 2.1
 jobs:
-  pytorch_tutorial_build_worker_0:
+  pytorch_tutorial_build_worker_0_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_1:
+  pytorch_tutorial_build_worker_1_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_2:
+  pytorch_tutorial_build_worker_2_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_3:
+  pytorch_tutorial_build_worker_3_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_4:
+  pytorch_tutorial_build_worker_4_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_5:
+  pytorch_tutorial_build_worker_5_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_6:
+  pytorch_tutorial_build_worker_6_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_7:
+  pytorch_tutorial_build_worker_7_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_8:
+  pytorch_tutorial_build_worker_8_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_9:
+  pytorch_tutorial_build_worker_9_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_10:
+  pytorch_tutorial_build_worker_10_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_11:
+  pytorch_tutorial_build_worker_11_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_12:
+  pytorch_tutorial_build_worker_12_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_13:
+  pytorch_tutorial_build_worker_13_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_14:
+  pytorch_tutorial_build_worker_14_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_15:
+  pytorch_tutorial_build_worker_15_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_16:
+  pytorch_tutorial_build_worker_16_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_17:
+  pytorch_tutorial_build_worker_17_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_18:
+  pytorch_tutorial_build_worker_18_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_worker_19:
+  pytorch_tutorial_build_worker_19_pr:
     <<: *pytorch_tutorial_build_worker_defaults
 
-  pytorch_tutorial_build_manager:
+  pytorch_tutorial_build_manager_pr:
+    <<: *pytorch_tutorial_build_manager_defaults
+
+  pytorch_tutorial_build_worker_0_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_1_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_2_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_3_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_4_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_5_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_6_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_7_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_8_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_9_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_10_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_11_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_12_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_13_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_14_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_15_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_16_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_17_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_18_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_worker_19_master:
+    <<: *pytorch_tutorial_build_worker_defaults
+
+  pytorch_tutorial_build_manager_master:
     <<: *pytorch_tutorial_build_manager_defaults
 
 workflows:
-  version: 2
+  version: 2.1
   build:
     jobs:
-      - pytorch_tutorial_build_worker_0
-      - pytorch_tutorial_build_worker_1
-      - pytorch_tutorial_build_worker_2
-      - pytorch_tutorial_build_worker_3
-      - pytorch_tutorial_build_worker_4
-      - pytorch_tutorial_build_worker_5
-      - pytorch_tutorial_build_worker_6
-      - pytorch_tutorial_build_worker_7
-      - pytorch_tutorial_build_worker_8
-      - pytorch_tutorial_build_worker_9
-      - pytorch_tutorial_build_worker_10
-      - pytorch_tutorial_build_worker_11
-      - pytorch_tutorial_build_worker_12
-      - pytorch_tutorial_build_worker_13
-      - pytorch_tutorial_build_worker_14
-      - pytorch_tutorial_build_worker_15
-      - pytorch_tutorial_build_worker_16
-      - pytorch_tutorial_build_worker_17
-      - pytorch_tutorial_build_worker_18
-      - pytorch_tutorial_build_worker_19
-      - pytorch_tutorial_build_manager
+      # Build jobs that only run on PR
+      - pytorch_tutorial_build_worker_0_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_1_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_2_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_3_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_4_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_5_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_6_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_7_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_8_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_9_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_10_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_11_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_12_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_13_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_14_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_15_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_16_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_17_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_18_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_worker_19_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      - pytorch_tutorial_build_manager_pr
+          filters:
+            branches:
+              ignore:
+                - master
+      # Build jobs that only run on master
+      - pytorch_tutorial_build_worker_0_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_1_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_2_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_3_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_4_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_5_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_6_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_7_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_8_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_9_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_10_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_11_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_12_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_13_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_14_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_15_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_16_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_17_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_18_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_worker_19_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master
+      - pytorch_tutorial_build_manager_master
+          context: org-member
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
Master CI jobs need access to `context: org-member`, but PR CI jobs don't. So we create two separate sets of jobs for master and PR respectively.