### PR TITLE
fix broken link issue

### DIFF
--- a/recipes_source/recipes_index.rst
+++ b/recipes_source/recipes_index.rst
@@ -120,7 +120,7 @@ Recipes are bite-sized, actionable examples of how to use specific PyTorch featu
    :header: PyTorch Profiler with Instrumentation and Tracing Technology API (ITT API) support
    :card_description: Learn how to use PyTorch's profiler with Instrumentation and Tracing Technology API (ITT API) to visualize operators labeling in Intel® VTune™ Profiler GUI
    :image: ../_static/img/thumbnails/cropped/profiler.png
-   :link: ../recipes/recipes/profile_with_itt.html
+   :link: ../recipes/profile_with_itt.html
    :tags: Basics
 
 .. Interpretability


### PR DESCRIPTION
https://pytorch.org/tutorials/recipes/recipes/profile_with_itt.html is 404.
https://pytorch.org/tutorials/recipes/profile_with_itt.html works.