### PR TITLE
Fix Win CI failure for installing torchaudio

### DIFF
--- a/.circleci/scripts/build_for_windows.sh
+++ b/.circleci/scripts/build_for_windows.sh
@@ -37,8 +37,7 @@ pip install -r requirements.txt
 pip install pySoundFile
 # Force uninstall torch & related packages, we'll install them using conda later.
 pip uninstall -y torch torchvision torchtext
-conda install -yq -c pytorch "cudatoolkit=10.1" pytorch torchvision torchtext
-conda install torchaudio -c pytorch-test
+conda install -yq -c pytorch "cudatoolkit=10.1" pytorch torchvision torchtext torchaudio
 python -m spacy download de
 python -m spacy download en
 pushd ${PROJECT_DIR}


### PR DESCRIPTION
The windows package of torchaudio was not uploaded to pytorch channel of conda cloud when CI added for windows, so it was installed from pytorch-test channel. It seems that some failure happen for installing from pytorch-test channel: https://app.circleci.com/pipelines/github/pytorch/tutorials/3747/workflows/dd34f556-4fd7-4073-8b8f-5b8e525d87bd/jobs/70580
And for now torchaudio of windows can be installed from the pytroch channel already. Just fix it.