### PR TITLE
Remove obsolete import

### DIFF
--- a/beginner_source/basics/optimization_tutorial.py
+++ b/beginner_source/basics/optimization_tutorial.py
@@ -28,7 +28,7 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader
 from torchvision import datasets
-from torchvision.transforms import ToTensor, Lambda
+from torchvision.transforms import ToTensor
 
 training_data = datasets.FashionMNIST(
     root="data",


### PR DESCRIPTION
The import `Lambda` is not being used in the example, so I removed it.