### PR TITLE
Pin jinja2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ flask
 spacy==2.3.2
 ray[tune]
 tensorboard
+jinja2==3.0.3
 
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
Jinja 3.1.0 was released yesterday (https://github.com/pallets/jinja/releases). This is causing errors with sphinx 1.8 builds.