### PR TITLE
Fix contiguous usage in tutorials

### DIFF
--- a/recipes_source/fuse.rst
+++ b/recipes_source/fuse.rst
@@ -39,7 +39,7 @@ Use the same example model defined in the `PyTorch Mobile Performance Recipes <h
             self.dequant = torch.quantization.DeQuantStub()
 
         def forward(self, x):
-            x.contiguous(memory_format=torch.channels_last)
+            x = x.contiguous(memory_format=torch.channels_last)
             x = self.quant(x)
             x = self.conv(x)
             x = self.bn(x)

--- a/recipes_source/mobile_perf.rst
+++ b/recipes_source/mobile_perf.rst
@@ -54,7 +54,7 @@ Code your model:
           self.dequant = torch.quantization.DeQuantStub()
 
       def forward(self, x):
-          x.contiguous(memory_format=torch.channels_last)
+          x = x.contiguous(memory_format=torch.channels_last)
           x = self.quant(x)
           x = self.conv(x)
           x = self.bn(x)
@@ -145,7 +145,7 @@ At the moment of writing this recipe, PyTorch Android java API does not support 
 .. code-block:: python
 
   def forward(self, x):
-      x.contiguous(memory_format=torch.channels_last)
+      x = x.contiguous(memory_format=torch.channels_last)
       ...
 
 


### PR DESCRIPTION
contiguous never mutates self.  It only returns a contiguous copy if the
tensor is not already contiguous.  Update tutorials to properly capture
this return value and use it for later operations.