### PR TITLE
Add new directory for prototype tutorials

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -86,6 +86,17 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
       FILES_TO_RUN+=($(basename $filename .py))
     fi
     count=$((count+1))
+   done
+    done
+   for filename in $(find prototype_source/ -name '*.py' -not -path '*/data/*'); do
+    if [ $(($count % $NUM_WORKERS)) != $WORKER_ID ]; then
+      echo "Removing runnable code from "$filename
+      python $DIR/remove_runnable_code.py $filename $filename
+    else
+      echo "Keeping "$filename
+      FILES_TO_RUN+=($(basename $filename .py))
+    fi
+    count=$((count+1))
   done
   echo "FILES_TO_RUN: " ${FILES_TO_RUN[@]}
 
@@ -94,13 +105,13 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
 
   # Step 4: If any of the generated files are not related the tutorial files we want to run,
   # then we remove them
-  for filename in $(find docs/beginner docs/intermediate docs/advanced docs/recipes -name '*.html'); do
+  for filename in $(find docs/beginner docs/intermediate docs/advanced docs/recipes docs/prototype -name '*.html'); do
     file_basename=$(basename $filename .html)
     if [[ ! " ${FILES_TO_RUN[@]} " =~ " ${file_basename} " ]]; then
       rm $filename
     fi
   done
-  for filename in $(find docs/beginner docs/intermediate docs/advanced docs/recipes -name '*.rst'); do
+  for filename in $(find docs/beginner docs/intermediate docs/advanced docs/recipes docs/prototype -name '*.rst'); do
     file_basename=$(basename $filename .rst)
     if [[ ! " ${FILES_TO_RUN[@]} " =~ " ${file_basename} " ]]; then
       rm $filename
@@ -124,7 +135,7 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
       rm $filename
     fi
   done
-  for filename in $(find docs/.doctrees/beginner docs/.doctrees/intermediate docs/.doctrees/advanced docs/.doctrees/recipes -name '*.doctree'); do
+  for filename in $(find docs/.doctrees/beginner docs/.doctrees/intermediate docs/.doctrees/advanced docs/.doctrees/recipes docs/.doctrees/prototype -name '*.doctree'); do
     file_basename=$(basename $filename .doctree)
     if [[ ! " ${FILES_TO_RUN[@]} " =~ " ${file_basename} " ]]; then
       rm $filename

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -87,7 +87,6 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
     fi
     count=$((count+1))
    done
-    done
    for filename in $(find prototype_source/ -name '*.py' -not -path '*/data/*'); do
     if [ $(($count % $NUM_WORKERS)) != $WORKER_ID ]; then
       echo "Removing runnable code from "$filename

--- a/conf.py
+++ b/conf.py
@@ -63,8 +63,8 @@ extensions = ['sphinx.ext.mathjax',
 
 sphinx_gallery_conf = {
     'examples_dirs': ['beginner_source', 'intermediate_source',
-                      'advanced_source', 'recipes_source'],
-    'gallery_dirs': ['beginner', 'intermediate', 'advanced', 'recipes'],
+                      'advanced_source', 'recipes_source', 'prototype_source'],
+    'gallery_dirs': ['beginner', 'intermediate', 'advanced', 'recipes', 'prototype'],
     'filename_pattern': 'tutorial.py',
     'backreferences_dir': False
 }

--- a/prototype_source/README.md
+++ b/prototype_source/README.md
@@ -1,0 +1,7 @@
+# Prototype Tutorials
+
+This directory contains tutorials demonstrating prototype features in PyTorch. 
+
+**Prototype features** are not available as part of binary distributions like PyPI or Conda (except maybe behind run-time flags). To test these features we would, depending on the feature, recommend building from master or using the nightly wheelss that are made available on pytorch.org. 
+
+*Level of commitment:* We are committing to gathering high bandwidth feedback only on these features. Based on this feedback and potential further engagement between community members, we as a community will decide if we want to upgrade the level of commitment or to fail fast. 

--- a/prototype_source/README.txt
+++ b/prototype_source/README.txt
@@ -1,0 +1,2 @@
+Prototype Tutorials
+------------------


### PR DESCRIPTION
This directory will house all prototype feature tutorials so they won’t be searchable from http://pytorch.org/tutorials since prototype features will only be relevant to a small population of developers and the code will only be in unstable. Once features no longer have the “prototype” classification, they will be graduated to one of the other existing, public-facing directories (e.g. beginner, intermediate, advanced). 