### PR TITLE
Disable Windows tutorial builders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,48 +598,47 @@ workflows:
             branches:
               only:
                 - master
-      - pytorch_tutorial_windows_pr_build_worker_0:
-          filters:
-            branches:
-              ignore:
-                - master
-      - pytorch_tutorial_windows_pr_build_worker_1:
-          filters:
-            branches:
-              ignore:
-                - master
-      - pytorch_tutorial_windows_pr_build_worker_2:
-          filters:
-            branches:
-              ignore:
-                - master
-      - pytorch_tutorial_windows_pr_build_worker_3:
-          filters:
-            branches:
-              ignore:
-                - master
-      - pytorch_tutorial_windows_master_build_worker_0:
-          context: org-member
-          filters:
-            branches:
-              only:
-                - master
-      - pytorch_tutorial_windows_master_build_worker_1:
-          context: org-member
-          filters:
-            branches:
-              only:
-                - master
-      - pytorch_tutorial_windows_master_build_worker_2:
-          context: org-member
-          filters:
-            branches:
-              only:
-                - master
-      - pytorch_tutorial_windows_master_build_worker_3:
-          context: org-member
-          filters:
-            branches:
-              only:
-                - master
-
+#      - pytorch_tutorial_windows_pr_build_worker_0:
+#          filters:
+#            branches:
+#              ignore:
+#                - master
+#      - pytorch_tutorial_windows_pr_build_worker_1:
+#          filters:
+#            branches:
+#              ignore:
+#                - master
+#      - pytorch_tutorial_windows_pr_build_worker_2:
+#          filters:
+#            branches:
+#              ignore:
+#                - master
+#      - pytorch_tutorial_windows_pr_build_worker_3:
+#          filters:
+#            branches:
+#              ignore:
+#                - master
+#      - pytorch_tutorial_windows_master_build_worker_0:
+#          context: org-member
+#          filters:
+#            branches:
+#              only:
+#                - master
+#      - pytorch_tutorial_windows_master_build_worker_1:
+#          context: org-member
+#          filters:
+#            branches:
+#              only:
+#                - master
+#      - pytorch_tutorial_windows_master_build_worker_2:
+#          context: org-member
+#          filters:
+#            branches:
+#              only:
+#                - master
+#      - pytorch_tutorial_windows_master_build_worker_3:
+#          context: org-member
+#          filters:
+#            branches:
+#              only:
+#                - master


### PR DESCRIPTION
Not sure what extra value to they bring, but they take 70+% of CI budget
for tutorials. For example for last 30 days
`machine-windows.gpu.nvidia.medium` cost us 10+M credits, vs
`machine-gpu.medium` less than 4M
