### PR TITLE
Update neural_networks_tutorial.py

### DIFF
--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -144,7 +144,7 @@ out.backward(torch.randn(1, 10))
 # `loss functions <https://pytorch.org/docs/nn.html#loss-functions>`_ under the
 # nn package .
 # A simple loss is: ``nn.MSELoss`` which computes the mean-squared error
-# between the input and the target.
+# between the output and the target.
 #
 # For example:
 


### PR DESCRIPTION
- Fix a typo in the tutorial text `input` -> `output`