### PR TITLE
Use extra index to download pytorch binaries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://download.pytorch.org/whl/cu117/index.html
 # Refer to ./jenkins/build.sh for tutorial build instructions
 
 sphinx==5.0.0


### PR DESCRIPTION
To allow us to pick up changes from our own index before having to publish to PyPI