### PR TITLE
[TorchScript] Fix archive file extension in tutorials

### DIFF
--- a/beginner_source/Intro_to_TorchScript_tutorial.py
+++ b/beginner_source/Intro_to_TorchScript_tutorial.py
@@ -368,9 +368,9 @@ print(traced.code)
 # process. Let’s save and load our wrapped RNN module:
 #
 
-traced.save('wrapped_rnn.zip')
+traced.save('wrapped_rnn.pt')
 
-loaded = torch.jit.load('wrapped_rnn.zip')
+loaded = torch.jit.load('wrapped_rnn.pt')
 
 print(loaded)
 print(loaded.code)


### PR DESCRIPTION
**Summary**
Tutorials, documentation and comments are not consistent with the file
extension they use for JIT archives. This commit modifies certain
instances of `*.zip` in `torch.jit.save` calls with `*.pt`.
    
**Test Plan**
Continuous integration.
    
**Fixes**
This commit fixes #49660 in the pytorch/pytorch repository.