### PR TITLE
Fix cheat sheet typo that causes ImportError

### DIFF
--- a/beginner_source/ptcheat.rst
+++ b/beginner_source/ptcheat.rst
@@ -10,7 +10,7 @@ General
 .. code-block:: python
 
     import torch                                        # root package
-    from torch.utils.data import Dataset, Dataloader    # dataset representation and loading
+    from torch.utils.data import Dataset, DataLoader    # dataset representation and loading
 
 Neural Network API
 ------------------


### PR DESCRIPTION
Duplicate of https://github.com/pytorch/tutorials/pull/1189