### PR TITLE
Use the correct batch values in the output

### DIFF
--- a/beginner_source/basics/optimization_tutorial.py
+++ b/beginner_source/basics/optimization_tutorial.py
@@ -160,7 +160,7 @@ def train_loop(dataloader, model, loss_fn, optimizer):
         optimizer.step()
 
         if batch % 100 == 0:
-            loss, current = loss.item(), batch * len(X)
+            loss, current = loss.item(), (batch + 1) * len(X)
             print(f"loss: {loss:>7f}  [{current:>5d}/{size:>5d}]")
 
 

--- a/beginner_source/basics/quickstart_tutorial.py
+++ b/beginner_source/basics/quickstart_tutorial.py
@@ -151,7 +151,7 @@ def train(dataloader, model, loss_fn, optimizer):
         optimizer.step()
 
         if batch % 100 == 0:
-            loss, current = loss.item(), batch * len(X)
+            loss, current = loss.item(), (batch + 1) * len(X)
             print(f"loss: {loss:>7f}  [{current:>5d}/{size:>5d}]")
 
 ##############################################################################


### PR DESCRIPTION
The current logic uses enumerate counter (i.e. variable `batch`). It displays the loss for trained data in an increment of 100 using `if batch % 100 == 0`. i.e. 1st batch, 101 stbatch, and so on for the given dataset. This maps to batch =0, 100, and so on). So for the first batch, the loss displayed should be `[ 64/60000]` instead of `[ 0/60000]`. For the second it should be `[ 6464/60000]` instead of `[ 6400/60000]` , and so on. The values displayed in the `Out:` text box on the tutorial page, e.g. `loss: 2.306185  [ 0/60000]`, read as a loss observed for zero input data which seems incorrect. This loss mentioned here was for the first batch, which was 64 input data. The second was for 101 batch which has 6464 input data, and so on.

cc @suraj813