### PR TITLE
Update buildmodel_tutorial.py

### DIFF
--- a/beginner_source/basics/buildmodel_tutorial.py
+++ b/beginner_source/basics/buildmodel_tutorial.py
@@ -77,7 +77,7 @@ print(model)
 # along with some `background operations <https://github.com/pytorch/pytorch/blob/270111b7b611d174967ed204776985cefca9c144/torch/nn/modules/module.py#L866>`_.
 # Do not call ``model.forward()`` directly!
 #
-# Calling the model on the input returns a 10-dimensional tensor with raw predicted values for each class.
+# Calling the model on the input returns a 2-dimensional tensor with dim=0 corresponding to each output of 10 raw predicted values for each class, and dim=1 corresponding to the individual values of each output.  .
 # We get the prediction probabilities by passing it through an instance of the ``nn.Softmax`` module.
 
 X = torch.rand(1, 28, 28, device=device)


### PR DESCRIPTION
Currently incorrectly states "Calling the model on the input returns a 10-dimensional tensor with raw predicted values for each class." In reality, a 2-D tensor is returned.