### PR TITLE
fix typo on Flask tutorial

### DIFF
--- a/intermediate_source/flask_rest_api_tutorial.py
+++ b/intermediate_source/flask_rest_api_tutorial.py
@@ -46,7 +46,7 @@ with high performance requirements. For that:
 #
 # ::
 #
-#     $ pip install Flask==1.0.3 torchvision-0.3.0
+#     $ pip install Flask==1.0.3 torchvision==0.3.0
 
 
 ######################################################################


### PR DESCRIPTION
### Related Issue

typo on Flask tutorial (#1498)

### What would change

Fix typo: `torchvision-0.3.0` => `torchvision==0.3.0`