### PR TITLE
Tiny fix of torch_script_custom_classes custom_op namespace and fix of the missing end `}`

### DIFF
--- a/advanced_source/torch_script_custom_classes.rst
+++ b/advanced_source/torch_script_custom_classes.rst
@@ -329,7 +329,7 @@ Once this is done, you can use the op like the following example:
           self.f = torch.classes.my_classes.MyStackClass(["foo", "bar"])
 
       def forward(self):
-          return torch.ops.foo.manipulate_instance(self.f)
+          return torch.ops.my_classes.manipulate_instance(self.f)
 
 .. note::
 

--- a/advanced_source/torch_script_custom_classes/custom_class_project/class.cpp
+++ b/advanced_source/torch_script_custom_classes/custom_class_project/class.cpp
@@ -125,8 +125,8 @@ TORCH_LIBRARY(my_classes, m) {
 
 // BEGIN def_free
     m.def(
-      "foo::manipulate_instance(__torch__.torch.classes.my_classes.MyStackClass x) -> __torch__.torch.classes.my_classes.MyStackClass Y",
+      "manipulate_instance(__torch__.torch.classes.my_classes.MyStackClass x) -> __torch__.torch.classes.my_classes.MyStackClass Y",
       manipulate_instance
     );
 // END def_free
-
+}

--- a/advanced_source/torch_script_custom_classes/custom_class_project/custom_test.py
+++ b/advanced_source/torch_script_custom_classes/custom_class_project/custom_test.py
@@ -19,6 +19,11 @@ s = torch.classes.my_classes.MyStackClass(["foo", "bar"])
 s.push("pushed")
 assert s.pop() == "pushed"
 
+# Test custom operator
+s.push("pushed")
+torch.ops.my_classes.manipulate_instance(s)  # acting as s.pop()
+assert s.top() == "bar" 
+
 # Returning and passing instances of custom classes works as you'd expect
 s2 = s.clone()
 s.merge(s2)
@@ -46,3 +51,4 @@ stack, top = do_stacks(torch.classes.my_classes.MyStackClass(["wow"]))
 assert top == "wow"
 for expected in ["wow", "mom", "hi"]:
     assert stack.pop() == expected
+


### PR DESCRIPTION
Error message before this fix
```
terminate called after throwing an instance of 'c10::Error'
  what():  Explicitly provided namespace (foo) in schema strng does not match namespace of
enclosing TORCH_LIBRARY block (my_classes).  Move this definition to the (unique) TORCH_LIBRARY block 
corresponding to this namespace (and consider deleting the namespace from your schema string.)  (Error occurred 
while processing TORCH_LIBRARY block at 
/work/dev/tutorials/advanced_source/torch_script_custom_classes/custom_class_project/class.cpp:60)

```

@ezyang 