### PR TITLE
Update link to torch.nn.dataparallel

### DIFF
--- a/beginner_source/former_torchies/parallelism_tutorial.py
+++ b/beginner_source/former_torchies/parallelism_tutorial.py
@@ -41,7 +41,7 @@ class DataParallelModel(nn.Module):
 # The code does not need to be changed in CPU-mode.
 #
 # The documentation for DataParallel can be found
-# `here <https://pytorch.org/docs/nn.html#dataparallel>`_.
+# `here <https://pytorch.org/docs/stable/nn.html#dataparallel-layers-multi-gpu-distributed>`_.
 # 
 # **Attributes of the wrapped module**
 # 


### PR DESCRIPTION
This updates the link to the torch.nn.dataparallel docs. See https://github.com/pytorch/tutorials/pull/1063.