### PR TITLE
Fix matmul resizing UserWarning

### DIFF
--- a/beginner_source/basics/tensorqs_tutorial.py
+++ b/beginner_source/basics/tensorqs_tutorial.py
@@ -145,7 +145,7 @@ print(t1)
 y1 = tensor @ tensor.T
 y2 = tensor.matmul(tensor.T)
 
-y3 = torch.rand_like(tensor)
+y3 = torch.rand_like(y1)
 torch.matmul(tensor, tensor.T, out=y3)
 
 


### PR DESCRIPTION
Hi all, I just noticed a tiny issue.

The tensor tutorial has a section illustrating standard matrix multiplication vs. element-wise multiplication. In the standard matrix multiplication part, the output array is created with size [5, 4], while the output size will be [5, 5]. This raises a UserWarning:
`UserWarning: An output with one or more elements was resized since it had shape [5, 4], which does not match the required output shape [5, 5].This behavior is deprecated, and in a future PyTorch release outputs will not be resized unless they have zero elements. You can explicitly reuse an out tensor t by resizing it, inplace, to zero elements with t.resize_(0).`

Fix is to replace the `rand_like` argument with a tensor of the proper size, like `y1`.