### PR TITLE
Update transformer_tutorial.py

### DIFF
--- a/beginner_source/transformer_tutorial.py
+++ b/beginner_source/transformer_tutorial.py
@@ -274,13 +274,13 @@ def train():
         total_loss += loss.item()
         log_interval = 200
         if batch % log_interval == 0 and batch > 0:
-            cur_loss = total_loss / log_interval
+            cur_loss = total_loss / batch
             elapsed = time.time() - start_time
             print('| epoch {:3d} | {:5d}/{:5d} batches | '
                   'lr {:02.2f} | ms/batch {:5.2f} | '
                   'loss {:5.2f} | ppl {:8.2f}'.format(
                     epoch, batch, len(train_data) // bptt, scheduler.get_lr()[0],
-                    elapsed * 1000 / log_interval,
+                    elapsed * 1000 / batch,
                     cur_loss, math.exp(cur_loss)))
             total_loss = 0
             start_time = time.time()


### PR DESCRIPTION
`cur_loss` and ms/batch should be calculated with `batch` (the # of batches processed so far), not `log_interval` (the interval of printing out learning statistics)