### PR TITLE
add : torchserve version required for multi-worker in ipex

### DIFF
--- a/intermediate_source/torchserve_with_ipex.rst
+++ b/intermediate_source/torchserve_with_ipex.rst
@@ -204,7 +204,7 @@ We'll compare the following three configurations:
 
 (2) `torch.set_num_threads <https://pytorch.org/docs/stable/generated/torch.set_num_threads.html>`_ = ``number of physical cores / number of workers`` (no core pinning)
 
-(3) core pinning via the launch script 
+(3) core pinning via the launch script (Required Torchserve>=0.6.1)
 
 After this exercise, we'll have verified that we prefer avoiding logical cores and prefer local memory access via core pinning with a real TorchServe use case. 
 


### PR DESCRIPTION
It would be good if the multi-worker inference specifies the Torchserve version that can apply ipex.

Related Issues : https://github.com/intel/intel-extension-for-pytorch/issues/323#issuecomment-1502895640

cc @msaroufim