### PR TITLE
Fix kernel dimensions for LeNet model code example

### DIFF
--- a/beginner_source/introyt/introyt1_tutorial.py
+++ b/beginner_source/introyt/introyt1_tutorial.py
@@ -179,7 +179,7 @@ class LeNet(nn.Module):
         # 1 input image channel (black & white), 6 output channels, 5x5 square convolution
         # kernel
         self.conv1 = nn.Conv2d(1, 6, 5)
-        self.conv2 = nn.Conv2d(6, 16, 3)
+        self.conv2 = nn.Conv2d(6, 16, 5)
         # an affine operation: y = Wx + b
         self.fc1 = nn.Linear(16 * 6 * 6, 120)  # 6*6 from image dimension
         self.fc2 = nn.Linear(120, 84)

--- a/beginner_source/introyt/introyt1_tutorial.py
+++ b/beginner_source/introyt/introyt1_tutorial.py
@@ -176,9 +176,9 @@ class LeNet(nn.Module):
 
     def __init__(self):
         super(LeNet, self).__init__()
-        # 1 input image channel (black & white), 6 output channels, 3x3 square convolution
+        # 1 input image channel (black & white), 6 output channels, 5x5 square convolution
         # kernel
-        self.conv1 = nn.Conv2d(1, 6, 3)
+        self.conv1 = nn.Conv2d(1, 6, 5)
         self.conv2 = nn.Conv2d(6, 16, 3)
         # an affine operation: y = Wx + b
         self.fc1 = nn.Linear(16 * 6 * 6, 120)  # 6*6 from image dimension

--- a/beginner_source/introyt/introyt1_tutorial.py
+++ b/beginner_source/introyt/introyt1_tutorial.py
@@ -181,7 +181,7 @@ class LeNet(nn.Module):
         self.conv1 = nn.Conv2d(1, 6, 5)
         self.conv2 = nn.Conv2d(6, 16, 5)
         # an affine operation: y = Wx + b
-        self.fc1 = nn.Linear(16 * 6 * 6, 120)  # 6*6 from image dimension
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)  # 5*5 from image dimension
         self.fc2 = nn.Linear(120, 84)
         self.fc3 = nn.Linear(84, 10)
 


### PR DESCRIPTION
Fixes #2104 

In going through the [YouTube Intro tutorial](https://pytorch.org/tutorials/beginner/introyt/introyt1_tutorial.html?highlight=lenet), I noticed that the dimensions in the LeNet diagram don't match up with code that immediately follows it. Namely, the kernel size should be 5x5 rather than the 3x3 that's given. (And I believe the same should be true for the second convolutional layer?) While not really necessary for the point the tutorial is making, it may reduce confusion for those with no experience with this model (myself included 😄). Especially when comparing with the same network in [this blitz tutorial](https://pytorch.org/tutorials/beginner/blitz/neural_networks_tutorial.html?highlight=lenet) that has the correct kernel size.



cc @suraj813