### PR TITLE
Fix typo

### DIFF
--- a/recipes_source/recipes/what_is_state_dict.py
+++ b/recipes_source/recipes/what_is_state_dict.py
@@ -28,7 +28,7 @@ available.
 
 ::
 
-   pip install torchaudio
+   pip install torch
 
 """
 


### PR DESCRIPTION
In PyTorch tutorial, `torch` should be installed rather than `torchaudio`