### PR TITLE
Add Google Colab info to the tutorials home page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -505,6 +505,11 @@ Additional Resources
    :button_link: https://github.com/pytorch/tutorials
    :button_text: Go To GitHub
 
+.. customcalloutitem::
+   :header: Run Tutorials on Google Colab
+   :description: Learn how to copy tutorial data into Google Drive so that you can run tutorials on Google Colab.
+   :button_link: beginner/colab.html
+   :button_text: Download
 
 .. End of callout section
 


### PR DESCRIPTION
Adding google colab info (https://pytorch.org/tutorials/beginner/colab.html) to the additional resources section on the tutorials home page.