### PR TITLE
[CircleCI] Make PR build manager dependent on few worker jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,6 +448,10 @@ workflows:
               ignore:
                 - master
       - pytorch_tutorial_pr_build_manager:
+          requires:
+            - pytorch_tutorial_pr_build_worker_17
+            - pytorch_tutorial_pr_build_worker_18
+            - pytorch_tutorial_pr_build_worker_19
           filters:
             branches:
               ignore:


### PR DESCRIPTION
Just a proof of concept change, shows how it could be done to avoid wasting `build-manager` cycles waiting for the job to finish.