### PR TITLE
Fixed link to docs in audio_preprocessing_tutorial

### DIFF
--- a/beginner_source/audio_preprocessing_tutorial.py
+++ b/beginner_source/audio_preprocessing_tutorial.py
@@ -60,7 +60,7 @@ plt.plot(waveform.t().numpy())
 # ---------------
 # 
 # ``torchaudio`` supports a growing list of
-# `transformations <https://pytorch.org/audio/transforms.html>`_.
+# `transformations <https://pytorch.org/audio/stable/transforms.html>`_.
 # 
 # -  **Resample**: Resample waveform to a different sample rate.
 # -  **Spectrogram**: Create a spectrogram from a waveform.


### PR DESCRIPTION
One line fix of the link to the documentation as defined in #1233 