### PR TITLE
Update torchmetrics callsite to fix error due to BC-breaking changes

### DIFF
--- a/intermediate_source/mnist_train_nas.py
+++ b/intermediate_source/mnist_train_nas.py
@@ -16,7 +16,7 @@ from pytorch_lightning import loggers as pl_loggers
 from torch import nn
 from torch.nn import functional as F
 from torch.utils.data import DataLoader
-from torchmetrics.functional.classification.accuracy import accuracy
+from torchmetrics.functional.classification.accuracy import multiclass_accuracy
 from torchvision import transforms
 from torchvision.datasets import MNIST
 
@@ -106,7 +106,7 @@ class MnistModel(LightningModule):
         logits = self(x)
         loss = F.nll_loss(logits, y)
         preds = torch.argmax(logits, dim=1)
-        acc = accuracy(preds, y)
+        acc = multiclass_accuracy(preds, y, num_classes=self.num_classes)
         self.log("val_acc", acc, prog_bar=False)
         return loss
 


### PR DESCRIPTION
torchmetrics changed the signature of the `accuracy` function in a BC-breaking fashion. This updates the callsite to work with torchmetrics 0.11 and uses `multiclass_accuracy` instead.

cc @dme65