### PR TITLE
Fix tensorboard tutorial to use http

### DIFF
--- a/intermediate_source/tensorboard_tutorial.rst
+++ b/intermediate_source/tensorboard_tutorial.rst
@@ -161,7 +161,7 @@ Now running
 
     tensorboard --logdir=runs
 
-from the command line and then navigating to `https://localhost:6006 <https://localhost:6006>`_
+from the command line and then navigating to `http://localhost:6006 <http://localhost:6006>`_
 should show the following.
 
 .. image:: ../../_static/img/tensorboard_first_view.png


### PR DESCRIPTION
This PR fixes [Tensorboard Tutorial](https://github.com/pytorch/tutorials/blob/master/intermediate_source/tensorboard_tutorial.rst).
The tutorial says 
```
navigating to https://localhost:6006 should show the following.
```

Problem is that Tensorboard server does not support `https` protocol. We need to use plain [http://localhost:6006](http://localhost:6006) to open Tensorboard in our browser.

BTW, Other examples use correct http schema:
- [recipes_source/recipes/tensorboard_with_pytorch.py](https://github.com/pytorch/tutorials/blob/master/recipes_source/recipes/tensorboard_with_pytorch.py#L112)
- [intermediate_source/tensorboard_profiler_tutorial.py](https://github.com/pytorch/tutorials/blob/master/intermediate_source/tensorboard_profiler_tutorial.py#L157)