### PR TITLE
Minor fix to discontinued comment block 

### DIFF
--- a/recipes_source/recipes/loading_data_recipe.py
+++ b/recipes_source/recipes/loading_data_recipe.py
@@ -91,7 +91,7 @@ import torchaudio
 # training and testing dataset will exist. The other parameters are
 # optional, with their default values shown. Here is some additional
 # useful info on the other parameters:
-
+#
 # * ``download``: If true, downloads the dataset from the internet and puts it in root directory. If dataset is already downloaded, it is not downloaded again.
 # * ``transform``: Using transforms on your data allows you to take it from its source state and transform it into data that’s joined together, de-normalized, and ready for training. Each library in PyTorch supports a growing list of transformations.
 # * ``target_transform``: A function/transform that takes in the target and transforms it.


### PR DESCRIPTION
Hey guys, it looks like a comment block was cut off due to a missing `#`, causing paragraph text to show up as Python comments. Here is the document in question:

<img width="500" alt="Screen Shot 2020-08-15 at 2 33 19 PM" src="https://user-images.githubusercontent.com/23400562/90306074-87d57d00-df04-11ea-8ab1-41eda05d85e5.png">

This PR adds the missing `#`