### PR TITLE
Update awscli dep

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -11,7 +11,7 @@ torchtext
 torchaudio
 PyHamcrest
 bs4
-awscli==1.16.35
+awscli==1.16.253
 flask
 spacy
 ray[tune]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ torchtext
 torchaudio
 PyHamcrest
 bs4
-awscli==1.16.35
+awscli==1.16.253
 flask
 spacy==2.3.2
 ray[tune]


### PR DESCRIPTION
This PR updates the awscli dependency so that this project can be installed alongside a recent version of rich, which requires a more recent version of colorama than was allowed by the old awcli version.

I choose the oldest version of awscli that is compatible, to be minimally invasive.