### PR TITLE
Update ios_coreml_workflow.rst

### DIFF
--- a/prototype_source/ios_coreml_workflow.rst
+++ b/prototype_source/ios_coreml_workflow.rst
@@ -26,7 +26,7 @@ Next, since the Core ML delegate is a prototype feature, let's install the PyTor
 
     pip3 install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
-    pip3 install coremltools==5.0b5
+    pip3 install coremltools==5.0b5 protobuf==3.20.1
 
 
 Model Preparation


### PR DESCRIPTION
Downgrading to this version of protobuf may be necessary for this workflow to succeed. This is reflected in our build here https://github.com/pytorch/pytorch/blob/master/.github/workflows/_ios-build-test.yml#L168