### PR TITLE
G to be in eval() mode for G's output on fixed_noise

### DIFF
--- a/beginner_source/dcgan_faces_tutorial.py
+++ b/beginner_source/dcgan_faces_tutorial.py
@@ -645,8 +645,10 @@ for epoch in range(num_epochs):
         
         # Check how the generator is doing by saving G's output on fixed_noise
         if (iters % 500 == 0) or ((epoch == num_epochs-1) and (i == len(dataloader)-1)):
+            netG.eval()
             with torch.no_grad():
                 fake = netG(fixed_noise).detach().cpu()
+            netG.train()
             img_list.append(vutils.make_grid(fake, padding=2, normalize=True))
             
         iters += 1


### PR DESCRIPTION
For G's output on fixed_noise, netG should be in eval() mode for Batch_Norm layers to use running mean & running variance instead of batch_statistics.
netG's eval() mode makes sure that that G's output will also be valid on a single instance of fixed_noise e.g. fixed_noise = torch.randn(1, nz, 1, 1, device=device).
After G's output has been obtained, we reset netG to train() mode to allow G's training further.