### PR TITLE
Correct name of registered operator

### DIFF
--- a/advanced_source/torch_script_custom_ops.rst
+++ b/advanced_source/torch_script_custom_ops.rst
@@ -1029,5 +1029,5 @@ visible to TorchScript:
 
   >>> import torch
   >>> torch.ops.load_library("warp_perspective.so")
-  >>> print(torch.ops.custom.warp_perspective)
+  >>> print(torch.ops.my_ops.warp_perspective)
   <built-in method custom::warp_perspective of PyCapsule object at 0x7ff51c5b7bd0>


### PR DESCRIPTION
duplicate of https://github.com/pytorch/tutorials/pull/906. Fixes https://github.com/pytorch/tutorials/issues/909.