### PR TITLE
Move code to non-executable block

### DIFF
--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -219,7 +219,9 @@ print(net.conv1.bias.grad)
 # The simplest update rule used in practice is the Stochastic Gradient
 # Descent (SGD):
 #
-#      ``weight = weight - learning_rate * gradient``
+# .. code:: python
+#
+#     weight = weight - learning_rate * gradient
 #
 # We can implement this using simple Python code:
 #
@@ -233,18 +235,21 @@ print(net.conv1.bias.grad)
 # update rules such as SGD, Nesterov-SGD, Adam, RMSProp, etc.
 # To enable this, we built a small package: ``torch.optim`` that
 # implements all these methods. Using it is very simple:
-
-import torch.optim as optim
-
-# create your optimizer
-optimizer = optim.SGD(net.parameters(), lr=0.01)
-
-# in your training loop:
-optimizer.zero_grad()   # zero the gradient buffers
-output = net(input)
-loss = criterion(output, target)
-loss.backward()
-optimizer.step()    # Does the update
+#
+# .. code:: python
+#
+#     import torch.optim as optim
+#
+#     # create your optimizer
+#     optimizer = optim.SGD(net.parameters(), lr=0.01)
+#
+#     # in your training loop:
+#     optimizer.zero_grad()   # zero the gradient buffers
+#     output = net(input)
+#     loss = criterion(output, target)
+#     loss.backward()
+#     optimizer.step()    # Does the update
+#
 
 
 ###############################################################


### PR DESCRIPTION
Fixes #787

Moves the aforementioned code block for the [Neural Network notebook](https://colab.research.google.com/github/pytorch/tutorials/blob/gh-pages/_downloads/neural_networks_tutorial.ipynb#scrollTo=-H1tj2vB2lFG) into a non-executable block. I also changed the formatting of the weight calculation line, as it wasn't rendering properly in the html. See screenshots below.

### Before: 

#### HTML
<img width="807" alt="Screenshot 2023-01-27 at 12 29 15 PM" src="https://user-images.githubusercontent.com/31816267/215167983-880f59de-f7b4-40c5-bc87-7db073ec19c8.png">

#### Notebook
<img width="1088" alt="Screenshot 2023-01-27 at 12 24 24 PM" src="https://user-images.githubusercontent.com/31816267/215167950-0960a2f7-3d36-4df2-b4d3-2c83149dfe21.png">



### After:

#### HTML
<img width="812" alt="Screenshot 2023-01-27 at 12 27 33 PM" src="https://user-images.githubusercontent.com/31816267/215167904-c470a29a-a262-429e-a6c5-6abfb61c1648.png">

#### Notebook
<img width="1055" alt="Screenshot 2023-01-27 at 12 28 17 PM" src="https://user-images.githubusercontent.com/31816267/215167998-2a054a65-0790-44ef-af75-974ea1c1cb83.png">


cc @suraj813 @svekars @carljparker