### PR TITLE
Make sure line breaks are in generated dependency file

### DIFF
--- a/.circleci/scripts/build_for_windows.sh
+++ b/.circleci/scripts/build_for_windows.sh
@@ -32,7 +32,7 @@ conda create -qyn testenv python=3.7
 conda activate testenv
 
 REQUIREMENTS="$(grep -v '^ *#\|^torch\|^torchaudio\|^torchvision|^torchtext' $PROJECT_DIR/requirements.txt  | grep .)"
-echo $REQUIREMENTS > requirements.txt
+echo -e "${REQUIREMENTS}" > requirements.txt
 pip install -r requirements.txt
 pip install pySoundFile
 # Force uninstall torch & related packages, we'll install them using conda later.


### PR DESCRIPTION
`ERROR: Invalid requirement: 'sphinx==1.8.2 sphinx-gallery==0.3.1 docutils==0.16 sphinx-copybutton tqdm numpy matplotlib PyHamcrest bs4 awscli==1.16.35 flask spacy==2.3.2 ray[tune] tensorboard' (from line 1 of requirements.txt)`
The error message tell us that `sphinx==1.8.2 sphinx-gallery==0.3.1 docutils==0.16 ...` are in one line.