### PR TITLE
Fix image URL in tutorial Intro_to_TorchScript

### DIFF
--- a/beginner_source/Intro_to_TorchScript_tutorial.py
+++ b/beginner_source/Intro_to_TorchScript_tutorial.py
@@ -158,7 +158,7 @@ print(my_cell(x, h))
 # have to explicitly define derivatives for all constructs in the
 # language.
 #
-# .. figure:: https://github.com/pytorch/pytorch/raw/master/docs/source/_static/img/dynamic_graph.gif
+# .. figure:: https://github.com/pytorch/pytorch/raw/main/docs/source/_static/img/dynamic_graph.gif
 #    :alt: How autograd works
 #
 #    How autograd works


### PR DESCRIPTION
Fix url to this GIF: https://raw.githubusercontent.com/pytorch/pytorch/main/docs/source/_static/img/dynamic_graph.gif

Currently, the image is not shown in the tutorial.