### PR TITLE
fix bugs for data_loading_tutorial and dcgan_faces_tutorial

### DIFF
--- a/beginner_source/data_loading_tutorial.py
+++ b/beginner_source/data_loading_tutorial.py
@@ -374,7 +374,7 @@ for i in range(len(transformed_dataset)):
 #
 
 dataloader = DataLoader(transformed_dataset, batch_size=4,
-                        shuffle=True, num_workers=4)
+                        shuffle=True, num_workers=0)
 
 
 # Helper function to show a batch

--- a/beginner_source/dcgan_faces_tutorial.py
+++ b/beginner_source/dcgan_faces_tutorial.py
@@ -591,7 +591,7 @@ for epoch in range(num_epochs):
         # Format batch
         real_cpu = data[0].to(device)
         b_size = real_cpu.size(0)
-        label = torch.full((b_size,), real_label, device=device)
+        label = torch.full((b_size,), real_label, dtype=torch.float, device=device)
         # Forward pass real batch through D
         output = netD(real_cpu).view(-1)
         # Calculate loss on all-real batch


### PR DESCRIPTION
bug in data_loading_tutorial:
      This tutorial fails on windows because code with multiple processes must be put in main() function on windows platform. And to not change the structure of the tutorial html page,  just modify the multiple processes to single process.

bug in dcgan_faces_tutorial:
       When pytorch updating from v1.5 to v1.6, one warning message "Providing a bool or integral fill value without setting the optional `dtype` or `out` arguments is currently unsupported." is changed to error. So change the tutorial correspondingly.