### PR TITLE
Fix a display bug which cannot update figure correctly.

### DIFF
--- a/intermediate_source/reinforcement_q_learning.py
+++ b/intermediate_source/reinforcement_q_learning.py
@@ -378,8 +378,8 @@ def plot_durations():
 
     plt.pause(0.001)  # pause a bit so that plots are updated
     if is_ipython:
-        display.clear_output(wait=True)
         display.display(plt.gcf())
+        display.clear_output(wait=True)
 
 
 ######################################################################


### PR DESCRIPTION
When using notebook such as colab and local jupyter where `is_ipython == True`, the training procedure is not shown correctly. The figure is closed too fast to observe since `clear_output(wait=True)` is always activated.

Excanging `display.display(plt.gcf())` and `display.clear_output(wait=True)` could fix the bug.