### PR TITLE
Fix duplicate "bite sized" text/typo in introduction paragraph

### DIFF
--- a/recipes_source/recipes_index.rst
+++ b/recipes_source/recipes_index.rst
@@ -1,6 +1,6 @@
 PyTorch Recipes
 ---------------------------------------------
-Recipes are bite-sized bite-sized, actionable examples of how to use specific PyTorch features, different from our full-length tutorials.
+Recipes are bite-sized, actionable examples of how to use specific PyTorch features, different from our full-length tutorials.
 
 .. raw:: html
 


### PR DESCRIPTION
Small PR, noticed that there was a typo on the main landing page, in the introductory paragraph. This fixed that. :)