### PR TITLE
Use flatten() instead of view() for clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# PyCharm files
+.idea
+
 # Mac things
 .DS_Store
 cleanup.sh

--- a/advanced_source/ddp_pipeline.py
+++ b/advanced_source/ddp_pipeline.py
@@ -236,7 +236,7 @@ def run_worker(rank, world_size):
     def get_batch(source, i):
         seq_len = min(bptt, len(source) - 1 - i)
         data = source[i:i+seq_len]
-        target = source[i+1:i+1+seq_len].view(-1)
+        target = source[i+1:i+1+seq_len].flatten()
         # Need batch dimension first for pipeline parallelism.
         return data.t(), target
 

--- a/advanced_source/neural_style_tutorial.py
+++ b/advanced_source/neural_style_tutorial.py
@@ -220,7 +220,7 @@ def gram_matrix(input):
     # b=number of feature maps
     # (c,d)=dimensions of a f. map (N=c*d)
 
-    features = input.view(a * b, c * d)  # resise F_XL into \hat F_XL
+    features = input.view(a * b, c * d)  # resize F_XL into \hat F_XL
 
     G = torch.mm(features, features.t())  # compute the gram product
 

--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -136,7 +136,7 @@ class Net(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = torch.flatten(x, 1) # flatten all dimensions except batch
+        x = x.flatten(start_dim=1) # flatten all dimensions except batch
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -60,7 +60,7 @@ class Net(nn.Module):
         x = F.max_pool2d(F.relu(self.conv1(x)), (2, 2))
         # If the size is a square, you can specify with a single number
         x = F.max_pool2d(F.relu(self.conv2(x)), 2)
-        x = torch.flatten(x, 1) # flatten all dimensions except the batch dimension
+        x = x.flatten(start_dim=1) # flatten all dimensions except the batch dimension
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/beginner_source/dcgan_faces_tutorial.py
+++ b/beginner_source/dcgan_faces_tutorial.py
@@ -593,7 +593,7 @@ for epoch in range(num_epochs):
         b_size = real_cpu.size(0)
         label = torch.full((b_size,), real_label, dtype=torch.float, device=device)
         # Forward pass real batch through D
-        output = netD(real_cpu).view(-1)
+        output = netD(real_cpu).flatten()
         # Calculate loss on all-real batch
         errD_real = criterion(output, label)
         # Calculate gradients for D in backward pass
@@ -607,7 +607,7 @@ for epoch in range(num_epochs):
         fake = netG(noise)
         label.fill_(fake_label)
         # Classify all fake batch with D
-        output = netD(fake.detach()).view(-1)
+        output = netD(fake.detach()).flatten()
         # Calculate D's loss on the all-fake batch
         errD_fake = criterion(output, label)
         # Calculate the gradients for this batch, accumulated (summed) with previous gradients
@@ -624,7 +624,7 @@ for epoch in range(num_epochs):
         netG.zero_grad()
         label.fill_(real_label)  # fake labels are real for generator cost
         # Since we just updated D, perform another forward pass of all-fake batch through D
-        output = netD(fake).view(-1)
+        output = netD(fake).flatten()
         # Calculate G's loss based on this output
         errG = criterion(output, label)
         # Calculate gradients for G

--- a/beginner_source/former_torchies/nnft_tutorial.py
+++ b/beginner_source/former_torchies/nnft_tutorial.py
@@ -85,7 +85,7 @@ class MNISTConvNet(nn.Module):
         # while x.norm(2) < 10:
         #    x = self.conv1(x)
 
-        x = x.view(x.size(0), -1)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         return x

--- a/beginner_source/hyperparameter_tuning_tutorial.py
+++ b/beginner_source/hyperparameter_tuning_tutorial.py
@@ -97,7 +97,7 @@ class Net(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/intermediate_source/dist_pipeline_parallel_tutorial.rst
+++ b/intermediate_source/dist_pipeline_parallel_tutorial.rst
@@ -170,7 +170,7 @@ match.
         def forward(self, x_rref):
             x = x_rref.to_here().to(self.device)
             with self._lock:
-                out = self.fc(torch.flatten(self.seq(x), 1))
+                out = self.fc(self.seq(x).flatten(start_dim=1))
             return out.cpu()
 
 

--- a/intermediate_source/pipeline_tutorial.py
+++ b/intermediate_source/pipeline_tutorial.py
@@ -212,7 +212,7 @@ bptt = 35
 def get_batch(source, i):
     seq_len = min(bptt, len(source) - 1 - i)
     data = source[i:i+seq_len]
-    target = source[i+1:i+1+seq_len].view(-1)
+    target = source[i+1:i+1+seq_len].flatten()
     # Need batch dimension first for pipeline parallelism.
     return data.t(), target
 

--- a/intermediate_source/pruning_tutorial.py
+++ b/intermediate_source/pruning_tutorial.py
@@ -54,7 +54,7 @@ class LeNet(nn.Module):
     def forward(self, x):
         x = F.max_pool2d(F.relu(self.conv1(x)), (2, 2))
         x = F.max_pool2d(F.relu(self.conv2(x)), 2)
-        x = x.view(-1, int(x.nelement() / x.shape[0]))
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)
@@ -361,7 +361,7 @@ class FooBarPruningMethod(prune.BasePruningMethod):
 
     def compute_mask(self, t, default_mask):
         mask = default_mask.clone()
-        mask.view(-1)[::2] = 0 
+        mask.flatten()[::2] = 0
         return mask
 
 ######################################################################

--- a/intermediate_source/quantized_transfer_learning_tutorial.rst
+++ b/intermediate_source/quantized_transfer_learning_tutorial.rst
@@ -364,7 +364,7 @@ The function below creates a model with a custom head.
       # Step 3. Combine, and don't forget the quant stubs.
       new_model = nn.Sequential(
         model_fe_features,
-        nn.Flatten(1),
+        nn.Flatten(start_dim=1),
         new_head,
       )
       return new_model

--- a/intermediate_source/reinforcement_q_learning.py
+++ b/intermediate_source/reinforcement_q_learning.py
@@ -364,7 +364,7 @@ def plot_durations():
     plt.plot(durations_t.numpy())
     # Take 100 episode averages and plot them too
     if len(durations_t) >= 100:
-        means = durations_t.unfold(0, 100, 1).mean(1).view(-1)
+        means = durations_t.unfold(0, 100, 1).mean(1).flatten()
         means = torch.cat((torch.zeros(99), means))
         plt.plot(means.numpy())
 

--- a/intermediate_source/rpc_param_server_tutorial.rst
+++ b/intermediate_source/rpc_param_server_tutorial.rst
@@ -64,7 +64,7 @@ Let's start with the familiar: importing our required modules and defining a sim
            x = F.max_pool2d(x, 2)
 
            x = self.dropout1(x)
-           x = torch.flatten(x, 1)
+           x = x.flatten(start_dim=1)
            # Move tensor to next device if necessary
            next_device = next(self.fc1.parameters()).device
            x = x.to(next_device)

--- a/intermediate_source/tensorboard_tutorial.rst
+++ b/intermediate_source/tensorboard_tutorial.rst
@@ -102,7 +102,7 @@ one channel instead of three and 28x28 instead of 32x32:
         def forward(self, x):
             x = self.pool(F.relu(self.conv1(x)))
             x = self.pool(F.relu(self.conv2(x)))
-            x = x.view(-1, 16 * 4 * 4)
+            x = x.flatten(start_dim=1)
             x = F.relu(self.fc1(x))
             x = F.relu(self.fc2(x))
             x = self.fc3(x)

--- a/prototype_source/torchscript_freezing.py
+++ b/prototype_source/torchscript_freezing.py
@@ -38,7 +38,7 @@ class Net(torch.nn.Module):
         x = self.conv2(x)
         x = torch.nn.functional.max_pool2d(x, 2)
         x = self.dropout1(x)
-        x = torch.flatten(x, 1)
+        x = x.flatten(start_dim=1)
         x = self.fc1(x)
         x = torch.nn.functional.relu(x)
         x = self.dropout2(x)

--- a/recipes_source/recipes/defining_a_neural_network.py
+++ b/recipes_source/recipes/defining_a_neural_network.py
@@ -139,7 +139,7 @@ class Net(nn.Module):
       # Pass data through dropout1
       x = self.dropout1(x)
       # Flatten x with start_dim=1
-      x = torch.flatten(x, 1)
+      x = x.flatten(start_dim=1)
       # Pass data through fc1
       x = self.fc1(x)
       x = F.relu(x)

--- a/recipes_source/recipes/save_load_across_devices.py
+++ b/recipes_source/recipes/save_load_across_devices.py
@@ -70,7 +70,7 @@ class Net(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/recipes_source/recipes/saving_and_loading_a_general_checkpoint.py
+++ b/recipes_source/recipes/saving_and_loading_a_general_checkpoint.py
@@ -80,7 +80,7 @@ class Net(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/recipes_source/recipes/saving_and_loading_models_for_inference.py
+++ b/recipes_source/recipes/saving_and_loading_models_for_inference.py
@@ -82,7 +82,7 @@ class Net(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/recipes_source/recipes/saving_multiple_models_in_one_file.py
+++ b/recipes_source/recipes/saving_multiple_models_in_one_file.py
@@ -75,7 +75,7 @@ class Net(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/recipes_source/recipes/warmstarting_model_using_parameters_from_a_different_model.py
+++ b/recipes_source/recipes/warmstarting_model_using_parameters_from_a_different_model.py
@@ -73,7 +73,7 @@ class NetA(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)
@@ -94,7 +94,7 @@ class NetB(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/recipes_source/recipes/what_is_state_dict.py
+++ b/recipes_source/recipes/what_is_state_dict.py
@@ -76,7 +76,7 @@ class Net(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)

--- a/recipes_source/recipes/zeroing_out_gradients.py
+++ b/recipes_source/recipes/zeroing_out_gradients.py
@@ -120,7 +120,7 @@ class Net(nn.Module):
     def forward(self, x):
         x = self.pool(F.relu(self.conv1(x)))
         x = self.pool(F.relu(self.conv2(x)))
-        x = x.view(-1, 16 * 5 * 5)
+        x = x.flatten(start_dim=1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         x = self.fc3(x)


### PR DESCRIPTION
This PR continues the improvements started in #1505.
It replaces the following:
```
view(-1) -> flatten()
view(-1, <non_batch_length_calculation>)  -> flatten(start_dim=1)
view(size(0), -1) -> flatten(start_dim=1)
torch.flatten(x, ...) -> x.flatten(...)
```

Related issue [#7743](https://github.com/pytorch/pytorch/issues/7743)
@ranman 