### PR TITLE
Disable memory_format_tutorial on Windows CI

### DIFF
--- a/.circleci/scripts/build_for_windows.sh
+++ b/.circleci/scripts/build_for_windows.sh
@@ -44,8 +44,6 @@ python $DIR/remove_runnable_code.py beginner_source/aws_distributed_training_tut
 python $DIR/remove_runnable_code.py beginner_source/data_loading_tutorial.py beginner_source/data_loading_tutorial.py || true
 python $DIR/remove_runnable_code.py beginner_source/dcgan_faces_tutorial.py beginner_source/dcgan_faces_tutorial.py || true
 python $DIR/remove_runnable_code.py intermediate_source/model_parallel_tutorial.py intermediate_source/model_parallel_tutorial.py || true
-python $DIR/remove_runnable_code.py advanced_source/static_quantization_tutorial.py advanced_source/static_quantization_tutorial.py || true
-python $DIR/remove_runnable_code.py prototype_source/numeric_suite_tutorial.py || true
-python $DIR/remove_runnable_code.py prototype_source/graph_mode_static_quantization_tutorial.py || true
+python $DIR/remove_runnable_code.py intermediate_source/memory_format_tutorial.py intermediate_source/memory_format_tutorial.py || true
 
 make docs


### PR DESCRIPTION
To resolve https://github.com/pytorch/tutorials/issues/1101

memory_format_tutorial.py uses setattr() to modify the attributes of torch. This will cause CI test failure to other tutorials because they are all executed in one process in sphinx.
This bugs will not influence the linux because tutorials are running parallelly with 20 workers on CircleCI for linux and memory_format_tutorial and other related tutorials are running in different workers.
This pr fix it by disable memory_format_tutorial.py when running windows CI test.

test at #1106 