### PR TITLE
Replaces `gym` with `gymnasium` in reinforcement learning q-learning tutorial

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,7 @@ pillow==9.3.0
 wget
 gym==0.25.1
 gym-super-mario-bros==7.4.0
+gymnasium==0.27.0
 timm
 iopath
 pygame==2.1.2


### PR DESCRIPTION
Gymnasium is a fork of OpenAI gym that is developed by the same team that maintained Gym since v0.19-v0.26

You can read more about the reason for the fork in https://farama.org/Announcing-The-Farama-Foundation

In this PR, I have replaced the instances of Gym with gymnasium and removed old code that provided support for Gym v0.25

@vmoens Let me know if there is anything else you would like me to change
