### PR TITLE
remove deadlink of old AWS tutorial

### DIFF
--- a/beginner_source/dist_overview.rst
+++ b/beginner_source/dist_overview.rst
@@ -131,8 +131,6 @@ DDP materials are listed below:
    tutorial.
 3. The `Launching and configuring distributed data parallel applications <https://github.com/pytorch/examples/blob/master/distributed/ddp/README.md>`__
    document shows how to use the DDP launching script.
-4. `PyTorch Distributed Trainer with Amazon AWS <aws_distributed_training_tutorial.html>`__
-   demonstrates how to use DDP on AWS.
 
 TorchElastic
 ~~~~~~~~~~~~


### PR DESCRIPTION
The link is missed since the old AWS tutorial is removed.
[PyTorch Distributed Trainer with Amazon AWS](https://pytorch.org/tutorials/beginner/aws_distributed_training_tutorial.html) demonstrates how to use DDP on AWS.
