### PR TITLE
Correct typo in example code for autograd example

### DIFF
--- a/beginner_source/examples_autograd/polynomial_custom_function.py
+++ b/beginner_source/examples_autograd/polynomial_custom_function.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-r"""
+"""
 PyTorch: Defining New autograd Functions
 ----------------------------------------
 


### PR DESCRIPTION
there is a typo in the sample code for [this example](https://pytorch.org/tutorials/beginner/pytorch_with_examples.html#pytorch-defining-new-autograd-functions).  The sample code contains this
```
# -*- coding: utf-8 -*-
rimport torch                           #<= this generates an error when attempting to run sample code
import math

```

This PR removes the extraneous "r".