### PR TITLE
Update neural_style_tutorial.py

### DIFF
--- a/advanced_source/neural_style_tutorial.py
+++ b/advanced_source/neural_style_tutorial.py
@@ -403,7 +403,7 @@ def get_input_optimizer(input_img):
 # each iteration of the networks, it is fed an updated input and computes
 # new losses. We will run the ``backward`` methods of each loss module to
 # dynamicaly compute their gradients. The optimizer requires a “closure”
-# function, which reevaluates the modul and returns the loss.
+# function, which reevaluates the module and returns the loss.
 # 
 # We still have one final constraint to address. The network may try to
 # optimize the input with values that exceed the 0 to 1 tensor range for


### PR DESCRIPTION
Fix typo in "modul" to "module"

Originally from [Neural Style Transfer Tutorial typo #34010](https://github.com/pytorch/pytorch/issues/34010)