### PR TITLE
Fix redirect

### DIFF
--- a/beginner/examples_autograd/two_layer_net_autograd.html
+++ b/beginner/examples_autograd/two_layer_net_autograd.html
@@ -1,1 +1,1 @@
-beginner/examples_autograd/polynomial_autograd.html
+polynomial_autograd.html

--- a/beginner/examples_autograd/two_layer_net_custom_function.html
+++ b/beginner/examples_autograd/two_layer_net_custom_function.html
@@ -1,1 +1,1 @@
-beginner/examples_autograd/polynomial_custom_function.html
+polynomial_custom_function.html

--- a/beginner/examples_nn/two_layer_net_module.html
+++ b/beginner/examples_nn/two_layer_net_module.html
@@ -1,1 +1,1 @@
-beginner/examples_nn/polynomial_module.html
+polynomial_module.html

--- a/beginner/examples_nn/two_layer_net_nn.html
+++ b/beginner/examples_nn/two_layer_net_nn.html
@@ -1,1 +1,1 @@
-beginner/examples_nn/polynomial_nn.html
+polynomial_nn.html

--- a/beginner/examples_nn/two_layer_net_optim.html
+++ b/beginner/examples_nn/two_layer_net_optim.html
@@ -1,1 +1,1 @@
-beginner/examples_nn/polynomial_optim.html
+polynomial_optim.html

--- a/beginner/examples_tensor/two_layer_net_numpy.html
+++ b/beginner/examples_tensor/two_layer_net_numpy.html
@@ -1,1 +1,1 @@
-beginner/examples_tensor/polynomial_numpy.html
+polynomial_numpy.html

--- a/beginner/examples_tensor/two_layer_net_tensor.html
+++ b/beginner/examples_tensor/two_layer_net_tensor.html
@@ -1,1 +1,1 @@
-beginner/examples_tensor/polynomial_tensor.html
+polynomial_tensor.html


### PR DESCRIPTION
https://github.com/pytorch/tutorials/pull/1800 replaced the
obsolete tutorials with symbolic links to the new ones, but
the symbolic links were not correct, and causes deployment error.

https://github.com/pytorch/tutorials/runs/5054296371?check_suite_focus=true

This commit fixes the symbolic links.

https://mthrok.github.io/tutorials/beginner/examples_autograd/polynomial_custom_function.html
https://mthrok.github.io/tutorials/beginner/examples_autograd/two_layer_net_custom_function.html