### PR TITLE
Documenting cuda 11.5 windows issue

### DIFF
--- a/advanced_source/cpp_extension.rst
+++ b/advanced_source/cpp_extension.rst
@@ -206,6 +206,27 @@ into C++. Our primary datatype for all computations will be
 also that we can include ``<iostream>`` or *any other C or C++ header* -- we have
 the full power of C++11 at our disposal.
 
+Note that CUDA-11.5 nvcc will hit internal compiler error while parsing torch/extension.h on Windows.
+To workaround the issue, move python binding logic to pure C++ file.
+Example use:
+
+.. code-block:: cpp
+
+  #include <ATen/ATen.h>
+  at::Tensor SigmoidAlphaBlendForwardCuda(....)
+
+Instead of:
+
+.. code-block:: cpp
+
+  #include <torch/extension.h>
+  torch::Tensor SigmoidAlphaBlendForwardCuda(...)
+
+Currently open issue for nvcc bug `here
+<https://github.com/pytorch/pytorch/issues/69460>`_.
+Complete workaround code example `here
+<https://github.com/facebookresearch/pytorch3d/commit/cb170ac024a949f1f9614ffe6af1c38d972f7d48>`_. 
+
 Forward Pass
 ************
 


### PR DESCRIPTION
Adding documentation about compiling extension with CUDA 11.5 and Windows

Example of failure: https://github.com/pytorch/pytorch/runs/4408796098?check_suite_focus=true

Note: Don't use torch/extension.h In CUDA 11.5 under windows in your C++ code:
Use aten instead of torch interface in all cuda 11.5 code under windows. It has been failing with errors, due to a bug in nvcc.
Example use:
 #include <ATen/ATen.h>
at::Tensor SigmoidAlphaBlendForwardCuda(....)
Instead of:
#include <torch/extension.h> torch::Tensor SigmoidAlphaBlendForwardCuda(...)
Currently open issue for nvcc bug: #69460
Complete Workaround code example: facebookresearch/pytorch3d@cb170ac