### PR TITLE
Fix formatting in the FX Graph Mode Quantization guide

### DIFF
--- a/prototype_source/fx_graph_mode_quant_guide.rst
+++ b/prototype_source/fx_graph_mode_quant_guide.rst
@@ -26,7 +26,7 @@ If the code that is not symbolically traceable does not need to be quantized, we
 to run FX Graph Mode Quantization:
 
 
-a. Symbolically trace only the code that needs to be quantized
+Symbolically trace only the code that needs to be quantized
 -----------------------------------------------------------------
 When the whole model is not symbolically traceable but the submodule we want to quantize is
 symbolically traceable, we can run quantization only on that submodule.
@@ -71,7 +71,7 @@ Note if original model needs to be preserved, you will have to
 copy it yourself before calling the quantization APIs.
 
 
-b. Skip symbolically trace the non-traceable code
+Skip symbolically trace the non-traceable code
 ---------------------------------------------------
 When we have some non-traceable code in the module, and this part of code doesn’t need to be quantized,
 we can factor out this part of the code into a submodule and skip symbolically trace that submodule.
@@ -135,7 +135,7 @@ quantization code:
 
 If the code that is not symbolically traceable needs to be quantized, we have the following two options:
 
-a. Refactor your code to make it symbolically traceable
+Refactor your code to make it symbolically traceable
 --------------------------------------------------------
 If it is easy to refactor the code and make the code symbolically traceable,
 we can refactor the code and remove the use of non-traceable constructs in python.
@@ -174,7 +174,7 @@ depends on the model.
 
 
 
-b. Write your own observed and quantized submodule
+Write your own observed and quantized submodule
 -----------------------------------------------------
 
 If the non-traceable code can’t be refactored to be symbolically traceable,

--- a/prototype_source/fx_graph_mode_quant_guide.rst
+++ b/prototype_source/fx_graph_mode_quant_guide.rst
@@ -22,10 +22,11 @@ You can use any combination of these options:
     b. Write your own observed and quantized submodule
 
 
-####################################################################
 If the code that is not symbolically traceable does not need to be quantized, we have the following two options
 to run FX Graph Mode Quantization:
-1.a. Symbolically trace only the code that needs to be quantized
+
+
+a. Symbolically trace only the code that needs to be quantized
 -----------------------------------------------------------------
 When the whole model is not symbolically traceable but the submodule we want to quantize is
 symbolically traceable, we can run quantization only on that submodule.
@@ -69,8 +70,7 @@ Note if original model needs to be preserved, you will have to
 copy it yourself before calling the quantization APIs.
 
 
-#####################################################
-1.b. Skip symbolically trace the non-traceable code
+b. Skip symbolically trace the non-traceable code
 ---------------------------------------------------
 When we have some non-traceable code in the module, and this part of code doesn’t need to be quantized,
 we can factor out this part of the code into a submodule and skip symbolically trace that submodule.
@@ -134,8 +134,7 @@ quantization code:
 
 If the code that is not symbolically traceable needs to be quantized, we have the following two options:
 
-##########################################################
-2.a Refactor your code to make it symbolically traceable
+a. Refactor your code to make it symbolically traceable
 --------------------------------------------------------
 If it is easy to refactor the code and make the code symbolically traceable,
 we can refactor the code and remove the use of non-traceable constructs in python.
@@ -174,8 +173,7 @@ depends on the model.
 
 
 
-#######################################################
-2.b. Write your own observed and quantized submodule
+b. Write your own observed and quantized submodule
 -----------------------------------------------------
 
 If the non-traceable code can’t be refactored to be symbolically traceable,

--- a/prototype_source/fx_graph_mode_quant_guide.rst
+++ b/prototype_source/fx_graph_mode_quant_guide.rst
@@ -30,6 +30,7 @@ Symbolically trace only the code that needs to be quantized
 -----------------------------------------------------------------
 When the whole model is not symbolically traceable but the submodule we want to quantize is
 symbolically traceable, we can run quantization only on that submodule.
+
 before:
 
 .. code:: python
@@ -44,6 +45,7 @@ before:
 after:
 
 .. code:: python
+    
   class FP32Traceable(nn.Module):
       def forward(self, x):
           x = traceable_code(x)

--- a/prototype_source/fx_graph_mode_quant_guide.rst
+++ b/prototype_source/fx_graph_mode_quant_guide.rst
@@ -4,7 +4,7 @@
 **Author**: `Jerry Zhang <https://github.com/jerryzh168>`_
 
 FX Graph Mode Quantization requires a symbolically traceable model.
-We use the FX framework (TODO: link) to convert a symbolically traceable nn.Module instance to IR,
+We use the FX framework to convert a symbolically traceable nn.Module instance to IR,
 and we operate on the IR to execute the quantization passes.
 Please post your question about symbolically tracing your model in `PyTorch Discussion Forum <https://discuss.pytorch.org/c/quantization/17>`_
 

--- a/prototype_source/fx_graph_mode_quant_guide.rst
+++ b/prototype_source/fx_graph_mode_quant_guide.rst
@@ -33,6 +33,7 @@ symbolically traceable, we can run quantization only on that submodule.
 before:
 
 .. code:: python
+
   class M(nn.Module):
       def forward(self, x):
           x = non_traceable_code_1(x)

--- a/prototype_source/fx_graph_mode_quant_guide.rst
+++ b/prototype_source/fx_graph_mode_quant_guide.rst
@@ -205,8 +205,8 @@ non-traceable logic, wrapped in a module
   class FP32NonTraceable:
       ...
 
-
-2. Define observed version of FP32NonTraceable
+2. Define observed version of
+FP32NonTraceable
 
 .. code:: python
 

--- a/prototype_source/fx_graph_mode_quant_guide.rst
+++ b/prototype_source/fx_graph_mode_quant_guide.rst
@@ -169,12 +169,8 @@ after:
       return x.permute(0, 2, 1, 3)
 
 
-quantization code:
-
 This can be combined with other approaches and the quantization code
 depends on the model.
-
-
 
 Write your own observed and quantized submodule
 -----------------------------------------------------


### PR DESCRIPTION
Fixes #2337

## Description
Fix formatting in the tutorial: https://pytorch.org/tutorials/prototype/fx_graph_mode_quant_guide

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] Remove the extraneous ###### lines
- [x] Remove numbering from the headings.
- [x] Add line breaks where needed
- [x] Make editorial changes as needed.


cc @svekars @carljparker