### PR TITLE
update NS for FX tutorial for PyTorch v1.13

### DIFF
--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -50,7 +50,6 @@ NOT_RUN = [
     "recipes/Captum_Recipe",
     "hyperparameter_tuning_tutorial",
     "flask_rest_api_tutorial",
-    "fx_numeric_suite_tutorial", # remove when https://github.com/pytorch/tutorials/pull/2089 is fixed
     "ax_multiobjective_nas_tutorial",
 ]
 

--- a/prototype_source/fx_numeric_suite_tutorial.py
+++ b/prototype_source/fx_numeric_suite_tutorial.py
@@ -84,9 +84,9 @@ qconfig_dict = {
 # Note: quantization APIs are inplace, so we save a copy of the float model for
 # later comparison to the quantized model. This is done throughout the
 # tutorial.
-mobilenetv2_prepared = quantize_fx.prepare_fx(
-    copy.deepcopy(mobilenetv2_float), qconfig_dict)
 datum = torch.randn(1, 3, 224, 224)
+mobilenetv2_prepared = quantize_fx.prepare_fx(
+    copy.deepcopy(mobilenetv2_float), qconfig_dict, (datum,))
 mobilenetv2_prepared(datum)
 # Note: there is a long standing issue that we cannot copy.deepcopy a
 # quantized model. Since quantization APIs are inplace and we need to use

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,10 @@ ax-platform
 nbformat>=4.2.0
 deep_phonemizer==0.0.17
 
+# the following is necessary due to https://github.com/python/importlib_metadata/issues/411
+importlib-metadata < 5.0; python_version <= "3.7"
+importlib-metadata; python_version > "3.7"
+
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 


### PR DESCRIPTION
Summary:

Makes a couple of updates to ensure this tutorial still runs on 1.13:
1. add `example_inputs` to `prepare_fx`

Test plan:

Run the tutorial, it runs without errors on master