### PR TITLE
Enables intermediate_source/model_parallel_tutorial.py for testing

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -58,8 +58,8 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
   # Temp remove for 1.10 release. 
   # python $DIR/remove_runnable_code.py advanced_source/neural_style_tutorial.py advanced_source/neural_style_tutorial.py || true
   
-  # Build issue temp fix
-  python $DIR/remove_runnable_code.py intermediate_source/model_parallel_tutorial.py intermediate_source/model_parallel_tutorial.py || true
+  # Build issue temp fix - Enabling to test build in PR 2-24-22
+  # python $DIR/remove_runnable_code.py intermediate_source/model_parallel_tutorial.py intermediate_source/model_parallel_tutorial.py || true
  
   # TODO: Fix bugs in these tutorials to make them runnable again
   # python $DIR/remove_runnable_code.py beginner_source/audio_classifier_tutorial.py beginner_source/audio_classifier_tutorial.py || true


### PR DESCRIPTION
Build break was caused by an issue with intermediate_source/model_parallel_tutorial.py. I disabled that tutorial to get the build working. This PR enables that tutorial so we can debug the issue.