### PR TITLE
Move code to code block in Youtube "Training with PyTorch" module

### DIFF
--- a/beginner_source/introyt/trainingyt.py
+++ b/beginner_source/introyt/trainingyt.py
@@ -321,12 +321,12 @@ for epoch in range(EPOCHS):
 
 #########################################################################
 # To load a saved version of the model:
-# 
-# ::
-# 
-#    saved_model = GarmentClassifier()
-#    saved_model.load_state_dict(torch.load(PATH))
-# 
+#
+# .. code:: python
+#
+#     saved_model = GarmentClassifier()
+#     saved_model.load_state_dict(torch.load(PATH))
+#
 # Once you’ve loaded the model, it’s ready for whatever you need it for -
 # more training, inference, or analysis.
 # 


### PR DESCRIPTION
This PR corrects the formatting of a non-executable block of code in [this tutorial](https://pytorch.org/tutorials/beginner/introyt/trainingyt.html). 

Previously, the code is rendered correctly in the html, but shows up as follows in the notebook file (screenshot from Colab):

<img width="733" alt="Screenshot 2023-02-15 at 2 40 37 PM" src="https://user-images.githubusercontent.com/31816267/219151270-6587e356-c1e5-4e98-9888-66827c7087bf.png">

With these changes the same block is displayed correctly. The block should remain non-executable, as it is given as an example only and `PATH` is not defined earlier.

Alternatively, I could change the `PATH` variable to `model_path` and change the block into an executable one, but this concept is covered in other tutorials so this may be unnecessary.

cc @suraj813