### PR TITLE
fgsm_tutorial temp disable for windows CI

### DIFF
--- a/.circleci/scripts/build_for_windows.sh
+++ b/.circleci/scripts/build_for_windows.sh
@@ -50,6 +50,8 @@ if [[ "${CIRCLE_JOB}" == *worker_* ]]; then
   python $DIR/remove_runnable_code.py advanced_source/static_quantization_tutorial.py advanced_source/static_quantization_tutorial.py || true
   python $DIR/remove_runnable_code.py beginner_source/hyperparameter_tuning_tutorial.py beginner_source/hyperparameter_tuning_tutorial.py || true
   python $DIR/remove_runnable_code.py beginner_source/audio_preprocessing_tutorial.py  beginner_source/audio_preprocessing_tutorial.py || true
+  # Temp remove for mnist download issue.
+  python $DIR/remove_runnable_code.py beginner_source/fgsm_tutorial.py  beginner_source/fgsm_tutorial.py || true
 
   export WORKER_ID=$(echo "${CIRCLE_JOB}" | tr -dc '0-9')
   count=0


### PR DESCRIPTION
Temp disable fgsm_tutorial for the mnist download issue
It has been disabled in linux at https://github.com/pytorch/tutorials/pull/1415