### PR TITLE
Remove prototype from zero recipe

### DIFF
--- a/recipes_source/zero_redundancy_optimizer.rst
+++ b/recipes_source/zero_redundancy_optimizer.rst
@@ -1,9 +1,6 @@
 Shard Optimizer States with ZeroRedundancyOptimizer
 ===================================================
 
-.. note:: `ZeroRedundancyOptimizer` is introduced in PyTorch 1.8 as a prototype
-    feature. This API is subject to change.
-
 In this recipe, you will learn:
 
 - The high-level idea of `ZeroRedundancyOptimizer <https://pytorch.org/docs/master/distributed.optim.html>`__.


### PR DESCRIPTION
ZeRo is stable as of 1.10