### PR TITLE
Add new FX tutorial to the left hand nav

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -566,7 +566,8 @@ Additional Resources
    :includehidden:
    :hidden:
    :caption: Code Transforms with FX
-
+   
+   intermediate/fx_conv_bn_fuser
    intermediate/fx_profiling_tutorial
 
 .. toctree::


### PR DESCRIPTION
The Building a Convolution/Batch Norm fuser in FX tutorial (https://pytorch.org/tutorials/intermediate/fx_conv_bn_fuser.html) was added for 1.8. This is a minor update to index.rst to have the tutorial show up in the left hand nav under the "Code Transforms with FX" category.