### PR TITLE
Fix forward mode ad tutorial by updating stateless import

### DIFF
--- a/intermediate_source/forward_ad_usage.py
+++ b/intermediate_source/forward_ad_usage.py
@@ -100,13 +100,12 @@ with fwAD.dual_level():
     jvp = fwAD.unpack_dual(out).tangent
 
 ######################################################################
-# Using Modules stateless API (experimental)
+# Using the functional Module API (beta)
 # --------------------------------------------------------------------
 # Another way to use ``nn.Module`` with forward AD is to utilize
-# the stateless API. NB: At the time of writing the stateless API is still
-# experimental and may be subject to change.
+# the functional Module API (also known as the stateless Module API).
 
-from torch.nn.utils._stateless import functional_call
+from torch.func import functional_call
 
 # We need a fresh module because the functional call requires the
 # the model to have parameters registered.


### PR DESCRIPTION
Updated the import from the now deleted torch.nn.utils._stateless to torch.func

Fixes https://github.com/pytorch/tutorials/issues/2218

Test Plan:
- tested locally