### PR TITLE
Make 1st worker gpu.nvidia.medium resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,7 @@ jobs:
     resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_pr_build_worker_1:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.medium
   pytorch_tutorial_pr_build_worker_10:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_pr_build_worker_11:
@@ -234,6 +235,7 @@ jobs:
     resource_class: gpu.nvidia.small.multi
   pytorch_tutorial_trunk_build_worker_1:
     <<: *pytorch_tutorial_build_worker_defaults
+    resource_class: gpu.nvidia.medium
   pytorch_tutorial_trunk_build_worker_10:
     <<: *pytorch_tutorial_build_worker_defaults
   pytorch_tutorial_trunk_build_worker_11:

--- a/.circleci/regenerate.py
+++ b/.circleci/regenerate.py
@@ -26,9 +26,11 @@ def indent(indentation, data_list):
 def jobs(pr_or_trunk, num_workers=20, indentation=2):
     jobs = {}
 
-    # all tutorials that need gpu.nvidia.small.multi machines will be routed
-    # by get_files_to_run.py to 0th worker
+    # all tutorials that need gpu.nvidia.small.multi machines will be routed by
+    # get_files_to_run.py to 0th worker, similarly for gpu.nvidia.medium and the
+    # 1st worker
     needs_gpu_nvidia_small_multi = [0]
+    needs_gpu_nvidia_medium = [1]
     jobs[f"pytorch_tutorial_{pr_or_trunk}_build_manager"] = {
         "<<": "*pytorch_tutorial_build_manager_defaults"
     }
@@ -36,6 +38,8 @@ def jobs(pr_or_trunk, num_workers=20, indentation=2):
         job_info = {"<<": "*pytorch_tutorial_build_worker_defaults"}
         if i in needs_gpu_nvidia_small_multi:
             job_info["resource_class"] = "gpu.nvidia.small.multi"
+        if i in needs_gpu_nvidia_medium:
+            job_info["resource_class"] = "gpu.nvidia.medium"
         jobs[f"pytorch_tutorial_{pr_or_trunk}_build_worker_{i}"] = job_info
 
     return indent(indentation, jobs).replace("'", "")

--- a/.jenkins/get_files_to_run.py
+++ b/.jenkins/get_files_to_run.py
@@ -39,15 +39,23 @@ def calculate_shards(all_files: List[str], num_shards: int = 20) -> List[List[st
             shard_jobs,
         )
 
+    all_other_files = all_files.copy()
     needs_gpu_nvidia_small_multi = list(
         filter(lambda x: get_needs_machine(x) == "gpu.nvidia.small.multi", all_files,)
+    )
+    needs_gpu_nvidia_medium = list(
+        filter(lambda x: get_needs_machine(x) == "gpu.nvidia.medium", all_files,)
     )
     for filename in needs_gpu_nvidia_small_multi:
         # currently, the only job that uses gpu.nvidia.small.multi is the 0th worker,
         # so we'll add all the jobs that need this machine to the 0th worker
         add_to_shard(0, filename)
-
-    all_other_files = [x for x in all_files if x not in needs_gpu_nvidia_small_multi]
+        all_other_files.remove(filename)
+    for filename in needs_gpu_nvidia_medium:
+        # currently, the only job that uses gpu.nvidia.medium is the 1st worker,
+        # so we'll add all the jobs that need this machine to the 1st worker
+        add_to_shard(1, filename)
+        all_other_files.remove(filename)
 
     sorted_files = sorted(all_other_files, key=get_duration, reverse=True,)
 

--- a/.jenkins/metadata.json
+++ b/.jenkins/metadata.json
@@ -25,7 +25,7 @@
   "intermediate_source/model_parallel_tutorial.py": {
     "needs": "gpu.nvidia.small.multi"
   },
-  "torch_compile_tutorial_.py": {
+  "intermediate_source/torch_compile_tutorial_.py": {
     "needs": "gpu.nvidia.medium"
   }
 }

--- a/.jenkins/metadata.json
+++ b/.jenkins/metadata.json
@@ -25,7 +25,7 @@
   "intermediate_source/model_parallel_tutorial.py": {
     "needs": "gpu.nvidia.small.multi"
   },
-  "intermediate_source/torch_compile_tutorial_.py": {
+  "intermediate_source/torch_compile_tutorial.py": {
     "needs": "gpu.nvidia.medium"
   }
 }

--- a/.jenkins/metadata.json
+++ b/.jenkins/metadata.json
@@ -24,5 +24,8 @@
   },
   "intermediate_source/model_parallel_tutorial.py": {
     "needs": "gpu.nvidia.small.multi"
+  },
+  "torch_compile_tutorial_.py": {
+    "needs": "gpu.nvidia.medium"
   }
 }


### PR DESCRIPTION
`torch_compile_tutorial_.py` requires a gpu with capability > 7.1
```
Feb 28 00:20:45 torch._dynamo.exc.BackendCompilerFailed: debug_wrapper raised RuntimeError: Found Tesla P4 which is too old to be supported by the triton GPU compiler, which is used as the backend. Triton only supports devices of CUDA Capability >= 7.0, but your device is of CUDA capability 6.1
``` 
https://app.circleci.com/pipelines/github/pytorch/tutorials/7439/workflows/fffc8c6e-7f15-4b5b-b843-36d3e7969395/jobs/145263

gpu.nvidia.small has a Tesla P4, which has a compute capability of 6.1, so the PR switches the file to run on gpu.nvidia.medium, which has a Test T4 and a compute capability of 7.5 (https://developer.nvidia.com/cuda-gpus#compute)

This tutorial is actually on the NOT_RUN list, so I'm not actually sure how to test

Should help https://github.com/pytorch/tutorials/pull/2224 pass CI