### PR TITLE
Update tutorials for custom inplace & view ops.

### DIFF
--- a/advanced_source/cpp_extension.rst
+++ b/advanced_source/cpp_extension.rst
@@ -306,6 +306,21 @@ information on this):
     return {d_old_h, d_input, d_weights, d_bias, d_old_cell};
   }
 
+.. note::
+
+    If you are implementing a custom inplace op, make sure ``torch::autograd::increment_version(tensor)``
+    is called on every input tensor that was mutated. Otherwise if a tensor has been saved
+    for backward in other autograd computations but then mutated by this op, it might produce silent
+    wrong result for users (instead of throwing an error complaining saved tensor has been mutated).
+
+.. note::
+
+    Implementing a custom view op is highly discouraged. We suggest making a clone instead of returning
+    a tensor on the same storage of input tensor.  A view op produces output tensor which is an alias
+    of input tensor. You can find `supported view ops in PyTorch here<https://pytorch.org/docs/stable/tensor_view.html#tensor-views>`_.
+    If you really want to implement a custom view op, see ``torch::autograd::as_view`` usage in the
+    generated ``ADInplaceOrViewTypeEverything.cpp`` for how to set it up correctly to work with our autograd system.
+
 Binding to Python
 ^^^^^^^^^^^^^^^^^
 

--- a/advanced_source/cpp_extension.rst
+++ b/advanced_source/cpp_extension.rst
@@ -317,7 +317,7 @@ information on this):
 
     Implementing a custom view op is highly discouraged. We suggest making a clone instead of returning
     a tensor on the same storage of input tensor.  A view op produces output tensor which is an alias
-    of input tensor. You can find `supported view ops in PyTorch here<https://pytorch.org/docs/stable/tensor_view.html#tensor-views>`_.
+    of input tensor. You can find `supported view ops in PyTorch here <https://pytorch.org/docs/stable/tensor_view.html#tensor-views>`_.
     If you really want to implement a custom view op, see ``torch::autograd::as_view`` usage in the
     generated ``ADInplaceOrViewTypeEverything.cpp`` for how to set it up correctly to work with our autograd system.
 

--- a/advanced_source/cpp_extension.rst
+++ b/advanced_source/cpp_extension.rst
@@ -308,10 +308,9 @@ information on this):
 
 .. note::
 
-    If you are implementing a custom inplace op, make sure ``torch::autograd::increment_version(tensor)``
-    is called on every input tensor that was mutated. Otherwise if a tensor has been saved
-    for backward in other autograd computations but then mutated by this op, it might produce silent
-    wrong result for users (instead of throwing an error complaining saved tensor has been mutated).
+    If you are implementing a custom inplace op, please follow the guidance in section
+    `Special handling for inplace & view ops in dispatcher tutorial <dispatcher.rst>`_
+    to register a dispatched inplace op.
 
 .. note::
 

--- a/advanced_source/dispatcher.rst
+++ b/advanced_source/dispatcher.rst
@@ -161,7 +161,7 @@ The autograd function is written as normal using ``torch::autograd::Function``,
 except that instead of directly writing the implementation in ``forward()``,
 we:
 
-1. Turn off autograd handling with the ``at::AutoNonVariableTypeMode`` RAII
+1. Turn off autograd handling with the ``at::AutoDispatchBelowADInplaceOrView`` RAII
    guard, and then
 2. Call the dispatch function ``myadd`` to call back into the dispatcher.
 
@@ -189,6 +189,34 @@ functions:
     options in more detail, check out the ``PythonDispatcher`` tool provided in
     `torch/_python_dispatcher.py <https://github.com/pytorch/pytorch/blob/master/torch/_python_dispatcher.py>`_.
 
+Special handling for inplace & view ops
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As mentioned in `Custom C++ and CUDA Extensions <cpp_extension.rst>`_,
+custom inplace and view ops need a bit special handling if you want to add
+autograd support for them.
+
+For example, an inplace version of ``myadd_`` need to use ``at::AutoDispatchBelowAutograd``
+instead of ``at::AutoDispatchBelowADInplaceOrView`` inside ``MyAddFunction::forward``.
+And it requires an additional kernel to be registered to ``ADInplaceOrView`` dispatch key.
+
+.. code-block:: cpp
+
+    at::Tensor & myadd_(at::Tensor & self, const at::Tensor & other) {
+      {
+        at::AutoDispatchBelowADInplaceOrView guard;
+        at::myadd_(self, other);
+      }
+      increment_version(self);
+      return self;
+    }
+	// Registration code
+    TORCH_LIBRARY_IMPL(myops, ADInplaceOrView, m) {
+      m.impl("myadd_", myadd_);
+    }
+
+Custom view op are highly discouraged, see note in `Custom C++ and CUDA Extensions <cpp_extension.rst>`_
+for an code pointer if you really want to implement one.
 
 Going beyond autograd
 ---------------------

--- a/advanced_source/dispatcher/op.cpp
+++ b/advanced_source/dispatcher/op.cpp
@@ -63,7 +63,7 @@ class MyAddFunction : public torch::autograd::Function<MyAddFunction> {
  public:
   static Tensor forward(
       AutogradContext *ctx, torch::Tensor self, torch::Tensor other) {
-    at::AutoNonVariableTypeMode g;
+    at::AutoDispatchBelowADInplaceOrView g;
     return myadd(self, other);
   }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#1494 Update tutorials for custom inplace & view ops.**
* #1493 Replace AutoNonVariableTypeMode with InferenceMode in user facing tutorial.

