### PR TITLE
Fix MultiScaleRoIAlign featmap_names to string

### DIFF
--- a/intermediate_source/torchvision_tutorial.rst
+++ b/intermediate_source/torchvision_tutorial.rst
@@ -263,7 +263,7 @@ way of doing it:
    # be [0]. More generally, the backbone should return an
    # OrderedDict[Tensor], and in featmap_names you can choose which
    # feature maps to use.
-   roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=[0],
+   roi_pooler = torchvision.ops.MultiScaleRoIAlign(featmap_names=['0'],
                                                    output_size=7,
                                                    sampling_ratio=2)
 


### PR DESCRIPTION
When using a backbone that returns a tensor an OrderedDict with key '0' is created (string not int).
So when creating a MultiScaleRoIAlign the featmap_names should be a string '0'.