### PR TITLE
Fix rendering bug in basics/data_tutorial.py

### DIFF
--- a/beginner_source/basics/data_tutorial.py
+++ b/beginner_source/basics/data_tutorial.py
@@ -225,7 +225,7 @@ test_dataloader = DataLoader(test_data, batch_size=64, shuffle=True)
 # --------------------------
 #
 # We have loaded that dataset into the ``Dataloader`` and can iterate through the dataset as needed.
-# Each iteration below returns a batch of ``train_features`` and ``train_labels``(containing ``batch_size=64`` features and labels respectively).
+# Each iteration below returns a batch of ``train_features`` and ``train_labels`` (containing ``batch_size=64`` features and labels respectively).
 # Because we specified ``shuffle=True``, after we iterate over all batches the data is shuffled (for finer-grained control over 
 # the data loading order, take a look at `Samplers <https://pytorch.org/docs/stable/data.html#data-loading-order-and-sampler>`_).
 


### PR DESCRIPTION
Currently, a \`\`blurb\`\` is not being rendered correctly:

<img width="804" alt="Screen Shot 2021-04-23 at 6 14 20 PM" src="https://user-images.githubusercontent.com/899569/115938309-ca6e3280-a45f-11eb-9d9a-afa257c8df5e.png">

This adds a single space character to allow the renderer to successfully parse the input.