### PR TITLE
Replace num_flat_features with torch.flatten

### DIFF
--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -136,7 +136,7 @@ class Net(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = torch.flatten(x, 1) # flatten all dimensions except batch
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -60,18 +60,11 @@ class Net(nn.Module):
         x = F.max_pool2d(F.relu(self.conv1(x)), (2, 2))
         # If the size is a square, you can specify with a single number
         x = F.max_pool2d(F.relu(self.conv2(x)), 2)
-        x = x.view(-1, self.num_flat_features(x))
+        x = torch.flatten(x, 1) # flatten all dimensions except the batch dimension
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)
         return x
-
-    def num_flat_features(self, x):
-        size = x.size()[1:]  # all dimensions except the batch dimension
-        num_features = 1
-        for s in size:
-            num_features *= s
-        return num_features
 
 
 net = Net()
@@ -171,7 +164,7 @@ print(loss)
 # ::
 #
 #     input -> conv2d -> relu -> maxpool2d -> conv2d -> relu -> maxpool2d
-#           -> view -> linear -> relu -> linear -> relu -> linear
+#           -> flatten -> linear -> relu -> linear -> relu -> linear
 #           -> MSELoss
 #           -> loss
 #


### PR DESCRIPTION
This PR improves **Deep Learning with PyTorch: A 60 Minute Blitz** > [Neural Networks Tutorial](https://pytorch.org/tutorials/beginner/blitz/neural_networks_tutorial.html#define-the-network)

The following expression is quite confusing for new users
```
x = x.view(-1, self.num_flat_features(x))
```
This line flattens Conv2d output (except of batch dim) before sending it to Classifier.
The best practices here is to use simple `torch.flatten`.

For example, Alexnet uses `torch.flatten` before Classifier
https://github.com/pytorch/vision/blob/master/torchvision/models/alexnet.py#L48