### PR TITLE
Fix formatting typo in classifier tutorial

### DIFF
--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -62,6 +62,8 @@ import torchvision.transforms as transforms
 ########################################################################
 # The output of torchvision datasets are PILImage images of range [0, 1].
 # We transform them to Tensors of normalized range [-1, 1].
+
+########################################################################
 # .. note::
 #     If running on Windows and you get a BrokenPipeError, try setting
 #     the num_worker of torch.utils.data.DataLoader() to 0.


### PR DESCRIPTION
Fixes a formatting typo in the classifier tutorial that is preventing the text referring to the `BrokenPipeError` from being properly rendered as a note. The text is currently being rendered as a code block.

Screenshot of current page:
![Screenshot 2021-04-07 at 15 38 50](https://user-images.githubusercontent.com/4746145/113877811-583bf380-97b9-11eb-9435-256d1f3df538.png)

Screenshot of page after fix:
![Screenshot 2021-04-07 at 15 51 52](https://user-images.githubusercontent.com/4746145/113877834-5bcf7a80-97b9-11eb-96ff-5fa37ce9826f.png)
