### PR TITLE
Pin docutils to 0.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 
 sphinx==1.8.2
 sphinx-gallery==0.3.1
+docutils==0.16
 sphinx-copybutton
 tqdm
 numpy


### PR DESCRIPTION
docutils-0.17 causes sphinx-build to fail with:
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 69: ordinal not in range(128)
```
Which comes from new https://sourceforge.net/p/docutils/code/8590/tree/trunk/docutils/docutils/writers/latex2e/docutils.sty