### PR TITLE
Fixing a bug in Captum Recipe

### DIFF
--- a/recipes_source/recipes/Captum_Recipe.py
+++ b/recipes_source/recipes/Captum_Recipe.py
@@ -136,7 +136,7 @@ from captum.attr import visualization as viz
 attribution_dog = np.transpose(attribution_dog.squeeze().cpu().detach().numpy(), (1,2,0))
 
 vis_types = ["heat_map", "original_image"]
-vis_signs = ["all", "all"], # "positive", "negative", or "all" to show both
+vis_signs = ["all", "all"] # "positive", "negative", or "all" to show both
 # positive attribution indicates that the presence of the area increases the prediction score
 # negative attribution indicates distractor areas whose absence increases the score
 


### PR DESCRIPTION
In the Pytorch Recipe, MODEL INTERPRETABILITY USING CAPTUM there is a following bug:

In the following line of code, the comma after the brackets is interpreted as an additional array dimension, causing an assert error when passed to the viz.visualize_image_attr_multiple() function.

vis_signs = ["all", "all"],

Removing the comma solves the issue.