### PR TITLE
Update pillow version in build.sh

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -42,7 +42,7 @@ python -m spacy download de
 # PyTorch Theme
 rm -rf src
 pip install -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
-pip install sphinx-gallery==0.3.1 tqdm matplotlib ipython pillow==8.1.0
+pip install sphinx-gallery==0.3.1 tqdm matplotlib ipython pillow==9.0.1
 
 awsv2 -i
 awsv2 configure set default.s3.multipart_threshold 5120MB


### PR DESCRIPTION
Getting a dependency error in the master build

Mar 24 18:30:39 Installing collected packages: pillow
Mar 24 18:30:39   Attempting uninstall: pillow
Mar 24 18:30:39     Found existing installation: Pillow 9.0.1
Mar 24 18:30:39     Uninstalling Pillow-9.0.1:
Mar 24 18:30:39       Successfully uninstalled Pillow-9.0.1
Mar 24 18:30:39 ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
Mar 24 18:30:39 imageio 2.16.1 requires pillow>=8.3.2, but you have pillow 8.1.0 which is incompatible.