### PR TITLE
Update spaCy model download to full name

### DIFF
--- a/.circleci/scripts/build_for_windows.sh
+++ b/.circleci/scripts/build_for_windows.sh
@@ -10,12 +10,12 @@ PROJECT_DIR="${SOURCE_DIR}/../.."
 pushd $SOURCE_DIR
 
 #install wget and make
-curl -k https://ymu.dl.osdn.jp/mingw/68260/mingw-get-0.6.3-mingw32-pre-20170905-1-bin.zip -o mingw32.zip
+curl --retry 3 -k https://ymu.dl.osdn.jp/mingw/68260/mingw-get-0.6.3-mingw32-pre-20170905-1-bin.zip -o mingw32.zip
 unzip mingw32.zip -d mingw32
 mingw32/bin/mingw-get.exe install mingw32-make
 mingw32/bin/mingw-get.exe install msys-findutils
 mv mingw32/bin/mingw32-make.exe mingw32/bin/make.exe
-curl -k https://eternallybored.org/misc/wget/1.20.3/64/wget.exe -o mingw32/bin/wget.exe
+curl --retry 3 -k https://eternallybored.org/misc/wget/1.20.3/64/wget.exe -o mingw32/bin/wget.exe
 export PATH="${SOURCE_DIR}/mingw32/bin:${SOURCE_DIR}/mingw32/msys/1.0/bin:$PATH"
 
 #install anaconda3
@@ -23,7 +23,7 @@ export CONDA_HOME="${SOURCE_DIR}/conda"
 export tmp_conda="${SOURCE_DIR}/conda"
 export miniconda_exe="${SOURCE_DIR}/miniconda.exe"
 rm -rf conda miniconda.exe
-curl -k https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o miniconda.exe
+curl --retry 3 -k https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe -o miniconda.exe
 ./install_conda.bat
 export PATH="${tmp_conda}:${tmp_conda}/Library/usr/bin:${tmp_conda}/Library/bin:${tmp_conda}/Scripts:${tmp_conda}/bin:$PATH"
 

--- a/.circleci/scripts/build_for_windows.sh
+++ b/.circleci/scripts/build_for_windows.sh
@@ -38,8 +38,8 @@ pip install pySoundFile
 # Force uninstall torch & related packages, we'll install them using conda later.
 pip uninstall -y torch torchvision torchtext
 conda install -yq -c pytorch "cudatoolkit=10.2" pytorch torchvision torchtext torchaudio
-python -m spacy download de
-python -m spacy download en
+python -m spacy download de_core_news_sm
+python -m spacy download en_core_web_sm
 pushd ${PROJECT_DIR}
 DIR=.jenkins
 export NUM_WORKERS=4

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -36,8 +36,8 @@ pip install -r $DIR/../requirements.txt
 pip install tb-nightly
 
 # Install two language tokenizers for Translation with TorchText tutorial
-python -m spacy download en
-python -m spacy download de
+python -m spacy download en_core_web_sm
+python -m spacy download de_core_news_sm
 
 # PyTorch Theme
 rm -rf src

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ PyHamcrest
 bs4
 awscliv2==2.1.1
 flask
-spacy
+spacy==3.4.1
 ray[tune]
 tensorboard
 jinja2==3.0.3


### PR DESCRIPTION
Short 'en' and 'de' names has been deprecated since spaCy 3.0, so use fullname instead as suggested by the warning:
```
[!] As of spaCy v3.0, shortcuts like 'en' are deprecated. Pleaseuse the full
pipeline package name 'en_core_web_sm' instead.
[!] As of spaCy v3.0, shortcuts like 'de' are deprecated. Pleaseuse the full
pipeline package name 'de_core_news_sm' instead.
```
Also, add `--retry 3` to all curl commands in Windows CI path