### PR TITLE
Fix misalignment of Microsoft Learn links in quickstart tutorial

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -48,7 +48,7 @@ if(window.location.href.indexOf("/beginner/basics/")!= -1)
       url="https://docs.microsoft.com/learn/modules/intro-machine-learning-pytorch/8-inference?WT.mc_id=aiml-7486-cxa";
     }
     
-    $(".pytorch-call-to-action-links").children().first().before("<a href="+url+' data-behavior="call-to-action-event" data-response="Run in Microsoft Learn" target="_blank"><div id="microsoft-learn-link" style="padding-bottom: 0.625rem;border-bottom: 1px solid #f3f4f7;padding-right: 2.5rem;display: -webkit-box;  display: -ms-flexbox; isplay: flex; -webkit-box-align: center;-ms-flex-align: center;align-items: center;"><img class="call-to-action-img" src="../../_static/images/microsoft-logo.svg"/><div class="call-to-action-desktop-view">Run in Microsoft Learn</div><div class="call-to-action-mobile-view">Learn</div></div></a>')
+    $(".pytorch-call-to-action-links").children().first().before("<a href="+url+' data-behavior="call-to-action-event" data-response="Run in Microsoft Learn" target="_blank"><div id="microsoft-learn-link" style="padding-bottom: 0.625rem;border-bottom: 1px solid #f3f4f7;padding-right: 2.5rem;display: -webkit-box;  display: -ms-flexbox; display: flex; -webkit-box-align: center;-ms-flex-align: center;align-items: center;"><img class="call-to-action-img" src="../../_static/images/microsoft-logo.svg"/><div class="call-to-action-desktop-view">Run in Microsoft Learn</div><div class="call-to-action-mobile-view">Learn</div></div></a>')
   }
 
   !function(f,b,e,v,n,t,s)


### PR DESCRIPTION
Fixes #1760 

This is a minor one, but I noticed a small typo in the css for the Microsoft Learn links that seems to fix the linked issue.

Before:
<img width="763" alt="Screenshot 2023-02-01 at 12 34 02 PM" src="https://user-images.githubusercontent.com/31816267/216131900-2558c71a-9e5d-410d-8e2c-62184cbc3c21.png">


After:
<img width="774" alt="Screenshot 2023-02-01 at 12 33 52 PM" src="https://user-images.githubusercontent.com/31816267/216131918-aa76c877-5af7-442b-9dd3-7dcb171df52d.png">



Signed-off-by: Kiersten Stokes <kierstenstokes@gmail.com>

cc @svekars @carljparker