### PR TITLE
torch_script_custom_ops restructure

### DIFF
--- a/advanced_source/torch_script_custom_ops/CMakeLists.txt
+++ b/advanced_source/torch_script_custom_ops/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+project(warp_perspective)
+
+find_package(Torch REQUIRED)
+find_package(OpenCV REQUIRED)
+
+# Define our library target
+add_library(warp_perspective SHARED op.cpp)
+# Enable C++14
+target_compile_features(warp_perspective PRIVATE cxx_std_14)
+# Link against LibTorch
+target_link_libraries(warp_perspective "${TORCH_LIBRARIES}")
+# Link against OpenCV
+target_link_libraries(warp_perspective opencv_core opencv_imgproc)

--- a/advanced_source/torch_script_custom_ops/op.cpp
+++ b/advanced_source/torch_script_custom_ops/op.cpp
@@ -1,0 +1,35 @@
+#include <opencv2/opencv.hpp>
+#include <torch/script.h>
+
+// BEGIN warp_perspective
+torch::Tensor warp_perspective(torch::Tensor image, torch::Tensor warp) {
+  // BEGIN image_mat
+  cv::Mat image_mat(/*rows=*/image.size(0),
+                    /*cols=*/image.size(1),
+                    /*type=*/CV_32FC1,
+                    /*data=*/image.data_ptr<float>());
+  // END image_mat
+
+  // BEGIN warp_mat
+  cv::Mat warp_mat(/*rows=*/warp.size(0),
+                   /*cols=*/warp.size(1),
+                   /*type=*/CV_32FC1,
+                   /*data=*/warp.data_ptr<float>());
+  // END warp_mat
+
+  // BEGIN output_mat
+  cv::Mat output_mat;
+  cv::warpPerspective(image_mat, output_mat, warp_mat, /*dsize=*/{8, 8});
+  // END output_mat
+
+  // BEGIN output_tensor
+  torch::Tensor output = torch::from_blob(output_mat.ptr<float>(), /*sizes=*/{8, 8});
+  return output.clone();
+  // END output_tensor
+}
+// END warp_perspective
+
+// BEGIN registry
+static auto registry =
+  torch::RegisterOperators("my_ops::warp_perspective", &warp_perspective);
+// END registry


### PR DESCRIPTION
I wanted to be able to run the examples easily in this tutorial, so that I could test upcoming changes I'm going to make to it. But this was not easily done because the source code was embedded in the rst file. So what I did was I moved these out to separate files, and then used the `literalinclude` directive to include them back into the rst file. (Gallery wasn't appropriate here because these aren't Python files). This tutorial did a lot of referencing of internal code fragments; I used `start-after` and `end-before` to do these, but I had to goop up the tutorial with some more comments to accurately do these. We could consider stripping these comments out from the final product later, but for now I didn't do it.

You need to install OpenCV somehow to run this test; `conda install opencv`. Then I built the example with:

```
(cd build && CMAKE_PREFIX_PATH=$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)') cmake .. && make)
```

I didn't attempt to start making other things runnable.

Signed-off-by: Edward Z. Yang <ezyang@fb.com>