### PR TITLE
Update cifar10_tutorial.py

### DIFF
--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -106,7 +106,7 @@ images, labels = dataiter.next()
 # show images
 imshow(torchvision.utils.make_grid(images))
 # print labels
-print(' '.join('%5s' % classes[labels[j]] for j in range(4)))
+print(*[classes[labels[j]] for j in range(4)])
 
 
 ########################################################################
@@ -211,7 +211,7 @@ images, labels = dataiter.next()
 
 # print images
 imshow(torchvision.utils.make_grid(images))
-print('GroundTruth: ', ' '.join('%5s' % classes[labels[j]] for j in range(4)))
+print('GroundTruth:', *[classes[labels[j]] for j in range(4)])
 
 ########################################################################
 # Next, let's load back in our saved model (note: saving and re-loading the model
@@ -232,8 +232,7 @@ outputs = net(images)
 # So, let's get the index of the highest energy:
 _, predicted = torch.max(outputs, 1)
 
-print('Predicted: ', ' '.join('%5s' % classes[predicted[j]]
-                              for j in range(4)))
+print('Predicted:', *[classes[predicted[j]] for j in range(4)])
 
 ########################################################################
 # The results seem pretty good.


### PR DESCRIPTION
`' '.join('%5s' %...` leads to ugly formatting issues where classes of length 3 are followed by double spaces, like
```
car  bird dog  ship
```
and, conversely, classes of length 5 are followed by no space at all, e.g.
```
bird truckship horse
```