### PR TITLE
Install torch not torchaudio

### DIFF
--- a/recipes_source/recipes/defining_a_neural_network.py
+++ b/recipes_source/recipes/defining_a_neural_network.py
@@ -26,7 +26,7 @@ available.
 
 ::
 
-   pip install torchaudio
+   pip install torch
 
 
 """


### PR DESCRIPTION
Small update to recipe that instructs users to install `torch` not `torchaudio`