### PR TITLE
update target network weight during episode after x timesteps

### DIFF
--- a/intermediate_source/reinforcement_q_learning.py
+++ b/intermediate_source/reinforcement_q_learning.py
@@ -492,9 +492,10 @@ for i_episode in range(num_episodes):
             episode_durations.append(t + 1)
             plot_durations()
             break
-    # Update the target network, copying all weights and biases in DQN
-    if i_episode % TARGET_UPDATE == 0:
-        target_net.load_state_dict(policy_net.state_dict())
+
+        # Update the target network, copying all weights and biases in DQN
+        if t % TARGET_UPDATE == 0:
+            target_net.load_state_dict(policy_net.state_dict())
 
 print('Complete')
 env.render()


### PR DESCRIPTION
Currently the target network remain fixed during the entire episode.
In this PR I have moved the update of the weigths inside the inner loop of the training. So the update can occure during the episode.

Without this change, if the episode is too long, the target network will be too different from the behavior network.

cc @vmoens @nairbv