### PR TITLE
Remove spawn configuration in AWS tutorial

### DIFF
--- a/beginner_source/aws_distributed_training_tutorial.py
+++ b/beginner_source/aws_distributed_training_tutorial.py
@@ -209,9 +209,6 @@ import time
 import sys
 import torch
 
-if __name__ == '__main__':
-    torch.multiprocessing.set_start_method('spawn')
-
 import torch.nn as nn
 import torch.nn.parallel
 import torch.distributed as dist
@@ -692,4 +689,3 @@ for epoch in range(num_epochs):
 #
 # -  If possible, setup a NFS so you only need one copy of the dataset
 #
-


### PR DESCRIPTION
The removed lines cause DDP to hang because somehow it triggered
the top layer code to run twice when launching the script from cmd.

Let's see if removing it would pass the CI tests