### PR TITLE
Blitz / Autograd Tutorial : Add word to distinguish math formulas.

### DIFF
--- a/beginner_source/blitz/autograd_tutorial.py
+++ b/beginner_source/blitz/autograd_tutorial.py
@@ -101,7 +101,7 @@ print(x.grad)
 ###############################################################
 # You should have got a matrix of ``4.5``. Let’s call the ``out``
 # *Tensor* “:math:`o`”.
-# We have that :math:`o = \frac{1}{4}\sum_i z_i`,
+# We have that :math:`o = \frac{1}{4}\sum_i z_i`, where
 # :math:`z_i = 3(x_i+2)^2` and :math:`z_i\bigr\rvert_{x_i=1} = 27`.
 # Therefore,
 # :math:`\frac{\partial o}{\partial x_i} = \frac{3}{2}(x_i+2)`, hence


### PR DESCRIPTION
In some browsers (Arch Linux + Chromium) math formulas are shown very small, so it was very hard to see the comma between the two adjacent formulas and thus, reading them.

For better reading comprehension I added the word _where_ at the relevant position.