### PR TITLE
Re-enable `Hyperparameter tuning with Ray Tune`

### DIFF
--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -49,7 +49,6 @@ NOT_RUN = [
     "recipes/timer_quick_start",
     "recipes/amp_recipe",
     "recipes/Captum_Recipe",
-    "hyperparameter_tuning_tutorial",
     "flask_rest_api_tutorial",
     "text_to_speech_with_torchaudio",
 ]

--- a/beginner_source/hyperparameter_tuning_tutorial.py
+++ b/beginner_source/hyperparameter_tuning_tutorial.py
@@ -424,6 +424,12 @@ def main(num_samples=10, max_num_epochs=10, gpus_per_trial=2):
 
 
 if __name__ == "__main__":
+    # sphinx_gallery_start_ignore
+    # Fixes AttributeError: '_LoggingTee' object has no attribute 'fileno'.
+    # This is only needed to run with sphinx-build.
+    import sys
+    sys.stdout.fileno = lambda: False
+    # sphinx_gallery_end_ignore
     # You can change the number of GPUs per trial here:
     main(num_samples=10, max_num_epochs=10, gpus_per_trial=0)
 


### PR DESCRIPTION
Fixes the issue identified in https://github.com/pytorch/tutorials/pull/2185, which allows to re-enable the `Hyperparameter tuning with Ray Tune` tutorial.
___________________

### Error
```
WARNING: /home/ubuntu/tutorials/beginner_source/hyperparameter_tuning_tutorial.py failed to execute correctly: Traceback (most recent call last):
  File "/home/ubuntu/tutorials/beginner_source/hyperparameter_tuning_tutorial.py", line 428, in <module>
    main(num_samples=10, max_num_epochs=10, gpus_per_trial=0)
  File "/home/ubuntu/tutorials/beginner_source/hyperparameter_tuning_tutorial.py", line 394, in main
    result = tune.run(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/ray/tune/tune.py", line 365, in run
    _ray_auto_init()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/ray/tune/tune.py", line 878, in _ray_auto_init
    ray.init()
  File "/home/ubuntu/.local/lib/python3.8/site-packages/ray/_private/client_mode_hook.py", line 105, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/ray/worker.py", line 1097, in init
    connect(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/ray/worker.py", line 1459, in connect
    faulthandler.enable(all_threads=False)
AttributeError: '_LoggingTee' object has no attribute 'fileno'
```

**_Note:_** This error is only raised when run with `sphinx-build` and not when running the script directly with `python3 beginner_source/hyperparameter_tuning_tutorial.py`

### Fix

This is fixed by disabling `fileno`, as shown [here](https://hiclass.readthedocs.io/en/latest/auto_examples/plot_parallel_training.html).


For reference, this was also seen with other libraries, e.g.  `celery`. See https://github.com/ray-project/ray/issues/8610.

### TODO
- [x] Verify that script runs successfully.
   - https://app.circleci.com/pipelines/github/pytorch/tutorials/7220/workflows/e2e4b096-4063-46ba-b582-174b8e484f86/jobs/140975
- [x] Verify that example shows up in generated docs.
   - https://deploy-preview-2187--pytorch-tutorials-preview.netlify.app/beginner/hyperparameter_tuning_tutorial.html
- [x] Verify that `sphinx_gallery_start_ignore`/`sphinx_gallery_start_ignore` hides this code.
 
<img width="540" alt="image" src="https://user-images.githubusercontent.com/3967392/215914429-c9d8ee41-1800-4b64-b591-7d25bd69c29c.png">


___________________

Closes https://github.com/ray-project/ray/issues/32094.


cc @suraj813