### PR TITLE
README.md: Corrected sphinx link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ All the tutorials are now presented as sphinx style documentation at:
 
 # Contributing
 
-We use sphinx-gallery's [notebook styled examples](https://sphinx-gallery.github.io/tutorials/plot_notebook.html#sphx-glr-tutorials-plot-notebook-py) to create the tutorials. Syntax is very simple. In essence, you write a slightly well formatted python file and it shows up as documentation page.
+We use sphinx-gallery's [notebook styled examples](https://sphinx-gallery.github.io/stable/tutorials/index.html) to create the tutorials. Syntax is very simple. In essence, you write a slightly well formatted python file and it shows up as documentation page.
 
 Here's how to create a new tutorial:
 1. Create a notebook styled python file. If you want it executed while inserted into documentation, save the file with suffix `tutorial` so that file name is `your_tutorial.py`.


### PR DESCRIPTION
sphinx no longer has a plot_notebook tutorial link. Linking the main 'Notebook style example' page.