### PR TITLE
Fix typo in polynomial_nn.py

### DIFF
--- a/beginner_source/examples_nn/polynomial_nn.py
+++ b/beginner_source/examples_nn/polynomial_nn.py
@@ -10,7 +10,7 @@ This implementation uses the nn package from PyTorch to build the network.
 PyTorch autograd makes it easy to define computational graphs and take gradients,
 but raw autograd can be a bit too low-level for defining complex neural networks;
 this is where the nn package can help. The nn package defines a set of Modules,
-which you can think of as a neural network layer that has produces output from
+which you can think of as a neural network layer that produces output from
 input and may have some trainable weights.
 """
 import torch


### PR DESCRIPTION
Fix a simple typo that has been bugging me:  

![image](https://user-images.githubusercontent.com/56438982/172711976-4bb14e8b-e6f9-4dab-81e1-3ad692646d6b.png)
