### PR TITLE
Use Modern Python 3 Syntax and Patterns

### DIFF
--- a/advanced_source/cpp_export.rst
+++ b/advanced_source/cpp_export.rst
@@ -79,7 +79,7 @@ vanilla Pytorch model::
 
   class MyModule(torch.nn.Module):
       def __init__(self, N, M):
-          super(MyModule, self).__init__()
+          super().__init__()
           self.weight = torch.nn.Parameter(torch.rand(N, M))
 
       def forward(self, input):
@@ -98,7 +98,7 @@ compile the module with ``torch.jit.script`` as follows::
 
     class MyModule(torch.nn.Module):
         def __init__(self, N, M):
-            super(MyModule, self).__init__()
+            super().__init__()
             self.weight = torch.nn.Parameter(torch.rand(N, M))
 
         def forward(self, input):

--- a/advanced_source/cpp_extension.rst
+++ b/advanced_source/cpp_extension.rst
@@ -55,7 +55,7 @@ look something like this::
 
   class LLTM(torch.nn.Module):
       def __init__(self, input_features, state_size):
-          super(LLTM, self).__init__()
+          super().__init__()
           self.input_features = input_features
           self.state_size = state_size
           # 3 * state_size for input gate, output gate and candidate cell gate.
@@ -469,7 +469,7 @@ class citizens of PyTorch::
 
   class LLTM(torch.nn.Module):
       def __init__(self, input_features, state_size):
-          super(LLTM, self).__init__()
+          super().__init__()
           self.input_features = input_features
           self.state_size = state_size
           self.weights = torch.nn.Parameter(

--- a/advanced_source/cpp_frontend.rst
+++ b/advanced_source/cpp_frontend.rst
@@ -271,7 +271,7 @@ Python interface:
 
   class Net(torch.nn.Module):
     def __init__(self, N, M):
-      super(Net, self).__init__()
+      super().__init__()
       self.W = torch.nn.Parameter(torch.randn(N, M))
       self.b = torch.nn.Parameter(torch.randn(M))
 
@@ -318,7 +318,7 @@ assigned as an attribute of a module:
 
   class Net(torch.nn.Module):
     def __init__(self, N, M):
-        super(Net, self).__init__()
+        super().__init__()
         # Registered as a submodule behind the scenes
         self.linear = torch.nn.Linear(N, M)
         self.another_bias = torch.nn.Parameter(torch.rand(M))

--- a/advanced_source/ddp_pipeline.py
+++ b/advanced_source/ddp_pipeline.py
@@ -43,7 +43,7 @@ from torch.nn import TransformerEncoder, TransformerEncoderLayer
 class PositionalEncoding(nn.Module):
 
     def __init__(self, d_model, dropout=0.1, max_len=5000):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         self.dropout = nn.Dropout(p=dropout)
 
         pe = torch.zeros(max_len, d_model)
@@ -88,7 +88,7 @@ if torch.cuda.device_count() < 4:
 
 class Encoder(nn.Module):
     def __init__(self, ntoken, ninp, dropout=0.5):
-        super(Encoder, self).__init__()
+        super().__init__()
         self.pos_encoder = PositionalEncoding(ninp, dropout)
         self.encoder = nn.Embedding(ntoken, ninp)
         self.ninp = ninp
@@ -106,7 +106,7 @@ class Encoder(nn.Module):
 
 class Decoder(nn.Module):
     def __init__(self, ntoken, ninp):
-        super(Decoder, self).__init__()
+        super().__init__()
         self.decoder = nn.Linear(ninp, ntoken)
         self.init_weights()
 

--- a/advanced_source/dynamic_quantization_tutorial.py
+++ b/advanced_source/dynamic_quantization_tutorial.py
@@ -41,7 +41,7 @@ class LSTMModel(nn.Module):
     """Container module with an encoder, a recurrent module, and a decoder."""
 
     def __init__(self, ntoken, ninp, nhid, nlayers, dropout=0.5):
-        super(LSTMModel, self).__init__()
+        super().__init__()
         self.drop = nn.Dropout(dropout)
         self.encoder = nn.Embedding(ntoken, ninp)
         self.rnn = nn.LSTM(ninp, nhid, nlayers, dropout=dropout)

--- a/advanced_source/generic_join.rst
+++ b/advanced_source/generic_join.rst
@@ -350,7 +350,7 @@ of inputs across all ranks.
         that it participates in.
         """
         def __init__(self, device, process_group):
-            super(Counter, self).__init__()
+            super().__init__()
             self.device = device
             self.process_group = process_group
             self.count = torch.tensor([0], device=device).float()

--- a/advanced_source/neural_style_tutorial.py
+++ b/advanced_source/neural_style_tutorial.py
@@ -47,7 +47,7 @@ to resemble the content of the content-image and the artistic style of the style
 # -  ``torchvision.models`` (train or load pre-trained models)
 # -  ``copy`` (to deep copy the models; system package)
 
-from __future__ import print_function
+
 
 import torch
 import torch.nn as nn

--- a/advanced_source/neural_style_tutorial.py
+++ b/advanced_source/neural_style_tutorial.py
@@ -172,7 +172,7 @@ imshow(content_img, title='Content Image')
 class ContentLoss(nn.Module):
 
     def __init__(self, target,):
-        super(ContentLoss, self).__init__()
+        super().__init__()
         # we 'detach' the target content from the tree used
         # to dynamically compute the gradient: this is a stated value,
         # not a variable. Otherwise the forward method of the criterion
@@ -238,7 +238,7 @@ def gram_matrix(input):
 class StyleLoss(nn.Module):
 
     def __init__(self, target_feature):
-        super(StyleLoss, self).__init__()
+        super().__init__()
         self.target = gram_matrix(target_feature).detach()
 
     def forward(self, input):
@@ -280,7 +280,7 @@ cnn_normalization_std = torch.tensor([0.229, 0.224, 0.225]).to(device)
 # nn.Sequential
 class Normalization(nn.Module):
     def __init__(self, mean, std):
-        super(Normalization, self).__init__()
+        super().__init__()
         # .view the mean and std to make them [C x 1 x 1] so that they can
         # directly work with image Tensor of shape [B x C x H x W].
         # B is batch size. C is number of channels. H is height and W is width.

--- a/advanced_source/numpy_extensions_tutorial.py
+++ b/advanced_source/numpy_extensions_tutorial.py
@@ -109,7 +109,7 @@ class ScipyConv2dFunction(Function):
 
 class ScipyConv2d(Module):
     def __init__(self, filter_width, filter_height):
-        super(ScipyConv2d, self).__init__()
+        super().__init__()
         self.filter = Parameter(torch.randn(filter_width, filter_height))
         self.bias = Parameter(torch.randn(1, 1))
 

--- a/advanced_source/rpc_ddp_tutorial/main.py
+++ b/advanced_source/rpc_ddp_tutorial/main.py
@@ -25,7 +25,7 @@ class HybridModel(torch.nn.Module):
     """
 
     def __init__(self, remote_emb_module, device):
-        super(HybridModel, self).__init__()
+        super().__init__()
         self.remote_emb_module = remote_emb_module
         self.fc = DDP(torch.nn.Linear(16, 8).cuda(device), device_ids=[device])
         self.device = device

--- a/advanced_source/static_quantization_tutorial.rst
+++ b/advanced_source/static_quantization_tutorial.rst
@@ -87,7 +87,7 @@ Note: this code is taken from
     class ConvBNReLU(nn.Sequential):  
         def __init__(self, in_planes, out_planes, kernel_size=3, stride=1, groups=1): 
             padding = (kernel_size - 1) // 2  
-            super(ConvBNReLU, self).__init__( 
+            super().__init__( 
                 nn.Conv2d(in_planes, out_planes, kernel_size, stride, padding, groups=groups, bias=False),  
                 nn.BatchNorm2d(out_planes, momentum=0.1), 
                 # Replace with ReLU 
@@ -97,7 +97,7 @@ Note: this code is taken from
 
     class InvertedResidual(nn.Module):  
         def __init__(self, inp, oup, stride, expand_ratio): 
-            super(InvertedResidual, self).__init__()  
+            super().__init__()  
             self.stride = stride  
             assert stride in [1, 2] 
 
@@ -137,7 +137,7 @@ Note: this code is taken from
                 round_nearest (int): Round the number of channels in each layer to be a multiple of this number 
                 Set to 1 to turn off rounding 
             """ 
-            super(MobileNetV2, self).__init__() 
+            super().__init__() 
             block = InvertedResidual  
             input_channel = 32  
             last_channel = 1280 

--- a/advanced_source/super_resolution_with_onnxruntime.py
+++ b/advanced_source/super_resolution_with_onnxruntime.py
@@ -57,7 +57,7 @@ import torch.nn.init as init
 
 class SuperResolutionNet(nn.Module):
     def __init__(self, upscale_factor, inplace=False):
-        super(SuperResolutionNet, self).__init__()
+        super().__init__()
 
         self.relu = nn.ReLU(inplace=inplace)
         self.conv1 = nn.Conv2d(1, 64, (5, 5), (1, 1), (2, 2))

--- a/advanced_source/torch_script_custom_classes.rst
+++ b/advanced_source/torch_script_custom_classes.rst
@@ -325,7 +325,7 @@ Once this is done, you can use the op like the following example:
 
   class TryCustomOp(torch.nn.Module):
       def __init__(self):
-          super(TryCustomOp, self).__init__()
+          super().__init__()
           self.f = torch.classes.my_classes.MyStackClass(["foo", "bar"])
 
       def forward(self):

--- a/beginner_source/Intro_to_TorchScript_tutorial.py
+++ b/beginner_source/Intro_to_TorchScript_tutorial.py
@@ -53,7 +53,7 @@ print(torch.__version__)
 
 class MyCell(torch.nn.Module):
     def __init__(self):
-        super(MyCell, self).__init__()
+        super().__init__()
 
     def forward(self, x, h):
         new_h = torch.tanh(x + h)
@@ -86,7 +86,7 @@ print(my_cell(x, h))
 
 class MyCell(torch.nn.Module):
     def __init__(self):
-        super(MyCell, self).__init__()
+        super().__init__()
         self.linear = torch.nn.Linear(4, 4)
 
     def forward(self, x, h):
@@ -133,7 +133,7 @@ class MyDecisionGate(torch.nn.Module):
 
 class MyCell(torch.nn.Module):
     def __init__(self):
-        super(MyCell, self).__init__()
+        super().__init__()
         self.dg = MyDecisionGate()
         self.linear = torch.nn.Linear(4, 4)
 
@@ -181,7 +181,7 @@ print(my_cell(x, h))
 
 class MyCell(torch.nn.Module):
     def __init__(self):
-        super(MyCell, self).__init__()
+        super().__init__()
         self.linear = torch.nn.Linear(4, 4)
 
     def forward(self, x, h):
@@ -264,7 +264,7 @@ class MyDecisionGate(torch.nn.Module):
 
 class MyCell(torch.nn.Module):
     def __init__(self, dg):
-        super(MyCell, self).__init__()
+        super().__init__()
         self.dg = dg
         self.linear = torch.nn.Linear(4, 4)
 
@@ -327,7 +327,7 @@ traced_cell(x, h)
 
 class MyRNNLoop(torch.nn.Module):
     def __init__(self):
-        super(MyRNNLoop, self).__init__()
+        super().__init__()
         self.cell = torch.jit.trace(MyCell(scripted_gate), (x, h))
 
     def forward(self, xs):
@@ -347,7 +347,7 @@ print(rnn_loop.code)
 
 class WrapRNN(torch.nn.Module):
     def __init__(self):
-        super(WrapRNN, self).__init__()
+        super().__init__()
         self.loop = torch.jit.script(MyRNNLoop())
 
     def forward(self, xs):

--- a/beginner_source/basics/buildmodel_tutorial.py
+++ b/beginner_source/basics/buildmodel_tutorial.py
@@ -49,7 +49,7 @@ print(f"Using {device} device")
 
 class NeuralNetwork(nn.Module):
     def __init__(self):
-        super(NeuralNetwork, self).__init__()
+        super().__init__()
         self.flatten = nn.Flatten()
         self.linear_relu_stack = nn.Sequential(
             nn.Linear(28*28, 512),

--- a/beginner_source/basics/optimization_tutorial.py
+++ b/beginner_source/basics/optimization_tutorial.py
@@ -49,7 +49,7 @@ test_dataloader = DataLoader(test_data, batch_size=64)
 
 class NeuralNetwork(nn.Module):
     def __init__(self):
-        super(NeuralNetwork, self).__init__()
+        super().__init__()
         self.flatten = nn.Flatten()
         self.linear_relu_stack = nn.Sequential(
             nn.Linear(28*28, 512),

--- a/beginner_source/basics/quickstart_tutorial.py
+++ b/beginner_source/basics/quickstart_tutorial.py
@@ -93,7 +93,7 @@ print(f"Using {device} device")
 # Define model
 class NeuralNetwork(nn.Module):
     def __init__(self):
-        super(NeuralNetwork, self).__init__()
+        super().__init__()
         self.flatten = nn.Flatten()
         self.linear_relu_stack = nn.Sequential(
             nn.Linear(28*28, 512),

--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -105,7 +105,7 @@ def imshow(img):
 
 # get some random training images
 dataiter = iter(trainloader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # show images
 imshow(torchvision.utils.make_grid(images))
@@ -210,7 +210,7 @@ torch.save(net.state_dict(), PATH)
 # Okay, first step. Let us display an image from the test set to get familiar.
 
 dataiter = iter(testloader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # print images
 imshow(torchvision.utils.make_grid(images))

--- a/beginner_source/blitz/data_parallel_tutorial.py
+++ b/beginner_source/blitz/data_parallel_tutorial.py
@@ -100,7 +100,7 @@ class Model(nn.Module):
     # Our model
 
     def __init__(self, input_size, output_size):
-        super(Model, self).__init__()
+        super().__init__()
         self.fc = nn.Linear(input_size, output_size)
 
     def forward(self, input):

--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -45,7 +45,7 @@ import torch.nn.functional as F
 class Net(nn.Module):
 
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         # 1 input image channel, 6 output channels, 5x5 square convolution
         # kernel
         self.conv1 = nn.Conv2d(1, 6, 5)

--- a/beginner_source/chatbot_tutorial.py
+++ b/beginner_source/chatbot_tutorial.py
@@ -666,7 +666,7 @@ print("max_target_len:", max_target_len)
 
 class EncoderRNN(nn.Module):
     def __init__(self, hidden_size, embedding, n_layers=1, dropout=0):
-        super(EncoderRNN, self).__init__()
+        super().__init__()
         self.n_layers = n_layers
         self.hidden_size = hidden_size
         self.embedding = embedding
@@ -758,7 +758,7 @@ class EncoderRNN(nn.Module):
 # Luong attention layer
 class Attn(nn.Module):
     def __init__(self, method, hidden_size):
-        super(Attn, self).__init__()
+        super().__init__()
         self.method = method
         if self.method not in ['dot', 'general', 'concat']:
             raise ValueError(self.method, "is not an appropriate attention method.")
@@ -832,7 +832,7 @@ class Attn(nn.Module):
 
 class LuongAttnDecoderRNN(nn.Module):
     def __init__(self, attn_model, embedding, hidden_size, output_size, n_layers=1, dropout=0.1):
-        super(LuongAttnDecoderRNN, self).__init__()
+        super().__init__()
 
         # Keep for reference
         self.attn_model = attn_model
@@ -1138,7 +1138,7 @@ def trainIters(model_name, voc, pairs, encoder, decoder, encoder_optimizer, deco
 
 class GreedySearchDecoder(nn.Module):
     def __init__(self, encoder, decoder):
-        super(GreedySearchDecoder, self).__init__()
+        super().__init__()
         self.encoder = encoder
         self.decoder = decoder
 

--- a/beginner_source/chatbot_tutorial.py
+++ b/beginner_source/chatbot_tutorial.py
@@ -91,10 +91,10 @@ Chatbot Tutorial
 # After that, let’s import some necessities.
 #
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
+
 
 import torch
 from torch.jit import script, trace

--- a/beginner_source/data_loading_tutorial.py
+++ b/beginner_source/data_loading_tutorial.py
@@ -18,7 +18,7 @@ installed:
 
 """
 
-from __future__ import print_function, division
+
 import os
 import torch
 import pandas as pd

--- a/beginner_source/dcgan_faces_tutorial.py
+++ b/beginner_source/dcgan_faces_tutorial.py
@@ -112,7 +112,7 @@ DCGAN Tutorial
 # will be explained in the coming sections.
 # 
 
-from __future__ import print_function
+
 #%matplotlib inline
 import argparse
 import os

--- a/beginner_source/dcgan_faces_tutorial.py
+++ b/beginner_source/dcgan_faces_tutorial.py
@@ -331,7 +331,7 @@ def weights_init(m):
 
 class Generator(nn.Module):
     def __init__(self, ngpu):
-        super(Generator, self).__init__()
+        super().__init__()
         self.ngpu = ngpu
         self.main = nn.Sequential(
             # input is Z, going into a convolution
@@ -405,7 +405,7 @@ print(netG)
 
 class Discriminator(nn.Module):
     def __init__(self, ngpu):
-        super(Discriminator, self).__init__()
+        super().__init__()
         self.ngpu = ngpu
         self.main = nn.Sequential(
             # input is (nc) x 64 x 64

--- a/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
+++ b/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
@@ -285,7 +285,7 @@ def indexesFromSentence(voc, sentence):
 
 class EncoderRNN(nn.Module):
     def __init__(self, hidden_size, embedding, n_layers=1, dropout=0):
-        super(EncoderRNN, self).__init__()
+        super().__init__()
         self.n_layers = n_layers
         self.hidden_size = hidden_size
         self.embedding = embedding
@@ -328,7 +328,7 @@ class EncoderRNN(nn.Module):
 # Luong attention layer
 class Attn(nn.Module):
     def __init__(self, method, hidden_size):
-        super(Attn, self).__init__()
+        super().__init__()
         self.method = method
         if self.method not in ['dot', 'general', 'concat']:
             raise ValueError(self.method, "is not an appropriate attention method.")
@@ -396,7 +396,7 @@ class Attn(nn.Module):
 
 class LuongAttnDecoderRNN(nn.Module):
     def __init__(self, attn_model, embedding, hidden_size, output_size, n_layers=1, dropout=0.1):
-        super(LuongAttnDecoderRNN, self).__init__()
+        super().__init__()
 
         # Keep for reference
         self.attn_model = attn_model
@@ -543,7 +543,7 @@ class LuongAttnDecoderRNN(nn.Module):
 
 class GreedySearchDecoder(nn.Module):
     def __init__(self, encoder, decoder, decoder_n_layers):
-        super(GreedySearchDecoder, self).__init__()
+        super().__init__()
         self.encoder = encoder
         self.decoder = decoder
         self._device = device

--- a/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
+++ b/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
@@ -101,10 +101,10 @@ Deploying a Seq2Seq Model with TorchScript
 # maximum length output that the model is capable of producing.
 #
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
+
+
+
 
 import torch
 import torch.nn as nn

--- a/beginner_source/fgsm_tutorial.py
+++ b/beginner_source/fgsm_tutorial.py
@@ -90,7 +90,7 @@ first and most popular attack methods, the Fast Gradient Sign Attack
 # into the implementation.
 # 
 
-from __future__ import print_function
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/beginner_source/fgsm_tutorial.py
+++ b/beginner_source/fgsm_tutorial.py
@@ -159,7 +159,7 @@ use_cuda=True
 # LeNet Model definition
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
         self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
         self.conv2_drop = nn.Dropout2d()

--- a/beginner_source/former_torchies/nnft_tutorial.py
+++ b/beginner_source/former_torchies/nnft_tutorial.py
@@ -57,7 +57,7 @@ class MNISTConvNet(nn.Module):
         # this is the place where you instantiate all your modules
         # you can later access them using the same names you've given them in
         # here
-        super(MNISTConvNet, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 10, 5)
         self.pool1 = nn.MaxPool2d(2, 2)
         self.conv2 = nn.Conv2d(10, 20, 5)
@@ -221,7 +221,7 @@ class RNN(nn.Module):
 
     # you can also accept arguments in your model constructor
     def __init__(self, data_size, hidden_size, output_size):
-        super(RNN, self).__init__()
+        super().__init__()
 
         self.hidden_size = hidden_size
         input_size = data_size + hidden_size

--- a/beginner_source/hybrid_frontend/learning_hybrid_frontend_through_example_tutorial.py
+++ b/beginner_source/hybrid_frontend/learning_hybrid_frontend_through_example_tutorial.py
@@ -197,7 +197,7 @@ class ScriptModule(torch.jit.ScriptModule):
 # methods and functions
 class Net(torch.nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         # Modules must be attributes on the Module because if you want to trace
         # or script this Module, we must be able to inherit the submodules'
         # params.

--- a/beginner_source/hyperparameter_tuning_tutorial.py
+++ b/beginner_source/hyperparameter_tuning_tutorial.py
@@ -86,7 +86,7 @@ def load_data(data_dir="./data"):
 
 class Net(nn.Module):
     def __init__(self, l1=120, l2=84):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(3, 6, 5)
         self.pool = nn.MaxPool2d(2, 2)
         self.conv2 = nn.Conv2d(6, 16, 5)

--- a/beginner_source/introyt/autogradyt_tutorial.py
+++ b/beginner_source/introyt/autogradyt_tutorial.py
@@ -248,7 +248,7 @@ DIM_OUT = 10
 class TinyModel(torch.nn.Module):
 
     def __init__(self):
-        super(TinyModel, self).__init__()
+        super().__init__()
         
         self.layer1 = torch.nn.Linear(1000, 100)
         self.relu = torch.nn.ReLU()

--- a/beginner_source/introyt/introyt1_tutorial.py
+++ b/beginner_source/introyt/introyt1_tutorial.py
@@ -175,7 +175,7 @@ import torch.nn.functional as F  # for the activation function
 class LeNet(nn.Module):
 
     def __init__(self):
-        super(LeNet, self).__init__()
+        super().__init__()
         # 1 input image channel (black & white), 6 output channels, 3x3 square convolution
         # kernel
         self.conv1 = nn.Conv2d(1, 6, 3)
@@ -462,7 +462,7 @@ print(' '.join('%5s' % classes[labels[j]] for j in range(4)))
 
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(3, 6, 5)
         self.pool = nn.MaxPool2d(2, 2)
         self.conv2 = nn.Conv2d(6, 16, 5)

--- a/beginner_source/introyt/introyt1_tutorial.py
+++ b/beginner_source/introyt/introyt1_tutorial.py
@@ -369,7 +369,7 @@ def imshow(img):
 
 # get some random training images
 dataiter = iter(trainloader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # show images
 imshow(torchvision.utils.make_grid(images))
@@ -446,7 +446,7 @@ def imshow(img):
 
 # get some random training images
 dataiter = iter(trainloader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # show images
 imshow(torchvision.utils.make_grid(images))

--- a/beginner_source/introyt/modelsyt_tutorial.py
+++ b/beginner_source/introyt/modelsyt_tutorial.py
@@ -48,7 +48,7 @@ import torch
 class TinyModel(torch.nn.Module):
     
     def __init__(self):
-        super(TinyModel, self).__init__()
+        super().__init__()
         
         self.linear1 = torch.nn.Linear(100, 200)
         self.activation = torch.nn.ReLU()
@@ -150,7 +150,7 @@ import torch.functional as F
 class LeNet(torch.nn.Module):
 
     def __init__(self):
-        super(LeNet, self).__init__()
+        super().__init__()
         # 1 input image channel (black & white), 6 output channels, 5x5 square convolution
         # kernel
         self.conv1 = torch.nn.Conv2d(1, 6, 5)
@@ -249,7 +249,7 @@ class LeNet(torch.nn.Module):
 class LSTMTagger(torch.nn.Module):
 
     def __init__(self, embedding_dim, hidden_dim, vocab_size, tagset_size):
-        super(LSTMTagger, self).__init__()
+        super().__init__()
         self.hidden_dim = hidden_dim
 
         self.word_embeddings = torch.nn.Embedding(vocab_size, embedding_dim)

--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -160,7 +160,7 @@ writer.flush()
 
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 6, 5)
         self.pool = nn.MaxPool2d(2, 2)
         self.conv2 = nn.Conv2d(6, 16, 5)

--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -115,7 +115,7 @@ def matplotlib_imshow(img, one_channel=False):
 
 # Extract a batch of 4 images
 dataiter = iter(training_loader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # Create a grid from the images and show them
 img_grid = torchvision.utils.make_grid(images)
@@ -242,7 +242,7 @@ writer.flush()
 
 # Again, grab a single mini-batch of images
 dataiter = iter(training_loader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # add_graph() will trace the sample input through your model,
 # and render it as a graph.

--- a/beginner_source/introyt/trainingyt.py
+++ b/beginner_source/introyt/trainingyt.py
@@ -112,7 +112,7 @@ def matplotlib_imshow(img, one_channel=False):
         plt.imshow(np.transpose(npimg, (1, 2, 0)))
 
 dataiter = iter(training_loader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # Create a grid from the images and show them
 img_grid = torchvision.utils.make_grid(images)

--- a/beginner_source/introyt/trainingyt.py
+++ b/beginner_source/introyt/trainingyt.py
@@ -134,7 +134,7 @@ import torch.nn.functional as F
 # PyTorch models inherit from torch.nn.Module
 class GarmentClassifier(nn.Module):
     def __init__(self):
-        super(GarmentClassifier, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 6, 5)
         self.pool = nn.MaxPool2d(2, 2)
         self.conv2 = nn.Conv2d(6, 16, 5)

--- a/beginner_source/nlp/advanced_tutorial.py
+++ b/beginner_source/nlp/advanced_tutorial.py
@@ -152,7 +152,7 @@ def log_sum_exp(vec):
 class BiLSTM_CRF(nn.Module):
 
     def __init__(self, vocab_size, tag_to_ix, embedding_dim, hidden_dim):
-        super(BiLSTM_CRF, self).__init__()
+        super().__init__()
         self.embedding_dim = embedding_dim
         self.hidden_dim = hidden_dim
         self.vocab_size = vocab_size

--- a/beginner_source/nlp/deep_learning_tutorial.py
+++ b/beginner_source/nlp/deep_learning_tutorial.py
@@ -261,7 +261,7 @@ class BoWClassifier(nn.Module):  # inheriting from nn.Module!
     def __init__(self, num_labels, vocab_size):
         # calls the init function of nn.Module.  Dont get confused by syntax,
         # just always do it in an nn.Module
-        super(BoWClassifier, self).__init__()
+        super().__init__()
 
         # Define the parameters that you will need.  In this case, we need A and b,
         # the parameters of the affine mapping.

--- a/beginner_source/nlp/sequence_models_tutorial.py
+++ b/beginner_source/nlp/sequence_models_tutorial.py
@@ -155,7 +155,7 @@ HIDDEN_DIM = 6
 class LSTMTagger(nn.Module):
 
     def __init__(self, embedding_dim, hidden_dim, vocab_size, tagset_size):
-        super(LSTMTagger, self).__init__()
+        super().__init__()
         self.hidden_dim = hidden_dim
 
         self.word_embeddings = nn.Embedding(vocab_size, embedding_dim)

--- a/beginner_source/nlp/word_embeddings_tutorial.py
+++ b/beginner_source/nlp/word_embeddings_tutorial.py
@@ -226,7 +226,7 @@ word_to_ix = {word: i for i, word in enumerate(vocab)}
 class NGramLanguageModeler(nn.Module):
 
     def __init__(self, vocab_size, embedding_dim, context_size):
-        super(NGramLanguageModeler, self).__init__()
+        super().__init__()
         self.embeddings = nn.Embedding(vocab_size, embedding_dim)
         self.linear1 = nn.Linear(context_size * embedding_dim, 128)
         self.linear2 = nn.Linear(128, vocab_size)

--- a/beginner_source/profiler.py
+++ b/beginner_source/profiler.py
@@ -55,7 +55,7 @@ import torch.autograd.profiler as profiler
 
 class MyModule(nn.Module):
     def __init__(self, in_features: int, out_features: int, bias: bool = True):
-        super(MyModule, self).__init__()
+        super().__init__()
         self.linear = nn.Linear(in_features, out_features, bias)
 
     def forward(self, input, mask):
@@ -241,7 +241,7 @@ Self CPU time total: 5.347s
 
 class MyModule(nn.Module):
     def __init__(self, in_features: int, out_features: int, bias: bool = True):
-        super(MyModule, self).__init__()
+        super().__init__()
         self.linear = nn.Linear(in_features, out_features, bias)
 
     def forward(self, input, mask):

--- a/beginner_source/saving_loading_models.py
+++ b/beginner_source/saving_loading_models.py
@@ -80,7 +80,7 @@ functions to be familiar with:
 #    # Define model
 #    class TheModelClass(nn.Module):
 #        def __init__(self):
-#            super(TheModelClass, self).__init__()
+#            super().__init__()
 #            self.conv1 = nn.Conv2d(3, 6, 5)
 #            self.pool = nn.MaxPool2d(2, 2)
 #            self.conv2 = nn.Conv2d(6, 16, 5)

--- a/beginner_source/text_sentiment_ngrams_tutorial.py
+++ b/beginner_source/text_sentiment_ngrams_tutorial.py
@@ -147,7 +147,7 @@ from torch import nn
 class TextClassificationModel(nn.Module):
 
     def __init__(self, vocab_size, embed_dim, num_class):
-        super(TextClassificationModel, self).__init__()
+        super().__init__()
         self.embedding = nn.EmbeddingBag(vocab_size, embed_dim, sparse=True)
         self.fc = nn.Linear(embed_dim, num_class)
         self.init_weights()

--- a/beginner_source/transfer_learning_tutorial.py
+++ b/beginner_source/transfer_learning_tutorial.py
@@ -33,7 +33,7 @@ These two major transfer learning scenarios look as follows:
 # License: BSD
 # Author: Sasank Chilamkurthy
 
-from __future__ import print_function, division
+
 
 import torch
 import torch.nn as nn

--- a/beginner_source/translation_transformer.py
+++ b/beginner_source/translation_transformer.py
@@ -106,7 +106,7 @@ class PositionalEncoding(nn.Module):
                  emb_size: int,
                  dropout: float,
                  maxlen: int = 5000):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         den = torch.exp(- torch.arange(0, emb_size, 2)* math.log(10000) / emb_size)
         pos = torch.arange(0, maxlen).reshape(maxlen, 1)
         pos_embedding = torch.zeros((maxlen, emb_size))
@@ -123,7 +123,7 @@ class PositionalEncoding(nn.Module):
 # helper Module to convert tensor of input indices into corresponding tensor of token embeddings
 class TokenEmbedding(nn.Module):
     def __init__(self, vocab_size: int, emb_size):
-        super(TokenEmbedding, self).__init__()
+        super().__init__()
         self.embedding = nn.Embedding(vocab_size, emb_size)
         self.emb_size = emb_size
 
@@ -141,7 +141,7 @@ class Seq2SeqTransformer(nn.Module):
                  tgt_vocab_size: int,
                  dim_feedforward: int = 512,
                  dropout: float = 0.1):
-        super(Seq2SeqTransformer, self).__init__()
+        super().__init__()
         self.transformer = Transformer(d_model=emb_size,
                                        nhead=nhead,
                                        num_encoder_layers=num_encoder_layers,

--- a/intermediate_source/FSDP_tutorial.rst
+++ b/intermediate_source/FSDP_tutorial.rst
@@ -112,7 +112,7 @@ We add the following code snippets to a python script “FSDP_mnist.py”.
 
     class Net(nn.Module):
         def __init__(self):
-            super(Net, self).__init__()
+            super().__init__()
             self.conv1 = nn.Conv2d(1, 32, 3, 1)
             self.conv2 = nn.Conv2d(32, 64, 3, 1)
             self.dropout1 = nn.Dropout(0.25)

--- a/intermediate_source/char_rnn_classification_tutorial.py
+++ b/intermediate_source/char_rnn_classification_tutorial.py
@@ -190,7 +190,7 @@ import torch.nn as nn
 
 class RNN(nn.Module):
     def __init__(self, input_size, hidden_size, output_size):
-        super(RNN, self).__init__()
+        super().__init__()
 
         self.hidden_size = hidden_size
 

--- a/intermediate_source/char_rnn_classification_tutorial.py
+++ b/intermediate_source/char_rnn_classification_tutorial.py
@@ -69,7 +69,7 @@ We'll end up with a dictionary of lists of names per language,
 ``{language: [names ...]}``. The generic variables "category" and "line"
 (for language and name in our case) are used for later extensibility.
 """
-from __future__ import unicode_literals, print_function, division
+
 from io import open
 import glob
 import os

--- a/intermediate_source/char_rnn_generation_tutorial.py
+++ b/intermediate_source/char_rnn_generation_tutorial.py
@@ -151,7 +151,7 @@ import torch.nn as nn
 
 class RNN(nn.Module):
     def __init__(self, input_size, hidden_size, output_size):
-        super(RNN, self).__init__()
+        super().__init__()
         self.hidden_size = hidden_size
 
         self.i2h = nn.Linear(n_categories + input_size + hidden_size, hidden_size)

--- a/intermediate_source/char_rnn_generation_tutorial.py
+++ b/intermediate_source/char_rnn_generation_tutorial.py
@@ -75,7 +75,7 @@ name per line. We split lines into an array, convert Unicode to ASCII,
 and end up with a dictionary ``{language: [names ...]}``.
 
 """
-from __future__ import unicode_literals, print_function, division
+
 from io import open
 import glob
 import os

--- a/intermediate_source/custom_function_conv_bn_tutorial.py
+++ b/intermediate_source/custom_function_conv_bn_tutorial.py
@@ -209,7 +209,7 @@ import math
 class FusedConvBN(nn.Module):
     def __init__(self, in_channels, out_channels, kernel_size, exp_avg_factor=0.1,
                  eps=1e-3, device=None, dtype=None):
-        super(FusedConvBN, self).__init__()
+        super().__init__()
         factory_kwargs = {'device': device, 'dtype': dtype}
         # Conv parameters
         weight_shape = (out_channels, in_channels, kernel_size, kernel_size)
@@ -248,7 +248,7 @@ memory_allocated = [[],[]]
 
 class Net(nn.Module):
     def __init__(self, fused=True):
-        super(Net, self).__init__()
+        super().__init__()
         self.fused = fused
         if fused:
             self.convbn1 = FusedConvBN(1, 32, 3)

--- a/intermediate_source/ddp_tutorial.rst
+++ b/intermediate_source/ddp_tutorial.rst
@@ -114,7 +114,7 @@ different DDP processes starting from different initial model parameter values.
 
     class ToyModel(nn.Module):
         def __init__(self):
-            super(ToyModel, self).__init__()
+            super().__init__()
             self.net1 = nn.Linear(10, 10)
             self.relu = nn.ReLU()
             self.net2 = nn.Linear(10, 5)
@@ -245,7 +245,7 @@ helpful when training large models with a huge amount of data.
 
     class ToyMpModel(nn.Module):
         def __init__(self, dev0, dev1):
-            super(ToyMpModel, self).__init__()
+            super().__init__()
             self.dev0 = dev0
             self.dev1 = dev1
             self.net1 = torch.nn.Linear(10, 10).to(dev0)
@@ -312,7 +312,7 @@ Let's still use the Toymodel example and create a file named ``elastic_ddp.py``.
 
     class ToyModel(nn.Module):
         def __init__(self):
-            super(ToyModel, self).__init__()
+            super().__init__()
             self.net1 = nn.Linear(10, 10)
             self.relu = nn.ReLU()
             self.net2 = nn.Linear(10, 5)

--- a/intermediate_source/dist_pipeline_parallel_tutorial.rst
+++ b/intermediate_source/dist_pipeline_parallel_tutorial.rst
@@ -80,7 +80,7 @@ the two ResNet shards.
     class ResNetBase(nn.Module):
         def __init__(self, block, inplanes, num_classes=1000,
                     groups=1, width_per_group=64, norm_layer=None):
-            super(ResNetBase, self).__init__()
+            super().__init__()
 
             self._lock = threading.Lock()
             self._block = block
@@ -129,7 +129,7 @@ match.
 
     class ResNetShard1(ResNetBase):
         def __init__(self, device, *args, **kwargs):
-            super(ResNetShard1, self).__init__(
+            super().__init__(
                 Bottleneck, 64, num_classes=num_classes, *args, **kwargs)
 
             self.device = device
@@ -158,7 +158,7 @@ match.
 
     class ResNetShard2(ResNetBase):
         def __init__(self, device, *args, **kwargs):
-            super(ResNetShard2, self).__init__(
+            super().__init__(
                 Bottleneck, 512, num_classes=num_classes, *args, **kwargs)
 
             self.device = device
@@ -206,7 +206,7 @@ simplify distributed optimizer construction, which will be used later.
 
     class DistResNet50(nn.Module):
         def __init__(self, num_split, workers, *args, **kwargs):
-            super(DistResNet50, self).__init__()
+            super().__init__()
 
             self.num_split = num_split
 

--- a/intermediate_source/fx_conv_bn_fuser.py
+++ b/intermediate_source/fx_conv_bn_fuser.py
@@ -174,7 +174,7 @@ def fuse(model: torch.nn.Module) -> torch.nn.Module:
         # that's being called. Here, we check `Node.target` to see if it's a
         # batch norm module, and then check `Node.args[0].target` to see if the
         # input `Node` is a convolution.
-        if type(modules[node.target]) is nn.BatchNorm2d and type(modules[node.args[0].target]) is nn.Conv2d:
+        if isinstance(modules[node.target], nn.BatchNorm2d) and isinstance(modules[node.args[0].target], nn.Conv2d):
             if len(node.args[0].users) > 1:  # Output of conv is used by other nodes
                 continue
             conv = modules[node.args[0].target]

--- a/intermediate_source/model_parallel_tutorial.py
+++ b/intermediate_source/model_parallel_tutorial.py
@@ -51,7 +51,7 @@ import torch.optim as optim
 
 class ToyModel(nn.Module):
     def __init__(self):
-        super(ToyModel, self).__init__()
+        super().__init__()
         self.net1 = torch.nn.Linear(10, 10).to('cuda:0')
         self.relu = torch.nn.ReLU()
         self.net2 = torch.nn.Linear(10, 5).to('cuda:1')
@@ -99,7 +99,7 @@ num_classes = 1000
 
 class ModelParallelResNet50(ResNet):
     def __init__(self, *args, **kwargs):
-        super(ModelParallelResNet50, self).__init__(
+        super().__init__(
             Bottleneck, [3, 4, 6, 3], num_classes=num_classes, *args, **kwargs)
 
         self.seq1 = nn.Sequential(
@@ -249,7 +249,7 @@ plot([mp_mean, rn_mean],
 
 class PipelineParallelResNet50(ModelParallelResNet50):
     def __init__(self, split_size=20, *args, **kwargs):
-        super(PipelineParallelResNet50, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.split_size = split_size
 
     def forward(self, x):

--- a/intermediate_source/pipeline_tutorial.py
+++ b/intermediate_source/pipeline_tutorial.py
@@ -55,7 +55,7 @@ if torch.cuda.device_count() < 2:
 
 class Encoder(nn.Module):
     def __init__(self, ntoken, ninp, dropout=0.5):
-        super(Encoder, self).__init__()
+        super().__init__()
         self.pos_encoder = PositionalEncoding(ninp, dropout)
         self.encoder = nn.Embedding(ntoken, ninp)
         self.ninp = ninp
@@ -73,7 +73,7 @@ class Encoder(nn.Module):
 
 class Decoder(nn.Module):
     def __init__(self, ntoken, ninp):
-        super(Decoder, self).__init__()
+        super().__init__()
         self.decoder = nn.Linear(ninp, ntoken)
         self.init_weights()
 
@@ -98,7 +98,7 @@ class Decoder(nn.Module):
 class PositionalEncoding(nn.Module):
 
     def __init__(self, d_model, dropout=0.1, max_len=5000):
-        super(PositionalEncoding, self).__init__()
+        super().__init__()
         self.dropout = nn.Dropout(p=dropout)
 
         pe = torch.zeros(max_len, d_model)

--- a/intermediate_source/pruning_tutorial.py
+++ b/intermediate_source/pruning_tutorial.py
@@ -43,7 +43,7 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 class LeNet(nn.Module):
     def __init__(self):
-        super(LeNet, self).__init__()
+        super().__init__()
         # 1 input image channel, 6 output channels, 3x3 square conv kernel
         self.conv1 = nn.Conv2d(1, 6, 3)
         self.conv2 = nn.Conv2d(6, 16, 3)

--- a/intermediate_source/reinforcement_q_learning.py
+++ b/intermediate_source/reinforcement_q_learning.py
@@ -204,7 +204,7 @@ class ReplayMemory(object):
 class DQN(nn.Module):
 
     def __init__(self, h, w, outputs):
-        super(DQN, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(3, 16, kernel_size=5, stride=2)
         self.bn1 = nn.BatchNorm2d(16)
         self.conv2 = nn.Conv2d(16, 32, kernel_size=5, stride=2)

--- a/intermediate_source/rpc_async_execution.rst
+++ b/intermediate_source/rpc_async_execution.rst
@@ -232,7 +232,7 @@ to change properly. Everything else stays intact.
 
     class Policy(nn.Module):
         def __init__(self, batch=True):
-            super(Policy, self).__init__()
+            super().__init__()
             self.affine1 = nn.Linear(4, 128)
             self.dropout = nn.Dropout(p=0.6)
             self.affine2 = nn.Linear(128, 2)

--- a/intermediate_source/rpc_param_server_tutorial.rst
+++ b/intermediate_source/rpc_param_server_tutorial.rst
@@ -41,7 +41,7 @@ Let's start with the familiar: importing our required modules and defining a sim
 
    class Net(nn.Module):
        def __init__(self, num_gpus=0):
-           super(Net, self).__init__()
+           super().__init__()
            print(f"Using {num_gpus} GPUs to train")
            self.num_gpus = num_gpus
            device = torch.device(

--- a/intermediate_source/rpc_tutorial.rst
+++ b/intermediate_source/rpc_tutorial.rst
@@ -73,7 +73,7 @@ usages.
     class Policy(nn.Module):
 
         def __init__(self):
-            super(Policy, self).__init__()
+            super().__init__()
             self.affine1 = nn.Linear(4, 128)
             self.dropout = nn.Dropout(p=0.6)
             self.affine2 = nn.Linear(128, 2)
@@ -420,7 +420,7 @@ takes a GPU tensor, you need to move it to the proper device explicitly.
         Encoding layers of the RNNModel
         """
         def __init__(self, ntoken, ninp, dropout):
-            super(EmbeddingTable, self).__init__()
+            super().__init__()
             self.drop = nn.Dropout(dropout)
             self.encoder = nn.Embedding(ntoken, ninp).cuda()
             self.encoder.weight.data.uniform_(-0.1, 0.1)
@@ -431,7 +431,7 @@ takes a GPU tensor, you need to move it to the proper device explicitly.
 
     class Decoder(nn.Module):
         def __init__(self, ntoken, nhid, dropout):
-            super(Decoder, self).__init__()
+            super().__init__()
             self.drop = nn.Dropout(dropout)
             self.decoder = nn.Linear(nhid, ntoken)
             self.decoder.bias.data.zero_()
@@ -463,7 +463,7 @@ RPC functions.
 
     class RNNModel(nn.Module):
         def __init__(self, ps, ntoken, ninp, nhid, nlayers, dropout=0.5):
-            super(RNNModel, self).__init__()
+            super().__init__()
 
             # setup embedding table remotely
             self.emb_table_rref = rpc.remote(ps, EmbeddingTable, args=(ntoken, ninp, dropout))

--- a/intermediate_source/seq2seq_translation_tutorial.py
+++ b/intermediate_source/seq2seq_translation_tutorial.py
@@ -78,7 +78,7 @@ models, respectively.
 
 **Requirements**
 """
-from __future__ import unicode_literals, print_function, division
+
 from io import open
 import unicodedata
 import string

--- a/intermediate_source/seq2seq_translation_tutorial.py
+++ b/intermediate_source/seq2seq_translation_tutorial.py
@@ -331,7 +331,7 @@ print(random.choice(pairs))
 
 class EncoderRNN(nn.Module):
     def __init__(self, input_size, hidden_size):
-        super(EncoderRNN, self).__init__()
+        super().__init__()
         self.hidden_size = hidden_size
 
         self.embedding = nn.Embedding(input_size, hidden_size)
@@ -376,7 +376,7 @@ class EncoderRNN(nn.Module):
 
 class DecoderRNN(nn.Module):
     def __init__(self, hidden_size, output_size):
-        super(DecoderRNN, self).__init__()
+        super().__init__()
         self.hidden_size = hidden_size
 
         self.embedding = nn.Embedding(output_size, hidden_size)
@@ -434,7 +434,7 @@ class DecoderRNN(nn.Module):
 
 class AttnDecoderRNN(nn.Module):
     def __init__(self, hidden_size, output_size, dropout_p=0.1, max_length=MAX_LENGTH):
-        super(AttnDecoderRNN, self).__init__()
+        super().__init__()
         self.hidden_size = hidden_size
         self.output_size = output_size
         self.dropout_p = dropout_p

--- a/intermediate_source/spatial_transformer_tutorial.py
+++ b/intermediate_source/spatial_transformer_tutorial.py
@@ -27,7 +27,7 @@ any existing CNN with very little modification.
 # License: BSD
 # Author: Ghassen Hamrouni
 
-from __future__ import print_function
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/intermediate_source/spatial_transformer_tutorial.py
+++ b/intermediate_source/spatial_transformer_tutorial.py
@@ -93,7 +93,7 @@ test_loader = torch.utils.data.DataLoader(
 
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
         self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
         self.conv2_drop = nn.Dropout2d()

--- a/intermediate_source/tensorboard_tutorial.rst
+++ b/intermediate_source/tensorboard_tutorial.rst
@@ -91,7 +91,7 @@ one channel instead of three and 28x28 instead of 32x32:
 
     class Net(nn.Module):
         def __init__(self):
-            super(Net, self).__init__()
+            super().__init__()
             self.conv1 = nn.Conv2d(1, 6, 5)
             self.pool = nn.MaxPool2d(2, 2)
             self.conv2 = nn.Conv2d(6, 16, 5)

--- a/prototype_source/fx_graph_mode_ptq_dynamic.py
+++ b/prototype_source/fx_graph_mode_ptq_dynamic.py
@@ -69,7 +69,7 @@ class LSTMModel(nn.Module):
     """Container module with an encoder, a recurrent module, and a decoder."""
 
     def __init__(self, ntoken, ninp, nhid, nlayers, dropout=0.5):
-        super(LSTMModel, self).__init__()
+        super().__init__()
         self.drop = nn.Dropout(dropout)
         self.encoder = nn.Embedding(ntoken, ninp)
         self.rnn = nn.LSTM(ninp, nhid, nlayers, dropout=dropout)

--- a/prototype_source/numeric_suite_tutorial.py
+++ b/prototype_source/numeric_suite_tutorial.py
@@ -24,7 +24,7 @@ We’ll start by doing the necessary imports:
 
 ##############################################################################
 
-from __future__ import print_function, division, absolute_import
+
 import numpy as np
 import torch
 import torch.nn as nn

--- a/prototype_source/numeric_suite_tutorial.py
+++ b/prototype_source/numeric_suite_tutorial.py
@@ -157,7 +157,7 @@ class MyOutputLogger(ns.Logger):
     """
 
     def __init__(self):
-        super(MyOutputLogger, self).__init__()
+        super().__init__()
 
     def forward(self, x):
         # Custom functionalities
@@ -249,7 +249,7 @@ class MyShadowLogger(ns.Logger):
     """
 
     def __init__(self):
-        super(MyShadowLogger, self).__init__()
+        super().__init__()
 
     def forward(self, x, y):
         # Custom functionalities
@@ -286,7 +286,7 @@ class LSTMModel(nn.Module):
     """Container module with an encoder, a recurrent module, and a decoder."""
 
     def __init__(self, ntoken, ninp, nhid, nlayers, dropout=0.5):
-        super(LSTMModel, self).__init__()
+        super().__init__()
         self.encoder = nn.Embedding(ntoken, ninp)
         self.rnn = nn.LSTM(ninp, nhid, nlayers, dropout=dropout)
         self.decoder = nn.Linear(nhid, ntoken)

--- a/prototype_source/torchscript_freezing.py
+++ b/prototype_source/torchscript_freezing.py
@@ -24,7 +24,7 @@ import torch, time
 
 class Net(torch.nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = torch.nn.Conv2d(1, 32, 3, 1)
         self.conv2 = torch.nn.Conv2d(32, 64, 3, 1)
         self.dropout1 = torch.nn.Dropout2d(0.25)

--- a/recipes_source/bundled_inputs.rst
+++ b/recipes_source/bundled_inputs.rst
@@ -23,7 +23,7 @@ Common case, bundling an input to a model that only uses 'forward' for inference
 
     class Net(nn.Module):
         def __init__(self):
-            super(Net, self).__init__()
+            super().__init__()
             self.lin = nn.Linear(10, 1)
 
         def forward(self, x):
@@ -66,7 +66,7 @@ Uncommon case, bundling and retrieving inputs for functions beyond 'forward'
 
     class Net(nn.Module):
         def __init__(self):
-            super(Net, self).__init__()
+            super().__init__()
             self.lin = nn.Linear(10, 1)
 
         def forward(self, x):

--- a/recipes_source/fuse.rst
+++ b/recipes_source/fuse.rst
@@ -31,7 +31,7 @@ Use the same example model defined in the `PyTorch Mobile Performance Recipes <h
 
     class AnnotatedConvBnReLUModel(torch.nn.Module):
         def __init__(self):
-            super(AnnotatedConvBnReLUModel, self).__init__()
+            super().__init__()
             self.conv = torch.nn.Conv2d(3, 5, 3, bias=False).to(dtype=torch.float)
             self.bn = torch.nn.BatchNorm2d(5).to(dtype=torch.float)
             self.relu = torch.nn.ReLU(inplace=True)

--- a/recipes_source/intel_extension_for_pytorch.rst
+++ b/recipes_source/intel_extension_for_pytorch.rst
@@ -88,7 +88,7 @@ Float32
    
    class Model(nn.Module):
        def __init__(self):
-           super(Model, self).__init__()
+           super().__init__()
            self.linear = nn.Linear(4, 5)
    
        def forward(self, input):
@@ -121,7 +121,7 @@ BFloat16
    
    class Model(nn.Module):
        def __init__(self):
-           super(Model, self).__init__()
+           super().__init__()
            self.linear = nn.Linear(4, 5)
    
        def forward(self, input):
@@ -158,7 +158,7 @@ Float32
    
    class Model(nn.Module):
        def __init__(self):
-           super(Model, self).__init__()
+           super().__init__()
            self.linear = nn.Linear(4, 5)
    
        def forward(self, input):
@@ -183,7 +183,7 @@ BFloat16
    
    class Model(nn.Module):
        def __init__(self):
-           super(Model, self).__init__()
+           super().__init__()
            self.linear = nn.Linear(4, 5)
    
        def forward(self, input):
@@ -220,7 +220,7 @@ Float32
    
    class Model(nn.Module):
        def __init__(self):
-           super(Model, self).__init__()
+           super().__init__()
            self.linear = nn.Linear(4, 5)
    
        def forward(self, input):
@@ -250,7 +250,7 @@ BFloat16
    
    class Model(nn.Module):
        def __init__(self):
-           super(Model, self).__init__()
+           super().__init__()
            self.linear = nn.Linear(4, 5)
    
        def forward(self, input):

--- a/recipes_source/intel_neural_compressor_for_pytorch.rst
+++ b/recipes_source/intel_neural_compressor_for_pytorch.rst
@@ -97,7 +97,7 @@ In this tutorial, the LeNet model is used to demonstrate how to deal with *Intel
     # LeNet Model definition
     class Net(nn.Module):
         def __init__(self):
-            super(Net, self).__init__()
+            super().__init__()
             self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
             self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
             self.conv2_drop = nn.Dropout2d()

--- a/recipes_source/mobile_perf.rst
+++ b/recipes_source/mobile_perf.rst
@@ -46,7 +46,7 @@ Code your model:
 
   class AnnotatedConvBnReLUModel(torch.nn.Module):
       def __init__(self):
-          super(AnnotatedConvBnReLUModel, self).__init__()
+          super().__init__()
           self.conv = torch.nn.Conv2d(3, 5, 3, bias=False).to(dtype=torch.float)
           self.bn = torch.nn.BatchNorm2d(5).to(dtype=torch.float)
           self.relu = torch.nn.ReLU(inplace=True)


### PR DESCRIPTION
### Description

Let's use modern style for modern code.

These changes remove python 2 syntax all over the place in favor of modern python 3 syntax first released in 2008.

Commits don't introduce any functionality changes. We're just swapping legacy syntax and practices for modern commonly accepted python practices all over the place.