### PR TITLE
Pin importlib_metadata<5.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,8 +30,8 @@ nbformat>=4.2.0
 deep_phonemizer==0.0.17
 
 # the following is necessary due to https://github.com/python/importlib_metadata/issues/411
-importlib-metadata<5.0; python-version<='3.7'
-importlib-metadata; python-version>'3.7'
+importlib-metadata < 5.0; python_version <= "3.7"
+importlib-metadata; python_version > "3.7"
 
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,10 @@ torchx
 ax-platform
 nbformat>=4.2.0
 deep_phonemizer==0.0.17
-importlib-metadata<5.0  # due to https://github.com/python/importlib_metadata/issues/411
+
+# the following is necessary due to https://github.com/python/importlib_metadata/issues/411
+importlib-metadata<5.0; python-version<='3.7'
+importlib-metadata; python-version>'3.7'
 
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ torchx
 ax-platform
 nbformat>=4.2.0
 deep_phonemizer==0.0.17
+importlib-metadata<5.0  # due to https://github.com/python/importlib_metadata/issues/411
 
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
v5.0.0 causes issues with python 3.7: https://github.com/python/importlib_metadata/issues/411

This was raised in the context of https://github.com/pytorch/tutorials/issues/2090

This PR pins the version to <5.0 to circumvent this. Maybe a better fix would be to bump the python version in CI to 3.8, but that's something to discuss more broadly.