### PR TITLE
[ci] convert sharding from bash to python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,7 @@ jobs:
     <<: *pytorch_tutorial_build_manager_defaults
   pytorch_tutorial_pr_build_worker_0:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_pr_build_worker_1:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_pr_build_worker_10:
@@ -230,6 +231,7 @@ jobs:
     <<: *pytorch_tutorial_build_manager_defaults
   pytorch_tutorial_master_build_worker_0:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_master_build_worker_1:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_master_build_worker_10:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,16 +195,12 @@ jobs:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_pr_build_worker_12:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_pr_build_worker_13:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_pr_build_worker_14:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.medium
   pytorch_tutorial_pr_build_worker_15:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.medium
   pytorch_tutorial_pr_build_worker_16:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_pr_build_worker_17:
@@ -217,7 +213,6 @@ jobs:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_pr_build_worker_3:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_pr_build_worker_4:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_pr_build_worker_5:
@@ -230,7 +225,6 @@ jobs:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_pr_build_worker_9:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.small.multi
 
   pytorch_tutorial_master_build_manager:
     <<: *pytorch_tutorial_build_manager_defaults
@@ -244,16 +238,12 @@ jobs:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_master_build_worker_12:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_master_build_worker_13:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_master_build_worker_14:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.medium
   pytorch_tutorial_master_build_worker_15:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.medium
   pytorch_tutorial_master_build_worker_16:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_master_build_worker_17:
@@ -266,7 +256,6 @@ jobs:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_master_build_worker_3:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_master_build_worker_4:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_master_build_worker_5:
@@ -279,7 +268,6 @@ jobs:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_master_build_worker_9:
     <<: *pytorch_tutorial_build_worker_defaults
-    resource_class: gpu.nvidia.small.multi
 
   pytorch_tutorial_windows_master_build_worker_0:
     <<: *pytorch_windows_build_worker

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -25,8 +25,10 @@ def indent(indentation, data_list):
 
 def jobs(pr_or_master, num_workers=20, indentation=2):
     jobs = {}
+
+    # all tutorials that need gpu.nvidia.small.multi machines will be routed
+    # by get_files_to_run.py to 0th worker
     needs_gpu_nvidia_small_multi = [0]
-    needs_gpu_nvidia_medium = []
     jobs[f"pytorch_tutorial_{pr_or_master}_build_manager"] = {
         "<<": "*pytorch_tutorial_build_manager_defaults"
     }
@@ -34,8 +36,6 @@ def jobs(pr_or_master, num_workers=20, indentation=2):
         job_info = {"<<": "*pytorch_tutorial_build_worker_defaults"}
         if i in needs_gpu_nvidia_small_multi:
             job_info["resource_class"] = "gpu.nvidia.small.multi"
-        if i in needs_gpu_nvidia_medium:
-            job_info["resource_class"] = "gpu.nvidia.medium"
         jobs[f"pytorch_tutorial_{pr_or_master}_build_worker_{i}"] = job_info
 
     return indent(indentation, jobs).replace("'", "")
@@ -43,10 +43,14 @@ def jobs(pr_or_master, num_workers=20, indentation=2):
 
 def workflows_jobs(pr_or_master, indentation=6, num_workers=20):
     jobs = []
-    job_info = deepcopy(WORKFLOWS_JOBS_PR if pr_or_master == "pr" else WORKFLOWS_JOBS_MASTER)
+    job_info = deepcopy(
+        WORKFLOWS_JOBS_PR if pr_or_master == "pr" else WORKFLOWS_JOBS_MASTER
+    )
 
     for i in range(num_workers):
-        jobs.append({f"pytorch_tutorial_{pr_or_master}_build_worker_{i}": deepcopy(job_info)})
+        jobs.append(
+            {f"pytorch_tutorial_{pr_or_master}_build_worker_{i}": deepcopy(job_info)}
+        )
 
     job_info["requires"] = [
         f"pytorch_tutorial_{pr_or_master}_build_worker_{i}" for i in range(num_workers)
@@ -71,11 +75,15 @@ def windows_workflows_jobs(indentation=6, num_workers=4):
     jobs = []
     job_info = WORKFLOWS_JOBS_PR
     for i in range(num_workers):
-        jobs.append({f"pytorch_tutorial_windows_pr_build_worker_{i}": deepcopy(job_info)})
+        jobs.append(
+            {f"pytorch_tutorial_windows_pr_build_worker_{i}": deepcopy(job_info)}
+        )
 
     job_info = WORKFLOWS_JOBS_MASTER
     for i in range(num_workers):
-        jobs.append({f"pytorch_tutorial_windows_master_build_worker_{i}": deepcopy(job_info)})
+        jobs.append(
+            {f"pytorch_tutorial_windows_master_build_worker_{i}": deepcopy(job_info)}
+        )
 
     return ("\n#").join(indent(indentation, jobs).splitlines())
 

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -25,7 +25,7 @@ def indent(indentation, data_list):
 
 def jobs(pr_or_master, num_workers=20, indentation=2):
     jobs = {}
-    needs_gpu_nvidia_small_multi = []
+    needs_gpu_nvidia_small_multi = [0]
     needs_gpu_nvidia_medium = []
     jobs[f"pytorch_tutorial_{pr_or_master}_build_manager"] = {
         "<<": "*pytorch_tutorial_build_manager_defaults"

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -25,8 +25,8 @@ def indent(indentation, data_list):
 
 def jobs(pr_or_master, num_workers=20, indentation=2):
     jobs = {}
-    needs_gpu_nvidia_small_multi = [3, 9, 12, 13]
-    needs_gpu_nvidia_medium = [14, 15]
+    needs_gpu_nvidia_small_multi = []
+    needs_gpu_nvidia_medium = []
     jobs[f"pytorch_tutorial_{pr_or_master}_build_manager"] = {
         "<<": "*pytorch_tutorial_build_manager_defaults"
     }

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -70,7 +70,7 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
   # IMPORTANT NOTE: We assume that each tutorial has a UNIQUE filename.
   export WORKER_ID=$(echo "${JOB_BASE_NAME}" | tr -dc '0-9')
   FILES_TO_RUN=$(python .jenkins/get_files_to_run.py)
-  echo "FILES_TO_RUN: " ${FILES_TO_RUN]}
+  echo "FILES_TO_RUN: " ${FILES_TO_RUN}
 
   # Step 3: Run `make docs` to generate HTML files and static files for these tutorials
   make docs

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -24,7 +24,7 @@ pip install -r $DIR/../requirements.txt
 # export PATH=/opt/conda/bin:$PATH
 # pip install sphinx==1.8.2 pandas
 
-#Install PyTorch Nightly for test. 
+#Install PyTorch Nightly for test.
 # Nightly - pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
 # RC Link
 # pip uninstall -y torch torchvision torchaudio torchtext
@@ -56,7 +56,7 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
   # Temp remove for mnist download issue. (Re-enabled for 1.8.1)
   # python $DIR/remove_runnable_code.py beginner_source/fgsm_tutorial.py beginner_source/fgsm_tutorial.py || true
   # python $DIR/remove_runnable_code.py intermediate_source/spatial_transformer_tutorial.py intermediate_source/spatial_transformer_tutorial.py || true
-  # Temp remove for 1.10 release. 
+  # Temp remove for 1.10 release.
   # python $DIR/remove_runnable_code.py advanced_source/neural_style_tutorial.py advanced_source/neural_style_tutorial.py || true
 
   # TODO: Fix bugs in these tutorials to make them runnable again
@@ -69,11 +69,8 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
   # Step 2: Keep certain tutorials based on file count, and remove runnable code in all other tutorials
   # IMPORTANT NOTE: We assume that each tutorial has a UNIQUE filename.
   export WORKER_ID=$(echo "${JOB_BASE_NAME}" | tr -dc '0-9')
-  FILES_TO_RUN=()
-  for filename in $(python .jenkins/get_files_to_run.py); do
-      FILES_TO_RUN+=($filename)
-  done
-  echo "FILES_TO_RUN: " ${FILES_TO_RUN[@]}
+  FILES_TO_RUN=$(python .jenkins/get_files_to_run.py)
+  echo "FILES_TO_RUN: " ${FILES_TO_RUN]}
 
   # Step 3: Run `make docs` to generate HTML files and static files for these tutorials
   make docs
@@ -82,37 +79,37 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
   # then we remove them
   for filename in $(find docs/beginner docs/intermediate docs/advanced docs/recipes docs/prototype -name '*.html'); do
     file_basename=$(basename $filename .html)
-    if [[ ! " ${FILES_TO_RUN[@]} " =~ " ${file_basename} " ]]; then
+    if [[ ! " ${FILES_TO_RUN} " =~ " ${file_basename} " ]]; then
       rm $filename
     fi
   done
   for filename in $(find docs/beginner docs/intermediate docs/advanced docs/recipes docs/prototype -name '*.rst'); do
     file_basename=$(basename $filename .rst)
-    if [[ ! " ${FILES_TO_RUN[@]} " =~ " ${file_basename} " ]]; then
+    if [[ ! " ${FILES_TO_RUN} " =~ " ${file_basename} " ]]; then
       rm $filename
     fi
   done
   for filename in $(find docs/_downloads -name '*.py'); do
     file_basename=$(basename $filename .py)
-    if [[ ! " ${FILES_TO_RUN[@]} " =~ " ${file_basename} " ]]; then
+    if [[ ! " ${FILES_TO_RUN} " =~ " ${file_basename} " ]]; then
       rm $filename
     fi
   done
   for filename in $(find docs/_downloads -name '*.ipynb'); do
     file_basename=$(basename $filename .ipynb)
-    if [[ ! " ${FILES_TO_RUN[@]} " =~ " ${file_basename} " ]]; then
+    if [[ ! " ${FILES_TO_RUN} " =~ " ${file_basename} " ]]; then
       rm $filename
     fi
   done
   for filename in $(find docs/_sources/beginner docs/_sources/intermediate docs/_sources/advanced docs/_sources/recipes -name '*.rst.txt'); do
     file_basename=$(basename $filename .rst.txt)
-    if [[ ! " ${FILES_TO_RUN[@]} " =~ " ${file_basename} " ]]; then
+    if [[ ! " ${FILES_TO_RUN} " =~ " ${file_basename} " ]]; then
       rm $filename
     fi
   done
   for filename in $(find docs/.doctrees/beginner docs/.doctrees/intermediate docs/.doctrees/advanced docs/.doctrees/recipes docs/.doctrees/prototype -name '*.doctree'); do
     file_basename=$(basename $filename .doctree)
-    if [[ ! " ${FILES_TO_RUN[@]} " =~ " ${file_basename} " ]]; then
+    if [[ ! " ${FILES_TO_RUN} " =~ " ${file_basename} " ]]; then
       rm $filename
     fi
   done

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -69,57 +69,9 @@ if [[ "${JOB_BASE_NAME}" == *worker_* ]]; then
   # Step 2: Keep certain tutorials based on file count, and remove runnable code in all other tutorials
   # IMPORTANT NOTE: We assume that each tutorial has a UNIQUE filename.
   export WORKER_ID=$(echo "${JOB_BASE_NAME}" | tr -dc '0-9')
-  count=0
   FILES_TO_RUN=()
-  for filename in $(find beginner_source/ -name '*.py' -not -path '*/data/*'); do
-    if [ $(($count % $NUM_WORKERS)) != $WORKER_ID ]; then
-      echo "Removing runnable code from "$filename
-      python $DIR/remove_runnable_code.py $filename $filename
-    else
-      echo "Keeping "$filename
-      FILES_TO_RUN+=($(basename $filename .py))
-    fi
-    count=$((count+1))
-  done
-  for filename in $(find intermediate_source/ -name '*.py' -not -path '*/data/*'); do
-    if [ $(($count % $NUM_WORKERS)) != $WORKER_ID ]; then
-      echo "Removing runnable code from "$filename
-      python $DIR/remove_runnable_code.py $filename $filename
-    else
-      echo "Keeping "$filename
-      FILES_TO_RUN+=($(basename $filename .py))
-    fi
-    count=$((count+1))
-  done
-  for filename in $(find advanced_source/ -name '*.py' -not -path '*/data/*'); do
-    if [ $(($count % $NUM_WORKERS)) != $WORKER_ID ]; then
-      echo "Removing runnable code from "$filename
-      python $DIR/remove_runnable_code.py $filename $filename
-    else
-      echo "Keeping "$filename
-      FILES_TO_RUN+=($(basename $filename .py))
-    fi
-    count=$((count+1))
-   done
-   for filename in $(find recipes_source/ -name '*.py' -not -path '*/data/*'); do
-    if [ $(($count % $NUM_WORKERS)) != $WORKER_ID ]; then
-      echo "Removing runnable code from "$filename
-      python $DIR/remove_runnable_code.py $filename $filename
-    else
-      echo "Keeping "$filename
-      FILES_TO_RUN+=($(basename $filename .py))
-    fi
-    count=$((count+1))
-   done
-   for filename in $(find prototype_source/ -name '*.py' -not -path '*/data/*'); do
-    if [ $(($count % $NUM_WORKERS)) != $WORKER_ID ]; then
-      echo "Removing runnable code from "$filename
-      python $DIR/remove_runnable_code.py $filename $filename
-    else
-      echo "Keeping "$filename
-      FILES_TO_RUN+=($(basename $filename .py))
-    fi
-    count=$((count+1))
+  for filename in $(python .jenkins/get_files_to_run.py); do
+      FILES_TO_RUN+=($filename)
   done
   echo "FILES_TO_RUN: " ${FILES_TO_RUN[@]}
 

--- a/.jenkins/get_files_to_run.py
+++ b/.jenkins/get_files_to_run.py
@@ -19,17 +19,35 @@ def get_all_files(encoding="utf-8") -> List[str]:
     return run(cmd, capture_output=True).stdout.decode(encoding).splitlines()
 
 
+def calculate_shards(all_files, num_shards=20):
+    metadata = json.load(open(".jenkins/metadata.json"))
+    sorted_files = sorted(all_files, key=lambda x: metadata.get(x, {}).get("duration", 1), reverse=True)
+
+    sharded_files = [(0.0, []) for _ in range(num_shards)]
+    for filename in sorted_files:
+        min_shard_index = sorted(range(num_shards), key=lambda i: sharded_files[i][0])[0]
+        curr_shard_time, curr_shard_jobs = sharded_files[min_shard_index]
+        curr_shard_jobs.append(filename)
+        sharded_files[min_shard_index] = (
+            curr_shard_time + metadata.get(filename, {}).get("duration", 1),
+            curr_shard_jobs,
+        )
+    return list(map(lambda x: x[1], sharded_files))
+
+
+def remove_other_files(all_files, files_to_run):
+    for file in all_files:
+        if file not in files_to_run:
+            remove_runnable_code(file, file)
+
+
 def main():
     num_shards = int(os.environ.get("NUM_WORKERS", 20))
     shard_num = int(os.environ.get("WORKER_ID", 0))
 
     all_files = get_all_files()
-    files_to_run = []
-    for i, name in enumerate(all_files):
-        if i % num_shards == shard_num:
-            files_to_run.append(name)
-        else:
-            remove_runnable_code(name, name)
+    files_to_run = calculate_shards(all_files, num_shards=num_shards)[shard_num]
+    remove_other_files(all_files, files_to_run)
     stripped_file_names = list(map(lambda x: Path(x).stem, files_to_run))
     print(" ".join(stripped_file_names))
 

--- a/.jenkins/get_files_to_run.py
+++ b/.jenkins/get_files_to_run.py
@@ -1,0 +1,38 @@
+from typing import List
+from subprocess import run
+import json
+import os
+from pathlib import Path
+from remove_runnable_code import remove_runnable_code
+
+
+def get_all_files(encoding="utf-8") -> List[str]:
+    sources = [
+        "beginner_source",
+        "intermediate_source",
+        "advanced_source",
+        "recipes_source",
+        "prototype_source",
+    ]
+    cmd = ["find"] + sources + ["-name", "*.py", "-not", "-path", "*/data/*"]
+
+    return run(cmd, capture_output=True).stdout.decode(encoding).splitlines()
+
+
+def main():
+    num_shards = int(os.environ.get("NUM_WORKERS", 20))
+    shard_num = int(os.environ.get("WORKER_ID", 0))
+
+    all_files = get_all_files()
+    files_to_run = []
+    for i, name in enumerate(all_files):
+        if i % num_shards == shard_num:
+            files_to_run.append(name)
+        else:
+            remove_runnable_code(name, name)
+    stripped_file_names = list(map(lambda x: Path(x).stem, files_to_run))
+    print(" ".join(stripped_file_names))
+
+
+if __name__ == "__main__":
+    main()

--- a/.jenkins/get_files_to_run.py
+++ b/.jenkins/get_files_to_run.py
@@ -21,9 +21,9 @@ def get_all_files(encoding="utf-8") -> List[str]:
 
 def calculate_shards(all_files, num_shards=20):
     metadata = json.load(open(".jenkins/metadata.json"))
-    sorted_files = sorted(all_files, key=lambda x: metadata.get(x, {}).get("duration", 1), reverse=True)
-
     sharded_files = [(0.0, []) for _ in range(num_shards)]
+
+    sorted_files = sorted(all_files, key=lambda x: metadata.get(x, {}).get("duration", 1), reverse=True)
     for filename in sorted_files:
         min_shard_index = sorted(range(num_shards), key=lambda i: sharded_files[i][0])[0]
         curr_shard_time, curr_shard_jobs = sharded_files[min_shard_index]

--- a/.jenkins/get_files_to_run.py
+++ b/.jenkins/get_files_to_run.py
@@ -24,7 +24,9 @@ def calculate_shards(all_files, num_shards=20):
     sharded_files = [(0.0, []) for _ in range(num_shards)]
 
     def get_duration(file):
-        return metadata.get(file, {}).get("duration", 1)
+        # tutorials not listed in the metadata.json file usually take
+        # <3min to run, so we'll default to 1min if it's not listed
+        return metadata.get(file, {}).get("duration", 60)
 
     def add_to_shard(i, filename):
         shard_time, shard_jobs = sharded_files[i]
@@ -38,6 +40,8 @@ def calculate_shards(all_files, num_shards=20):
         filter(lambda x: "needs" in metadata.get(x, {}), all_files)
     )
     for filename in needs_gpu_nvidia_small_multi:
+        # currently, the only job that uses gpu.nvidia.small.multi is the 0th worker,
+        # so we'll add all the jobs that need this machine to the 0th worker
         add_to_shard(0, filename)
 
     all_other_files = list(

--- a/.jenkins/get_files_to_run.py
+++ b/.jenkins/get_files_to_run.py
@@ -28,6 +28,9 @@ def calculate_shards(all_files, num_shards=20):
         # <3min to run, so we'll default to 1min if it's not listed
         return metadata.get(file, {}).get("duration", 60)
 
+    def get_needs_machine(file):
+        return metadata.get(file, {}).get("needs", None)
+
     def add_to_shard(i, filename):
         shard_time, shard_jobs = sharded_files[i]
         shard_jobs.append(filename)
@@ -37,7 +40,7 @@ def calculate_shards(all_files, num_shards=20):
         )
 
     needs_gpu_nvidia_small_multi = list(
-        filter(lambda x: "needs" in metadata.get(x, {}), all_files)
+        filter(lambda x: get_needs_machine(x) == "gpu.nvidia.small.multi", all_files,)
     )
     for filename in needs_gpu_nvidia_small_multi:
         # currently, the only job that uses gpu.nvidia.small.multi is the 0th worker,
@@ -72,7 +75,7 @@ def main():
     files_to_run = calculate_shards(all_files, num_shards=num_shards)[shard_num]
     remove_other_files(all_files, files_to_run)
     stripped_file_names = list(map(lambda x: Path(x).stem, files_to_run))
-    print(" ".join(stripped_file_names))
+    print("\n".join(stripped_file_names))
 
 
 if __name__ == "__main__":

--- a/.jenkins/metadata.json
+++ b/.jenkins/metadata.json
@@ -1,0 +1,20 @@
+{
+  "beginner_source/dcgan_faces_tutorial.py": {
+    "duration": 2000
+  },
+  "intermediate_source/seq2seq_translation_tutorial.py": {
+    "duration": 1200
+  },
+  "beginner_source/hyperparameter_tuning_tutorial.py": {
+    "duration": 910
+  },
+  "advanced_source/dynamic_quantization_tutorial.py": {
+    "duration": 380
+  },
+  "beginner_source/chatbot_tutorial.py": {
+    "duration": 330
+  },
+  "intermediate_source/pipeline_tutorial.py": {
+    "duration": 320
+  }
+}

--- a/.jenkins/metadata.json
+++ b/.jenkins/metadata.json
@@ -16,5 +16,8 @@
   },
   "intermediate_source/pipeline_tutorial.py": {
     "duration": 320
+  },
+  "intermediate_source/model_parallel_tutorial.py": {
+    "needs": "gpu.nvidia.small.multi"
   }
 }

--- a/.jenkins/metadata.json
+++ b/.jenkins/metadata.json
@@ -15,7 +15,8 @@
     "duration": 330
   },
   "intermediate_source/pipeline_tutorial.py": {
-    "duration": 320
+    "duration": 320,
+    "needs": "gpu.nvidia.small.multi"
   },
   "intermediate_source/model_parallel_tutorial.py": {
     "needs": "gpu.nvidia.small.multi"

--- a/.jenkins/remove_runnable_code.py
+++ b/.jenkins/remove_runnable_code.py
@@ -4,52 +4,55 @@ STATE_IN_MULTILINE_COMMENT_BLOCK_DOUBLE_QUOTE = "STATE_IN_MULTILINE_COMMENT_BLOC
 STATE_IN_MULTILINE_COMMENT_BLOCK_SINGLE_QUOTE = "STATE_IN_MULTILINE_COMMENT_BLOCK_SINGLE_QUOTE"
 STATE_NORMAL = "STATE_NORMAL"
 
-python_file_path = sys.argv[1]
-output_file_path = sys.argv[2]
 
-with open(python_file_path, 'r', encoding='utf-8') as file:
-    lines = file.readlines()
-    ret_lines = []
-    state = STATE_NORMAL
-    for line in lines:
-        if state == STATE_NORMAL:
-            if line.startswith('#'):
-                ret_lines.append(line)
-                state = STATE_NORMAL
-            elif ((line.startswith('"""') or line.startswith('r"""')) and
-                    line.endswith('"""')):
-                ret_lines.append(line)
-                state = STATE_NORMAL
-            elif line.startswith('"""') or line.startswith('r"""'):
-                ret_lines.append(line)
-                state = STATE_IN_MULTILINE_COMMENT_BLOCK_DOUBLE_QUOTE
-            elif ((line.startswith("'''") or line.startswith("r'''")) and
-                    line.endswith("'''")):
-                ret_lines.append(line)
-                state = STATE_NORMAL
-            elif line.startswith("'''") or line.startswith("r'''"):
-                ret_lines.append(line)
-                state = STATE_IN_MULTILINE_COMMENT_BLOCK_SINGLE_QUOTE
-            else:
-                ret_lines.append("\n")
-                state = STATE_NORMAL
-        elif state == STATE_IN_MULTILINE_COMMENT_BLOCK_DOUBLE_QUOTE:
-            if line.startswith('"""'):
-                ret_lines.append(line)
-                state = STATE_NORMAL
-            else:
-                ret_lines.append(line)
-                state = STATE_IN_MULTILINE_COMMENT_BLOCK_DOUBLE_QUOTE
-        elif state == STATE_IN_MULTILINE_COMMENT_BLOCK_SINGLE_QUOTE:
-            if line.startswith("'''"):
-                ret_lines.append(line)
-                state = STATE_NORMAL
-            else:
-                ret_lines.append(line)
-                state = STATE_IN_MULTILINE_COMMENT_BLOCK_SINGLE_QUOTE
+def remove_runnable_code(python_file_path, output_file_path):
+    with open(python_file_path, 'r', encoding='utf-8') as file:
+        lines = file.readlines()
+        ret_lines = []
+        state = STATE_NORMAL
+        for line in lines:
+            if state == STATE_NORMAL:
+                if line.startswith('#'):
+                    ret_lines.append(line)
+                    state = STATE_NORMAL
+                elif ((line.startswith('"""') or line.startswith('r"""')) and
+                        line.endswith('"""')):
+                    ret_lines.append(line)
+                    state = STATE_NORMAL
+                elif line.startswith('"""') or line.startswith('r"""'):
+                    ret_lines.append(line)
+                    state = STATE_IN_MULTILINE_COMMENT_BLOCK_DOUBLE_QUOTE
+                elif ((line.startswith("'''") or line.startswith("r'''")) and
+                        line.endswith("'''")):
+                    ret_lines.append(line)
+                    state = STATE_NORMAL
+                elif line.startswith("'''") or line.startswith("r'''"):
+                    ret_lines.append(line)
+                    state = STATE_IN_MULTILINE_COMMENT_BLOCK_SINGLE_QUOTE
+                else:
+                    ret_lines.append("\n")
+                    state = STATE_NORMAL
+            elif state == STATE_IN_MULTILINE_COMMENT_BLOCK_DOUBLE_QUOTE:
+                if line.startswith('"""'):
+                    ret_lines.append(line)
+                    state = STATE_NORMAL
+                else:
+                    ret_lines.append(line)
+                    state = STATE_IN_MULTILINE_COMMENT_BLOCK_DOUBLE_QUOTE
+            elif state == STATE_IN_MULTILINE_COMMENT_BLOCK_SINGLE_QUOTE:
+                if line.startswith("'''"):
+                    ret_lines.append(line)
+                    state = STATE_NORMAL
+                else:
+                    ret_lines.append(line)
+                    state = STATE_IN_MULTILINE_COMMENT_BLOCK_SINGLE_QUOTE
 
-ret_lines.append("\n# %%%%%%RUNNABLE_CODE_REMOVED%%%%%%")
+    ret_lines.append("\n# %%%%%%RUNNABLE_CODE_REMOVED%%%%%%")
 
-with open(output_file_path, 'w', encoding='utf-8') as file:
-    for line in ret_lines:
-        file.write(line)
+    with open(output_file_path, 'w', encoding='utf-8') as file:
+        for line in ret_lines:
+            file.write(line)
+
+
+if __name__ == "__main__":
+    remove_runnable_code(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
fixes #1905
helps w/ #1899
Changes:
- convert sharding from bash to python
- create a metadata file to list long running jobs + jobs that require special machines
- shard based on time
  - default to 1 min if not a super long time
- only 0th worker uses gpu.nvidia.small.multi

There are three files (can see them in the metadata file) that are long running (20-30 minutes) and are responsible for the unbalance in the shards.  The long run time comes from running a training loop, so we should see what can be done about not running this training loop everytime (perhaps caching the result or reducing the number of epochs)