### PR TITLE
Update runners to recommended ubuntu-2004

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,7 @@ jobs:
 
   pytorch_tutorial_pr_build_worker_9:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.small.multi
 
   pytorch_tutorial_pr_build_worker_10:
     <<: *pytorch_tutorial_build_worker_defaults
@@ -277,6 +278,7 @@ jobs:
 
   pytorch_tutorial_master_build_worker_9:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.small.multi
 
   pytorch_tutorial_master_build_worker_10:
     <<: *pytorch_tutorial_build_worker_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ setup_linux_system_environment: &setup_linux_system_environment
 
 pytorch_tutorial_build_defaults: &pytorch_tutorial_build_defaults
   machine:
-    image: ubuntu-1604-cuda-10.2:202012-01
+    image: ubuntu-2004-cuda-11.4:202110-01
   steps:
   - checkout
   - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ pytorch_tutorial_build_defaults: &pytorch_tutorial_build_defaults
         sudo apt-get -y update
         sudo apt-get -y install expect-dev moreutils
 
-        sudo pip -q install awscli==1.16.35
+        sudo pip3 -q install awscli==1.16.35
 
          if [ -n "${CUDA_VERSION}" ]; then
            nvidia-smi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,7 @@ jobs:
 
   pytorch_tutorial_pr_build_worker_12:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.small.multi
 
   pytorch_tutorial_pr_build_worker_13:
     <<: *pytorch_tutorial_build_worker_defaults
@@ -228,6 +229,7 @@ jobs:
 
   pytorch_tutorial_pr_build_worker_14:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.medium
 
   pytorch_tutorial_pr_build_worker_15:
     <<: *pytorch_tutorial_build_worker_defaults
@@ -288,6 +290,7 @@ jobs:
 
   pytorch_tutorial_master_build_worker_12:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.small.multi
 
   pytorch_tutorial_master_build_worker_13:
     <<: *pytorch_tutorial_build_worker_defaults
@@ -295,6 +298,7 @@ jobs:
 
   pytorch_tutorial_master_build_worker_14:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.medium
 
   pytorch_tutorial_master_build_worker_15:
     <<: *pytorch_tutorial_build_worker_defaults


### PR DESCRIPTION
As 16.04 is getting deprecated in May 31st, see this [runlog]( https://app.circleci.com/pipelines/github/pytorch/tutorials/5681/workflows/93c16d30-3559-4414-9eee-879038f881cf/jobs/111635)

Update pinned dependencies correspondingly