### PR TITLE
The correct Kernel size is 5*5 not 3*3

### DIFF
--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -48,10 +48,10 @@ class Net(nn.Module):
         super(Net, self).__init__()
         # 1 input image channel, 6 output channels, 3x3 square convolution
         # kernel
-        self.conv1 = nn.Conv2d(1, 6, 3)
-        self.conv2 = nn.Conv2d(6, 16, 3)
+        self.conv1 = nn.Conv2d(1, 6, 5)
+        self.conv2 = nn.Conv2d(6, 16, 5)
         # an affine operation: y = Wx + b
-        self.fc1 = nn.Linear(16 * 6 * 6, 120)  # 6*6 from image dimension 
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)  # 5*5 from image dimension 
         self.fc2 = nn.Linear(120, 84)
         self.fc3 = nn.Linear(84, 10)
 


### PR DESCRIPTION
There is a subtle issue with [`PyTorch 60-Minute Blitz`](https://pytorch.org/tutorials/beginner/blitz/neural_networks_tutorial.html) in designing depicted model by [this figure](https://pytorch.org/tutorials/_images/mnist.png). As the picture shows it has a kernel of size `5*5` not `3*3`. Since this page is a tutorial for beginners, it seems too confusable for them (including me :D) to recognize that there is a typo in the code. 

Both `conv1` and `conv2` in the code must have `kernel_size=5` not `3` in compliance with the shown model at the beginning of the article.

Consequently, the output of the code in the [page](https://pytorch.org/tutorials/beginner/blitz/neural_networks_tutorial.html) has to be fixed with `kernel_size=(5, 5)` like below:
```
Net(
    (conv1): Conv2d(1, 6, kernel_size=(5, 5), stride=(1, 1))
    (conv2): Conv2d(6, 16, kernel_size=(5, 5), stride=(1, 1))
    (fc1): Linear(in_features=400, out_features=120, bias=True)
    (fc2): Linear(in_features=120, out_features=84, bias=True)
    (fc3): Linear(in_features=84, out_features=10, bias=True)
)
```


P.S. 
I had also added an [issue](https://github.com/pytorch/tutorials/issues/877) last year about this mismatched dimension. 
