### PR TITLE
Fix the param: rank --> trainer_rank

### DIFF
--- a/advanced_source/rpc_ddp_tutorial/main.py
+++ b/advanced_source/rpc_ddp_tutorial/main.py
@@ -141,7 +141,7 @@ def run_worker(rank, world_size):
         for trainer_rank in [0, 1]:
             trainer_name = "trainer{}".format(trainer_rank)
             fut = rpc.rpc_async(
-                trainer_name, _run_trainer, args=(remote_emb_module, rank)
+                trainer_name, _run_trainer, args=(remote_emb_module, trainer_rank)
             )
             futs.append(fut)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1619

Summary:

w/o the fix, _run_trainer is invoked with rank hardcoded as 2. This introduced [CUDA error: invalid device ordinal]
w/ this fix, _run_trainer will be invoked with rank as 0 and 1 -- those are valid GPU devices.

Example code fix: https://github.com/pytorch/examples/pull/924 


Test Plan:

(pytorch) examples/distributed/rpc/ddp_rpc % python main.py -- run training successfully.

Reviewers:

Subscribers:

Tasks:

Tags: