### PR TITLE
[CI] Update CUDA to 11.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,14 +142,14 @@ pytorch_tutorial_build_defaults: &pytorch_tutorial_build_defaults
 
 pytorch_tutorial_build_worker_defaults: &pytorch_tutorial_build_worker_defaults
   environment:
-    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7"
+    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.7-cudnn8-py3-gcc7"
     CUDA_VERSION: "9"
   resource_class: gpu.nvidia.small
   <<: *pytorch_tutorial_build_defaults
 
 pytorch_tutorial_build_manager_defaults: &pytorch_tutorial_build_manager_defaults
   environment:
-    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7"
+    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.7-cudnn8-py3-gcc7"
   resource_class: medium
   <<: *pytorch_tutorial_build_defaults
 

--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -142,14 +142,14 @@ pytorch_tutorial_build_defaults: &pytorch_tutorial_build_defaults
 
 pytorch_tutorial_build_worker_defaults: &pytorch_tutorial_build_worker_defaults
   environment:
-    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7"
+    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.7-cudnn8-py3-gcc7"
     CUDA_VERSION: "9"
   resource_class: gpu.nvidia.small
   <<: *pytorch_tutorial_build_defaults
 
 pytorch_tutorial_build_manager_defaults: &pytorch_tutorial_build_manager_defaults
   environment:
-    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.6-cudnn8-py3-gcc7"
+    DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/pytorch-linux-bionic-cuda11.7-cudnn8-py3-gcc7"
   resource_class: medium
   <<: *pytorch_tutorial_build_defaults
 {% raw %}

--- a/.jenkins/get_docker_tag.py
+++ b/.jenkins/get_docker_tag.py
@@ -5,9 +5,14 @@ REQUEST_HEADERS = {
 }
 
 if __name__ == "__main__":
-    url = "https://api.github.com/repos/pytorch/pytorch/contents/.circleci"
+    url = "https://api.github.com/repos/pytorch/pytorch/contents/.ci"
 
     response = requests.get(url, headers=REQUEST_HEADERS)
-    for file in response.json():
-        if file["name"] == "docker":
-            print(file["sha"])
+    docker_sha = None
+    for finfo in response.json():
+        if finfo["name"] == "docker":
+            docker_sha = finfo["sha"]
+            break
+    if docker_sha is None:
+        raise RuntimeError("Can't find sha sum of docker folder")
+    print(docker_sha)


### PR DESCRIPTION
As 11.6 builds has been disabled by https://github.com/pytorch/pytorch/pull/93406
Also, update `.jenkins/get_docker_tag.py` to search for docker folder in `.ci` directory (that was moved there by https://github.com/pytorch/pytorch/pull/93104 ) and raise an error if folder can not be found