### PR TITLE
Update instructions to copy all files

### DIFF
--- a/intermediate_source/torchvision_tutorial.rst
+++ b/intermediate_source/torchvision_tutorial.rst
@@ -317,8 +317,8 @@ Putting everything together
 In ``references/detection/``, we have a number of helper functions to
 simplify training and evaluating detection models. Here, we will use
 ``references/detection/engine.py``, ``references/detection/utils.py``
-and ``references/detection/transforms.py``. Just copy them to your
-folder and use them here.
+and ``references/detection/transforms.py``. Just copy everything under 
+``references/detection`` to your folder and use them here.
 
 Let’s write some helper functions for data augmentation /
 transformation:

--- a/intermediate_source/torchvision_tutorial.rst
+++ b/intermediate_source/torchvision_tutorial.rst
@@ -54,7 +54,7 @@ should return:
 
 If your model returns the above methods, they will make it work for both
 training and evaluation, and will use the evaluation scripts from
-``pycocotools``.
+``pycocotools`` which can be installed with ``pip install pycocotools``.
 
 .. note ::
   For Windows, please install ``pycocotools`` from `gautamchitnis <https://github.com/gautamchitnis/cocoapi>`__ with command 


### PR DESCRIPTION
See issue raised here: https://github.com/pytorch/vision/issues/3630
Basically, just copying the selected files cause import errors, since the coco_eval and coco_utils need to be copied as well. 
@NicolasHug pinging you here.

Thanks!