### PR TITLE
Update `Tensor Gradients and Jacobian Products` example

### DIFF
--- a/beginner_source/basics/autogradqs_tutorial.py
+++ b/beginner_source/basics/autogradqs_tutorial.py
@@ -203,14 +203,14 @@ print(z_det.requires_grad)
 # compute the product:
 #
 
-inp = torch.eye(5, requires_grad=True)
-out = (inp+1).pow(2)
-out.backward(torch.ones_like(inp), retain_graph=True)
+inp = torch.eye(4, 5, requires_grad=True)
+out = (inp+1).pow(2).t()
+out.backward(torch.ones_like(out), retain_graph=True)
 print(f"First call\n{inp.grad}")
-out.backward(torch.ones_like(inp), retain_graph=True)
+out.backward(torch.ones_like(out), retain_graph=True)
 print(f"\nSecond call\n{inp.grad}")
 inp.grad.zero_()
-out.backward(torch.ones_like(inp), retain_graph=True)
+out.backward(torch.ones_like(out), retain_graph=True)
 print(f"\nCall after zeroing gradients\n{inp.grad}")
 
 


### PR DESCRIPTION
Shape of gradient argument of `x.backwards` method should be that of `x`.

Modify example, to make input tensor a 5x4 matrix and transpose it in the output

Fixes https://github.com/pytorch/tutorials/issues/2065