### PR TITLE
Remove PyTorch 1.2 notes in tutorials

### DIFF
--- a/advanced_source/cpp_export.rst
+++ b/advanced_source/cpp_export.rst
@@ -1,8 +1,6 @@
 Loading a TorchScript Model in C++
 =====================================
 
-**This tutorial was updated to work with PyTorch 1.2**
-
 As its name suggests, the primary interface to PyTorch is the Python
 programming language. While Python is a suitable and preferred language for
 many scenarios requiring dynamism and ease of iteration, there are equally many

--- a/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
+++ b/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
@@ -3,7 +3,6 @@
 Deploying a Seq2Seq Model with TorchScript
 ==================================================
 **Author:** `Matthew Inkawhich <https://github.com/MatthewInkawhich>`_
-1.2, this tutorial was updated to work with PyTorch 1.2
 """
 
 


### PR DESCRIPTION
Someone mentioned that they found this confusing, since the current
release is 1.4