### PR TITLE
Fixing timing scheme in cpp_extension tutorial

### DIFF
--- a/advanced_source/cpp_extension.rst
+++ b/advanced_source/cpp_extension.rst
@@ -688,7 +688,7 @@ We'll start with the C++ file, which we'll call ``lltm_cuda.cpp``, for example:
 
   // C++ interface
 
-  #define CHECK_CUDA(x) TORCH_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
+  #define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
   #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
   #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
 

--- a/advanced_source/cpp_extension.rst
+++ b/advanced_source/cpp_extension.rst
@@ -518,7 +518,7 @@ duration::
       (new_h.sum() + new_C.sum()).backward()
       backward += time.time() - start
 
-  print('Forward: {:.3f} us | Backward {:.3f} us'.format(forward * 1e6/1e5, backward * 1e6/1e5))
+  print('Forward: {:.3f} s | Backward {:.3f} s'.format(forward, backward))
 
 If we run this code with the original LLTM we wrote in pure Python at the start
 of this post, we get the following numbers (on my machine)::


### PR DESCRIPTION
Print statement incorrectly stated `us` when it was in `100ms` units.
For clarity I changed it to `s` units and removed the multiplication.
This could have intended to be averaged but total time works just as
well.