### PR TITLE
fix bug on model definition part of introduction

### DIFF
--- a/beginner_source/basics/buildmodel_tutorial.py
+++ b/beginner_source/basics/buildmodel_tutorial.py
@@ -57,7 +57,6 @@ class NeuralNetwork(nn.Module):
             nn.Linear(512, 512),
             nn.ReLU(),
             nn.Linear(512, 10),
-            nn.ReLU()
         )
 
     def forward(self, x):

--- a/beginner_source/basics/optimization_tutorial.py
+++ b/beginner_source/basics/optimization_tutorial.py
@@ -57,7 +57,6 @@ class NeuralNetwork(nn.Module):
             nn.Linear(512, 512),
             nn.ReLU(),
             nn.Linear(512, 10),
-            nn.ReLU()
         )
 
     def forward(self, x):


### PR DESCRIPTION
This PR is related to issue https://github.com/pytorch/tutorials/issues/1526

A relu layer was inserted just before the cross entropy error was calculated, and it seemed that the loss was not calculated correctly, so I removed the relu layer.
Accordingly, the structure of the NeuralNetwork class in buildmodel_tutorial.py was also changed.

If you have time, I hope you will take a look.