### PR TITLE
Fix loss printing in the hyperparameter tuning with Ray Tune tutorial

### DIFF
--- a/beginner_source/hyperparameter_tuning_tutorial.py
+++ b/beginner_source/hyperparameter_tuning_tutorial.py
@@ -233,7 +233,6 @@ def train_cifar(config, checkpoint_dir=None, data_dir=None):
 
     for epoch in range(10):  # loop over the dataset multiple times
         running_loss = 0.0
-        epoch_steps = 0
         for i, data in enumerate(trainloader, 0):
             # get the inputs; data is a list of [inputs, labels]
             inputs, labels = data
@@ -250,10 +249,9 @@ def train_cifar(config, checkpoint_dir=None, data_dir=None):
 
             # print statistics
             running_loss += loss.item()
-            epoch_steps += 1
             if i % 2000 == 1999:  # print every 2000 mini-batches
                 print("[%d, %5d] loss: %.3f" % (epoch + 1, i + 1,
-                                                running_loss / epoch_steps))
+                                                running_loss / 2000))
                 running_loss = 0.0
 
         # Validation loss


### PR DESCRIPTION
Hello !
The loss is incorrectly printed during training in the [hyperparameter tuning with Ray Tune tutorial](https://pytorch.org/tutorials/beginner/hyperparameter_tuning_tutorial.html). The `running_loss` is divided by the `epoch_steps` value which is incremented at each mini-batch, while the `running_loss` is reseted to 0 every 2000 mini-batches. This causes the printed loss to decrease as training goes along.

My fix is minimal and is inspired by the [Training a classifier tutorial](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html). Now the mean loss of the 2000 last mini batches is printed.

Let me know if I can do anything to improve this fix.
Have a nice day !