### PR TITLE
Register all the parameters in the optimizer

### DIFF
--- a/beginner_source/blitz/autograd_tutorial.py
+++ b/beginner_source/blitz/autograd_tutorial.py
@@ -299,7 +299,7 @@ model.fc = nn.Linear(512, 10)
 # The only parameters that compute gradients are the weights and bias of ``model.fc``.
 
 # Optimize only the classifier
-optimizer = optim.SGD(model.fc.parameters(), lr=1e-2, momentum=0.9)
+optimizer = optim.SGD(model.parameters(), lr=1e-2, momentum=0.9)
 
 ##########################################################################
 # Notice although we register all the parameters in the optimizer,


### PR DESCRIPTION
The code at the end registers only the parameters from `model.fc` in the optimizer, although the text underneath says: "Notice although we register all the parameters in the optimizer, the only parameters that are computing gradients (and hence updated in gradient descent) are the weights and bias of the classifier."

To be consistent with this explanation, we should be adding all the parameters from the model.