### PR TITLE
Fix cert failure during `apt-get update`

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -12,6 +12,8 @@ export LANG=C.UTF-8
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
+# Update root certificates by installing new libgnutls30
+sudo apt-get update || sudo apt-get install libgnutls30
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends unzip p7zip-full sox libsox-dev libsox-fmt-all rsync
 


### PR DESCRIPTION
By installing newer version of `libgnutls30` that contains a root cert
update
See https://github.com/nodesource/distributions/issues/1266#issuecomment-931481002
