### PR TITLE
Update mnist_train_nas script for PyTorch Lightning 2.0 API

### DIFF
--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -49,7 +49,6 @@ NOT_RUN = [
     "recipes_source/recipes/Captum_Recipe",
     "intermediate_source/flask_rest_api_tutorial",
     "intermediate_source/text_to_speech_with_torchaudio",
-    "intermediate_source/ax_multiobjective_nas_tutorial",
     "intermediate_source/tensorboard_profiler_tutorial" # reenable after 2.0 release.
 ]
 

--- a/intermediate_source/mnist_train_nas.py
+++ b/intermediate_source/mnist_train_nas.py
@@ -44,7 +44,6 @@ def parse_args():
 args = parse_args()
 
 PATH_DATASETS = os.environ.get("PATH_DATASETS", ".")
-AVAIL_GPUS = min(1, torch.cuda.device_count())
 
 
 class MnistModel(LightningModule):
@@ -136,7 +135,6 @@ def run_training_job():
     # Initialize a trainer (don't log anything since things get so slow...)
     trainer = Trainer(
         logger=False,
-        gpus=AVAIL_GPUS,
         max_epochs=args.epochs,
         enable_progress_bar=False,
         deterministic=True,  # Do we want a bit of noise?


### PR DESCRIPTION
PyTorch lightning 2.0 has a different `Trainer` API which breaks the current training script used in the `ax_multiobjective_nas_tutorial`. Looks like the `pytorch-lightning` dep is not pinned, and so the setup should use the 2.0 version. 

This PR updates the callsite to avoid this breakage.

cc @dme65