### PR TITLE
Recover the attributes of torch in memory_format_tutorial

### DIFF
--- a/intermediate_source/memory_format_tutorial.py
+++ b/intermediate_source/memory_format_tutorial.py
@@ -261,14 +261,17 @@ def check_wrapper(fn):
         return result
     return check_cl
 
+old_attrs = dict()
 
 def attribute(m):
+    old_attrs[m] = dict()
     for i in dir(m):
         e = getattr(m, i)
         exclude_functions = ['is_cuda', 'has_names', 'numel',
                              'stride', 'Tensor', 'is_contiguous', '__class__']
         if i not in exclude_functions and not i.startswith('_') and '__call__' in dir(e):
             try:
+                old_attrs[m][i] = e
                 setattr(m, i, check_wrapper(e))
             except Exception as e:
                 print(i)
@@ -285,6 +288,13 @@ attribute(torch)
 # and you want to contribute, feel free to use following developers
 # guide https://github.com/pytorch/pytorch/wiki/Writing-memory-format-aware-operators.
 #
+
+######################################################################
+# Code below is to recover the attributes of torch.
+
+for (m, attrs) in old_attrs.items():
+  for (k,v) in attrs.items():
+    setattr(m, k, v)
 
 ######################################################################
 # Work to do


### PR DESCRIPTION
memory_format_tutorial.py uses setattr() to modify the attributes of torch. This will cause CI test failure to other tutorials because they are all executed in one process in sphinx.
So this pr fix it by appending code of recovering attributes of torch to memory_format_tutorial.py.