### PR TITLE
remove unnecessary imports in pytorch_tutorial.py

### DIFF
--- a/beginner_source/nlp/pytorch_tutorial.py
+++ b/beginner_source/nlp/pytorch_tutorial.py
@@ -14,10 +14,6 @@ lets look what we can do with tensors.
 # Author: Robert Guthrie
 
 import torch
-import torch.autograd as autograd
-import torch.nn as nn
-import torch.nn.functional as F
-import torch.optim as optim
 
 torch.manual_seed(1)
 


### PR DESCRIPTION
When doing this tutorial, I was a bit confused about all of the initial imports. I realized once I'd finished it that I didn't actually need them.

I would recommend removing them to reduce cognitive overload for first-time users.