### PR TITLE
Fix TF32 convergence issue with TF32

### DIFF
--- a/beginner_source/examples_autograd/two_layer_net_autograd.py
+++ b/beginner_source/examples_autograd/two_layer_net_autograd.py
@@ -24,7 +24,7 @@ device = torch.device("cpu")
 # The above line disables TensorFloat32. This a feature that allows
 # networks to run at a much faster speed while sacrificing precision.
 # Although TensorFloat32 works well on most real models, for our toy model
-# in this tutorial, the sacrificed precision causes precision issue.
+# in this tutorial, the sacrificed precision causes convergence issue.
 # For more information, see:
 # https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices
 

--- a/beginner_source/examples_autograd/two_layer_net_autograd.py
+++ b/beginner_source/examples_autograd/two_layer_net_autograd.py
@@ -18,7 +18,15 @@ import torch
 
 dtype = torch.float
 device = torch.device("cpu")
-# device = torch.device("cuda:0") # Uncomment this to run on GPU
+# device = torch.device("cuda:0")  # Uncomment this to run on GPU
+# torch.backends.cuda.matmul.allow_tf32 = False  # Uncomment this to run on GPU
+
+# The above line disables TensorFloat32. This a feature that allows
+# networks to run at a much faster speed while sacrificing precision.
+# Although TensorFloat32 works well on most real models, for our toy model
+# in this tutorial, the sacrificed precision causes precision issue.
+# For more information, see:
+# https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices
 
 # N is batch size; D_in is input dimension;
 # H is hidden dimension; D_out is output dimension.

--- a/beginner_source/examples_autograd/two_layer_net_custom_function.py
+++ b/beginner_source/examples_autograd/two_layer_net_custom_function.py
@@ -54,7 +54,7 @@ device = torch.device("cpu")
 # The above line disables TensorFloat32. This a feature that allows
 # networks to run at a much faster speed while sacrificing precision.
 # Although TensorFloat32 works well on most real models, for our toy model
-# in this tutorial, the sacrificed precision causes precision issue.
+# in this tutorial, the sacrificed precision causes convergence issue.
 # For more information, see:
 # https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices
 

--- a/beginner_source/examples_autograd/two_layer_net_custom_function.py
+++ b/beginner_source/examples_autograd/two_layer_net_custom_function.py
@@ -48,7 +48,15 @@ class MyReLU(torch.autograd.Function):
 
 dtype = torch.float
 device = torch.device("cpu")
-# device = torch.device("cuda:0") # Uncomment this to run on GPU
+# device = torch.device("cuda:0")  # Uncomment this to run on GPU
+# torch.backends.cuda.matmul.allow_tf32 = False  # Uncomment this to run on GPU
+
+# The above line disables TensorFloat32. This a feature that allows
+# networks to run at a much faster speed while sacrificing precision.
+# Although TensorFloat32 works well on most real models, for our toy model
+# in this tutorial, the sacrificed precision causes precision issue.
+# For more information, see:
+# https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices
 
 # N is batch size; D_in is input dimension;
 # H is hidden dimension; D_out is output dimension.


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/47844

Output before the fix:
```
99 581.02685546875
199 10.408246994018555
299 8.866250991821289
399 21.11296844482422
499 21.725337982177734
```
and
```
99 244.06027221679688
199 11.857839584350586
299 6.741735935211182
399 8.316146850585938
499 18.457813262939453
```



Output after the fix:
```
99 645.8162841796875
199 6.169060707092285
299 0.08816853910684586
399 0.0016538957133889198
499 0.00013183383271098137
```
and
```
99 604.789794921875
199 10.036174774169922
299 0.269910991191864
399 0.009123876690864563
499 0.0006364969885908067
```