### PR TITLE
[basics/quickstart_tutorial.py] call model.trian() before training

### DIFF
--- a/beginner_source/basics/quickstart_tutorial.py
+++ b/beginner_source/basics/quickstart_tutorial.py
@@ -139,6 +139,7 @@ optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
 
 def train(dataloader, model, loss_fn, optimizer):
     size = len(dataloader.dataset)
+    model.train()
     for batch, (X, y) in enumerate(dataloader):
         X, y = X.to(device), y.to(device)
         


### PR DESCRIPTION
Adds a `model.train()` call before training.
Because the `model.eval()` is called inside the `test()` function, the model trains in eval mode after the first eopch.

Even though `model.train()` has no effect here because the architecture does not contain batch norm or dropout layers,
A lot of people (myself included) copy code from this tutorial and calling `model.train()` before training is a good practice.