### PR TITLE
Fix typo and formatting in bettertransformer_tutorial.rst

### DIFF
--- a/beginner_source/bettertransformer_tutorial.rst
+++ b/beginner_source/bettertransformer_tutorial.rst
@@ -18,7 +18,7 @@ been updated to use the core library modules to benefit from fastpath accelerati
 
 Better Transformer offers two types of acceleration:
 
-* Native multihead attention implementation for CPU and GPU to improvee overall execution efficiency.  
+* Native multihead attention (MHA) implementation for CPU and GPU to improve overall execution efficiency.  
 * Exploiting sparsity in NLP inference.  Because of variable input lengths, input
   tokens may contain a large number of padding tokens for which processing may be
   skipped, delivering significant speedups.
@@ -124,6 +124,7 @@ Finally, we set the benchmark iteration count:
 2.1  Run and benchmark inference on CPU with and without BT fastpath (native MHA only)
 
 We run the model on CPU, and collect profile information:  
+
 * The first run uses traditional ("slow path") execution.
 * The second run enables BT fastpath execution by putting the model in inference mode using `model.eval()` and disables gradient collection with `torch.no_grad()`.
 
@@ -167,6 +168,7 @@ We disable the BT sparsity:
     
  
 We run the model on DEVICE, and collect profile information for native MHA execution on DEVICE:  
+
 * The first run uses traditional ("slow path") execution.
 * The second run enables BT fastpath execution by putting the model in inference mode using `model.eval()`
   and disables gradient collection with `torch.no_grad()`.


### PR DESCRIPTION
This PR fixes some minor typos and formatting issues in `bettertransformer_tutorial.rst`. Specifically:

- Fix typo in `improvee`
- Add definition of what `MHA` means. It was mentioned multiple times in the text but it was never explicitly defined (even though it might easily be inferred)
- Add newlines above bullet groups so they're actually rendered as bullets and not as part of the paragraph above it

cc @svekars @carljparker