### PR TITLE
FIX: add neccessary backticks (#2309)

### DIFF
--- a/beginner_source/basics/saveloadrun_tutorial.py
+++ b/beginner_source/basics/saveloadrun_tutorial.py
@@ -33,7 +33,7 @@ torch.save(model.state_dict(), 'model_weights.pth')
 # To load model weights, you need to create an instance of the same model first, and then load the parameters
 # using ``load_state_dict()`` method.
 
-model = models.vgg16() # we do not specify weights, i.e. create untrained model
+model = models.vgg16() # we do not specify ``weights``, i.e. create untrained model
 model.load_state_dict(torch.load('model_weights.pth'))
 model.eval()
 

--- a/beginner_source/transformer_tutorial.py
+++ b/beginner_source/transformer_tutorial.py
@@ -135,7 +135,7 @@ class PositionalEncoding(nn.Module):
 
 ######################################################################
 # This tutorial uses ``torchtext`` to generate Wikitext-2 dataset.
-# To access torchtext datasets, please install torchdata following instructions at https://github.com/pytorch/data. 
+# To access torchtext datasets, please install torchdata following instructions at https://github.com/pytorch/data.
 # %%
 #  .. code-block:: bash
 #
@@ -175,7 +175,7 @@ from torchtext.vocab import build_vocab_from_iterator
 train_iter = WikiText2(split='train')
 tokenizer = get_tokenizer('basic_english')
 vocab = build_vocab_from_iterator(map(tokenizer, train_iter), specials=['<unk>'])
-vocab.set_default_index(vocab['<unk>']) 
+vocab.set_default_index(vocab['<unk>'])
 
 def data_process(raw_text_iter: dataset.IterableDataset) -> Tensor:
     """Converts raw text into a flat Tensor."""
@@ -196,7 +196,7 @@ def batchify(data: Tensor, bsz: int) -> Tensor:
     that wouldn't cleanly fit.
 
     Arguments:
-        data: Tensor, shape [N]
+        data: Tensor, shape ``[N]``
         bsz: int, batch size
 
     Returns:


### PR DESCRIPTION
As I reported #2309, I've added backticks to two tutorials, one in each place.
(Additionally, 2 more trailing spaces were removed).

Please review this PR. 😸 