### PR TITLE
Wrap Tutorials/Gallery divs

### DIFF
--- a/custom_directives.py
+++ b/custom_directives.py
@@ -266,7 +266,9 @@ CARD_TEMPLATE = """
 
     <div class="col-md-12 tutorials-card-container" data-tags={tags}>
 
-    <div class="card tutorials-card" link={link}>
+    <div class="card tutorials-card">
+
+    <a href="{link}">
 
     <div class="card-body">
 
@@ -281,6 +283,8 @@ CARD_TEMPLATE = """
     <div class="tutorials-image">{image}</div>
 
     </div>
+
+    </a>
 
     </div>
 


### PR DESCRIPTION
This PR wraps tutorial cards in an `<a>` tag to solve the issue of JS hijacking default on-click behavior. 

Issue: https://github.com/pytorch/pytorch_sphinx_theme/issues/93

Screenshot to show card body wrapped by an `<a>` tag

<img width="1792" alt="Screen Shot 2021-05-05 at 6 13 53 PM" src="https://user-images.githubusercontent.com/31549535/117307811-e655d900-ae4e-11eb-810a-48675f428cf4.png">