### PR TITLE
use spaces instead of newlines in `get_files_to_run.py`

### DIFF
--- a/.jenkins/get_files_to_run.py
+++ b/.jenkins/get_files_to_run.py
@@ -75,7 +75,7 @@ def main():
     files_to_run = calculate_shards(all_files, num_shards=num_shards)[shard_num]
     remove_other_files(all_files, files_to_run)
     stripped_file_names = list(map(lambda x: Path(x).stem, files_to_run))
-    print("\n".join(stripped_file_names))
+    print(" ".join(stripped_file_names))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
in build.sh they check if " files_to_run " matches " filename ", and if it doesn't it removes the file
get_files_to_run.py was using newlines to separate the file names, not spaces, so it never matched, so the files always got removed 

they have the spaces b/c some file names are substrings of each other