### PR TITLE
Update torchvision_tutorial.rst

### DIFF
--- a/intermediate_source/torchvision_tutorial.rst
+++ b/intermediate_source/torchvision_tutorial.rst
@@ -255,13 +255,13 @@ way of doing it:
    # use to perform the region of interest cropping, as well as
    # the size of the crop after rescaling.
    # if your backbone returns a Tensor, featmap_names is expected to
-   # be [0]. More generally, the backbone should return an
+   # be [0] or ["0"]. More generally, the backbone should return an
    # OrderedDict[Tensor], and in featmap_names you can choose which
    # feature maps to use.
    roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=[0],
                                                    output_size=7,
                                                    sampling_ratio=2)
-
+   
    # put the pieces together inside a FasterRCNN model
    model = FasterRCNN(backbone,
                       num_classes=2,


### PR DESCRIPTION
this is to reflect that, some users are seeing an error and you must put the integer into a string.. in order for the backbone neural network to be accepted during the tutorial.

See : https://github.com/pytorch/vision/issues/2021

I left the sourcecode as-is.. so tutorial members can get a little stuck in the event they need to modify this variable to a string.. and now the hint is in the comments