### PR TITLE
Update transformer tutorial

### DIFF
--- a/beginner_source/transformer_tutorial.py
+++ b/beginner_source/transformer_tutorial.py
@@ -217,6 +217,7 @@ nhead = 2 # the number of heads in the multiheadattention models
 dropout = 0.2 # the dropout value
 model = TransformerModel(ntokens, emsize, nhead, nhid, nlayers, dropout).to(device)
 
+
 ######################################################################
 # Run the model
 # -------------


### PR DESCRIPTION
This PR updates the transformer tutorial. In the new tutorial, we generate the `src_mask` tensor out of the forward function of the transformer. In this way, users are able to `torch.jit.script` TransformerModel. I have also run the tutorial locally and this PR doesn't change the results and performance.