### PR TITLE
Updated URLs for Multi30k dataset in translation_transformer tutorial

### DIFF
--- a/beginner_source/translation_transformer.py
+++ b/beginner_source/translation_transformer.py
@@ -24,9 +24,14 @@ This tutorial shows:
 
 from torchtext.data.utils import get_tokenizer
 from torchtext.vocab import build_vocab_from_iterator
-from torchtext.datasets import Multi30k
+from torchtext.datasets import multi30k, Multi30k
 from typing import Iterable, List
 
+
+# We need to modify the URLs for the dataset since the links to the original dataset are broken
+# Refer to https://github.com/pytorch/text/issues/1756#issuecomment-1163664163 for more info
+multi30k.URL["train"] = "https://raw.githubusercontent.com/neychev/small_DL_repo/master/datasets/Multi30k/training.tar.gz"
+multi30k.URL["valid"] = "https://raw.githubusercontent.com/neychev/small_DL_repo/master/datasets/Multi30k/validation.tar.gz"
 
 SRC_LANGUAGE = 'de'
 TGT_LANGUAGE = 'en'
@@ -37,6 +42,7 @@ vocab_transform = {}
 
 
 # Create source and target language tokenizer. Make sure to install the dependencies.
+# pip install -U torchdata
 # pip install -U spacy
 # python -m spacy download en_core_web_sm
 # python -m spacy download de_core_news_sm


### PR DESCRIPTION
## Description
- We need to programmatically modify the URLs for the multi30k dataset since the links to the original dataset are broken. 
- We plan to followup with a PR in torchtext that directly updates the URLs in source code, however this PR is still needed to make the dataset work for the 0.13 release (since the torchtext PR will not make it into the latest release)
- Added a commented line to install torchdata (a required dependency to work with torchtext datsets)