### PR TITLE
Correct mistake in requires_grad_

### DIFF
--- a/beginner_source/blitz/autograd_tutorial.py
+++ b/beginner_source/blitz/autograd_tutorial.py
@@ -74,7 +74,7 @@ print(z, out)
 
 ################################################################
 # ``.requires_grad_( ... )`` changes an existing Tensor's ``requires_grad``
-# flag in-place. The input flag defaults to ``False`` if not given.
+# flag in-place. The input flag defaults to ``True`` if not given.
 a = torch.randn(2, 2)
 a = ((a * 3) / (a - 1))
 print(a.requires_grad)


### PR DESCRIPTION
That's I got:
x = torch.tensor([1.])
print(x)  # tensor([1.])
x.requires_grad_()
print(x) # tensor([1.], requires_grad=True)