### PR TITLE
Update seq2seq_translation_tutorial.py

### DIFF
--- a/intermediate_source/seq2seq_translation_tutorial.py
+++ b/intermediate_source/seq2seq_translation_tutorial.py
@@ -585,8 +585,6 @@ def train(input_tensor, target_tensor, encoder, decoder, encoder_optimizer, deco
             decoder_input = topi.squeeze().detach()  # detach from history as input
 
             loss += criterion(decoder_output, target_tensor[di])
-            if decoder_input.item() == EOS_token:
-                break
 
     loss.backward()
 


### PR DESCRIPTION
In the training loop, in the NON teacher-forcing case, I deleted a line that says 'break early from the training loop if the model generates an EOS token'. This seems like a bug to me -- once the EOS token is generated, the loss is halted. In the case of a long sentence, you can imagine that the way to minimize loss would be to simply generate an EOS token first. Unless there is some way to penalize premature stopping, this seems like a bug to me.

Disclaimer: I am fairly new to RNNs (as I am looking at these tutorials!), so if my logic is faulty on this one, apologies.

Note: Other tutorials, such as the below, do not use this early stopping procedure.
https://github.com/bentrevett/pytorch-seq2seq/blob/master/1%20-%20Sequence%20to%20Sequence%20Learning%20with%20Neural%20Networks.ipynb