### PR TITLE
fix the author name link issue

### DIFF
--- a/intermediate_source/FSDP_tutorial.rst
+++ b/intermediate_source/FSDP_tutorial.rst
@@ -1,7 +1,7 @@
 Getting Started with Fully Sharded Data Parallel(FSDP)
 =====================================================
 
-**Author**: `Hamid Shojanazeri <https://github.com/HamidShojanazeri>`__, `Yanli Zhao <https://github.com/zhaojuanmao>`__,`Shen Li <https://mrshenli.github.io/>`__
+**Author**: `Hamid Shojanazeri <https://github.com/HamidShojanazeri>`__, `Yanli Zhao <https://github.com/zhaojuanmao>`__, `Shen Li <https://mrshenli.github.io/>`__
 
 
 Training AI models at a large scale is a challenging task that requires a lot of compute power and resources. 


### PR DESCRIPTION
PR fixes the issue with Author name link in [FSDP tutorial](https://pytorch.org/tutorials/intermediate/FSDP_tutorial.html)