### PR TITLE
Modernize cifar10_tutorial

### DIFF
--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -105,7 +105,7 @@ def imshow(img):
 
 # get some random training images
 dataiter = iter(trainloader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # show images
 imshow(torchvision.utils.make_grid(images))
@@ -210,7 +210,7 @@ torch.save(net.state_dict(), PATH)
 # Okay, first step. Let us display an image from the test set to get familiar.
 
 dataiter = iter(testloader)
-images, labels = dataiter.next()
+images, labels = next(dataiter)
 
 # print images
 imshow(torchvision.utils.make_grid(images))


### PR DESCRIPTION
Use `next(iter)` rather than `iter.next()`, which is more Python-3 friendly, that makes tutorial compatible with upcoming 1.13 release, that contains https://github.com/pytorch/pytorch/pull/78594