### PR TITLE
Update 'Was this Helpful?' tracking

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -67,6 +67,10 @@
       eventAction: 'click',
       eventLabel: $(this).attr("data-response")
     });
+    gtag('event', $(this).attr("data-response"), {
+      'event_category': 'Was this Helpful?',
+      'event_label': $("h1").first().text()
+    });
    });
 
    if (location.pathname == "/") {


### PR DESCRIPTION
This PR updates the event tracking for the "Was this Helpful?" button. It uses a different tracking ID and updates the way the data is sent to analytics.