### PR TITLE
Typo in tensorqs_tutorial.py

### DIFF
--- a/beginner_source/basics/tensorqs_tutorial.py
+++ b/beginner_source/basics/tensorqs_tutorial.py
@@ -133,7 +133,7 @@ print(tensor)
 ######################################################################
 # **Joining tensors** You can use ``torch.cat`` to concatenate a sequence of tensors along a given dimension.
 # See also `torch.stack <https://pytorch.org/docs/stable/generated/torch.stack.html>`__,
-# another tensor joining op that is subtly different from ``torch.cat``.
+# another tensor joining option that is subtly different from ``torch.cat``.
 t1 = torch.cat([tensor, tensor, tensor], dim=1)
 print(t1)
 


### PR DESCRIPTION
Looks like "op" should be "option" here

cc @svekars @carljparker