### PR TITLE
Updated web link for flask_rest_api_tutorial.py

### DIFF
--- a/intermediate_source/README.txt
+++ b/intermediate_source/README.txt
@@ -31,4 +31,4 @@ Intermediate tutorials
 
 8. flask_rest_api_tutorial.py
 	Deploying PyTorch and Building a REST API using Flask
-	https://pytorch.org/tutorials/beginner/flask_rest_api_tutorial.html
+	https://pytorch.org/tutorials/intermediate/flask_rest_api_tutorial.html


### PR DESCRIPTION
Link was broken. Updated to new link location. Thanks.