### PR TITLE
Fix typo in "Introduction to Pytorch" tutorial (in NLP tutorial)

### DIFF
--- a/beginner_source/nlp/pytorch_tutorial.py
+++ b/beginner_source/nlp/pytorch_tutorial.py
@@ -274,7 +274,7 @@ print(new_z.grad_fn)
 
 ###############################################################
 # You can also stop autograd from tracking history on Tensors
-# with ``.requires_grad``=True by wrapping the code block in
+# with ``.requires_grad=True`` by wrapping the code block in
 # ``with torch.no_grad():``
 print(x.requires_grad)
 print((x ** 2).requires_grad)

--- a/beginner_source/nlp/pytorch_tutorial.py
+++ b/beginner_source/nlp/pytorch_tutorial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+r"""
 Introduction to PyTorch
 ***********************
 

--- a/beginner_source/nlp/pytorch_tutorial.py
+++ b/beginner_source/nlp/pytorch_tutorial.py
@@ -281,3 +281,5 @@ print((x ** 2).requires_grad)
 
 with torch.no_grad():
 	print((x ** 2).requires_grad)
+
+

--- a/beginner_source/nlp/pytorch_tutorial.py
+++ b/beginner_source/nlp/pytorch_tutorial.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-r"""
+"""
 Introduction to PyTorch
 ***********************
 
@@ -281,5 +281,3 @@ print((x ** 2).requires_grad)
 
 with torch.no_grad():
 	print((x ** 2).requires_grad)
-
-


### PR DESCRIPTION
The `Introduction to Pytorch` page in the "Deep Learning for NLP" tutorial (https://pytorch.org/tutorials/beginner/nlp/pytorch_tutorial.html), has a typo. This one-line PR fixes the typo.

Before (with typo)
<img width="811" alt="Screen Shot 2020-08-31 at 10 55 41 PM" src="https://user-images.githubusercontent.com/2577384/91789683-23414000-ebdd-11ea-93f5-783e6f6cedfc.png">

With this PR (typo fixed)
<img width="811" alt="Screen Shot 2020-08-31 at 10 55 28 PM" src="https://user-images.githubusercontent.com/2577384/91789692-2805f400-ebdd-11ea-8196-fe1e04b9c9d2.png">
