### PR TITLE
Fix three usage errors: its vs it's

### DIFF
--- a/beginner_source/basics/autogradqs_tutorial.py
+++ b/beginner_source/basics/autogradqs_tutorial.py
@@ -58,7 +58,7 @@ loss = torch.nn.functional.binary_cross_entropy_with_logits(z, y)
 # A function that we apply to tensors to construct computational graph is
 # in fact an object of class ``Function``. This object knows how to
 # compute the function in the *forward* direction, and also how to compute
-# it's derivative during the *backward propagation* step. A reference to
+# its derivative during the *backward propagation* step. A reference to
 # the backward propagation function is stored in ``grad_fn`` property of a
 # tensor. You can find more information of ``Function`` `in the
 # documentation <https://pytorch.org/docs/stable/autograd.html#function>`__.

--- a/beginner_source/basics/buildmodel_tutorial.py
+++ b/beginner_source/basics/buildmodel_tutorial.py
@@ -67,7 +67,7 @@ class NeuralNetwork(nn.Module):
 
 ##############################################
 # We create an instance of ``NeuralNetwork``, and move it to the ``device``, and print 
-# it's structure.
+# its structure.
 
 model = NeuralNetwork().to(device)
 print(model)
@@ -119,7 +119,7 @@ print(flat_image.size())
 # nn.Linear 
 # ^^^^^^^^^^^^^^^^^^^^^^
 # The `linear layer <https://pytorch.org/docs/stable/generated/torch.nn.Linear.html>`_
-# is a module that applies a linear transformation on the input using it's stored weights and biases.
+# is a module that applies a linear transformation on the input using its stored weights and biases.
 #
 layer1 = nn.Linear(in_features=28*28, out_features=20)
 hidden1 = layer1(flat_image)


### PR DESCRIPTION
Addresses three grammatical usage errors of "its" (possessive) versus "it's" (contraction.)

Resolves: https://github.com/pytorch/tutorials/issues/1467
