### PR TITLE
Update torchtext_translation_tutorial.py

### DIFF
--- a/beginner_source/torchtext_translation_tutorial.py
+++ b/beginner_source/torchtext_translation_tutorial.py
@@ -228,7 +228,7 @@ class Decoder(nn.Module):
                  emb_dim: int,
                  enc_hid_dim: int,
                  dec_hid_dim: int,
-                 dropout: int,
+                 dropout: float,
                  attention: nn.Module):
         super().__init__()
 


### PR DESCRIPTION
the Decoder's dropout requires a float