### PR TITLE
fix: Autogradsqs_tutorial typo

### DIFF
--- a/beginner_source/basics/autogradqs_tutorial.py
+++ b/beginner_source/basics/autogradqs_tutorial.py
@@ -130,7 +130,7 @@ print(z_det.requires_grad)
 
 ######################################################################
 # There are reasons you might want to disable gradient tracking:
-#   - To mark some parameters in your neural network at **frozen parameters**. This is
+#   - To mark some parameters in your neural network as **frozen parameters**. This is
 #     a very common scenario for
 #     `finetuning a pretrained network <https://pytorch.org/tutorials/beginner/finetuning_torchvision_models_tutorial.html>`__
 #   - To **speed up computations** when you are only doing forward pass, because computations on tensors that do


### PR DESCRIPTION
Fixed typo, at -> as