### PR TITLE
Fix forward AD tutorial directory and add to index

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -387,6 +387,13 @@ Welcome to PyTorch Tutorials
    :link: intermediate/custom_function_conv_bn_tutorial.html
    :tags: Extending-PyTorch,Frontend-APIs
 
+.. customcarditem::
+   :header: Forward-mode Automatic Differentiation
+   :card_description: Learn how to use forward-mode automatic differentiation
+   :image: _static/img/thumbnails/cropped/generic-pytorch-logo.PNG
+   :link: intermediate/forward_ad_usage.html
+   :tags: Frontend-APIs
+
 .. Model Optimization
 
 .. customcarditem::
@@ -746,6 +753,7 @@ Additional Resources
    :caption: Frontend APIs
 
    intermediate/memory_format_tutorial
+   intermediate/forward_ad_usage
    advanced/cpp_frontend
    advanced/torch-script-parallelism
    advanced/cpp_autograd

--- a/intermediate_source/forward_ad_usage.py
+++ b/intermediate_source/forward_ad_usage.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 """
-Forward-mode Automatic Differentiation
-======================================
+Forward-mode Automatic Differentiation (Beta)
+=============================================
 
 This tutorial demonstrates how to use forward-mode AD to compute
 directional derivatives (or equivalently, Jacobian-vector products).
+
+The tutorial below uses some APIs only available in versions >= 1.11
+(or nightly builds).
+
+Also note that forward-mode AD is currently in beta. The API is
+subject to change and operator coverage is still incomplete.
 
 Basic Usage
 --------------------------------------------------------------------


### PR DESCRIPTION
Currently this tutorial is not being rendered at all. This PR places the tutorial in correct directory, adds it to the 'frontend API' index. We also note in the title/description that forward AD is beta (for now), so that users won't be mislead by the current lack of coverage.

After this merges, we can create another PR that updates the name (marked with the correct label).