### PR TITLE
Include introyt/trainingyt tutorial in the build

### DIFF
--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -14,7 +14,6 @@ NOT_RUN = [
     "profiler",
     "saving_loading_models",
     "introyt/captumyt",
-    "introyt/trainingyt",
     "examples_nn/polynomial_module",
     "examples_nn/dynamic_net",
     "examples_nn/polynomial_optim",

--- a/beginner_source/introyt/trainingyt.py
+++ b/beginner_source/introyt/trainingyt.py
@@ -81,8 +81,8 @@ training_set = torchvision.datasets.FashionMNIST('./data', train=True, transform
 validation_set = torchvision.datasets.FashionMNIST('./data', train=False, transform=transform, download=True)
 
 # Create data loaders for our datasets; shuffle for training, not for validation
-training_loader = torch.utils.data.DataLoader(training_set, batch_size=4, shuffle=True, num_workers=2)
-validation_loader = torch.utils.data.DataLoader(validation_set, batch_size=4, shuffle=False, num_workers=2)
+training_loader = torch.utils.data.DataLoader(training_set, batch_size=4, shuffle=True)
+validation_loader = torch.utils.data.DataLoader(validation_set, batch_size=4, shuffle=False)
 
 # Class labels
 classes = ('T-shirt/top', 'Trouser', 'Pullover', 'Dress', 'Coat',


### PR DESCRIPTION
Include introyt/trainingyt tutorial in the build

The tutorial was not being built and published on the website.
So fixes such as 7d8cb43 were not then visible on the website since old
output files are still present.