### PR TITLE
Fix CartPole Gif for Google Colab

### DIFF
--- a/intermediate_source/reinforcement_q_learning.py
+++ b/intermediate_source/reinforcement_q_learning.py
@@ -15,8 +15,7 @@ right - so that the pole attached to it stays upright. You can find an
 official leaderboard with various algorithms and visualizations at the
 `Gym website <https://gym.openai.com/envs/CartPole-v0>`__.
 
-.. figure:: /_static/img/cartpole.gif
-   :alt: cartpole
+![cartpole](../../_static/img/cartpole.gif)
 
    cartpole
 


### PR DESCRIPTION
Google Colab Notebook now shows Gif of cartpole
Before:
![image](https://user-images.githubusercontent.com/50382570/122472195-5d68ba80-d014-11eb-93eb-dcbf6f1353a3.png)

After:

![image](https://user-images.githubusercontent.com/50382570/122472280-7a9d8900-d014-11eb-8004-f012bca8451d.png)
