### PR TITLE
add code comments and test code readability++

### DIFF
--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -242,10 +242,13 @@ print('Predicted: ', ' '.join('%5s' % classes[predicted[j]]
 
 correct = 0
 total = 0
+# since we're not training, we don't need to calculate the gradients for our outputs
 with torch.no_grad():
     for data in testloader:
         images, labels = data
+        # calculate outputs by running images through the network 
         outputs = net(images)
+        # the class with the highest energy is what we choose as prediction
         _, predicted = torch.max(outputs.data, 1)
         total += labels.size(0)
         correct += (predicted == labels).sum().item()
@@ -261,23 +264,28 @@ print('Accuracy of the network on the 10000 test images: %d %%' % (
 # Hmmm, what are the classes that performed well, and the classes that did
 # not perform well:
 
-class_correct = list(0. for i in range(10))
-class_total = list(0. for i in range(10))
+# prepare to count predictions for each class
+correct_pred = {classname: 0 for classname in classes}
+total_pred = {classname: 0 for classname in classes}
+
+# again no gradients needed
 with torch.no_grad():
     for data in testloader:
-        images, labels = data
-        outputs = net(images)
-        _, predicted = torch.max(outputs, 1)
-        c = (predicted == labels).squeeze()
-        for i in range(4):
-            label = labels[i]
-            class_correct[label] += c[i].item()
-            class_total[label] += 1
+        images, labels = data    
+        outputs = net(images)    
+        _, predictions = torch.max(outputs, 1)
+        # collect the correct predictions for each class
+        for label, prediction in zip(labels, predictions):
+            if label == prediction:
+                correct_pred[classes[label]] += 1
+            total_pred[classes[label]] += 1
 
-
-for i in range(10):
-    print('Accuracy of %5s : %2d %%' % (
-        classes[i], 100 * class_correct[i] / class_total[i]))
+  
+# print accuracy for each class
+for classname, correct_count in correct_pred.items():
+    accuracy = 100 * float(correct_count) / total_pred[classname]
+    print("Accuracy for class {:5s} is: {:.1f} %".format(classname, 
+                                                   accuracy))
 
 ########################################################################
 # Okay, so what next?


### PR DESCRIPTION
When I was working through the blitz cifar 10 tutorial it took me quite some time to understand the evaluation logic of the per-class accuracy.
I've added some code comments and rewrote this small part to make it much more obvious what is going on. Generally I've tried to replace the `range`s with fixed numbers for batchsize or classes with speaking names.
In detail:
* now using dicts with classnames as keys to collect classifications, instead of lists which map to class by index
* implicitly removed an unneccessary squeeze operation [diffline271](https://github.com/pytorch/tutorials/compare/master...wAuner:cifartut_improve?expand=1#diff-8b1014a85ac6d7d7450e9c7c4b5a6dfdL271 )
* removed the unexplained reference to the batchsize (hardcoded int)
* make the counting of the correct predictions per class more readable