### PR TITLE
Fix command line example formatting by using literal block

### DIFF
--- a/beginner_source/introyt/captumyt.py
+++ b/beginner_source/introyt/captumyt.py
@@ -106,13 +106,13 @@ Before you get started, you need to have a Python environment with:
 To install Captum in an Anaconda or pip virtual environment, use the
 appropriate command for your environment below:
 
-With ``conda``:
+With ``conda``::
 
-``conda install pytorch torchvision captum -c pytorch``
+    conda install pytorch torchvision captum -c pytorch
 
-With ``pip``:
+With ``pip``::
 
-``pip install torch torchvision captum``
+    pip install torch torchvision captum
 
 Restart this notebook in the environment you set up, and you’re ready to
 go!

--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -24,14 +24,14 @@ Before You Start
 To run this tutorial, you’ll need to install PyTorch, TorchVision,
 Matplotlib, and TensorBoard.
 
-With ``conda``:
+With ``conda``::
 
-``conda install pytorch torchvision -c pytorch``
-``conda install matplotlib tensorboard``
+    conda install pytorch torchvision -c pytorch
+    conda install matplotlib tensorboard
 
-With ``pip``:
+With ``pip``::
 
-``pip install torch torchvision matplotlib tensorboard``
+    pip install torch torchvision matplotlib tensorboard
 
 Once the dependencies are installed, restart this notebook in the Python
 environment where you installed them.


### PR DESCRIPTION
This properly formats multi-line commands.

cc @suraj813 @svekars @carljparker