### PR TITLE
Added matplotlib dependency to blitz tutorial

### DIFF
--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -94,14 +94,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # functions to show an image
-
-
 def imshow(img):
     img = img / 2 + 0.5     # unnormalize
     npimg = img.numpy()
     plt.imshow(np.transpose(npimg, (1, 2, 0)))
     plt.show()
-
 
 # get some random training images
 dataiter = iter(trainloader)

--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -94,11 +94,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # functions to show an image
+
+
 def imshow(img):
     img = img / 2 + 0.5     # unnormalize
     npimg = img.numpy()
     plt.imshow(np.transpose(npimg, (1, 2, 0)))
     plt.show()
+
 
 # get some random training images
 dataiter = iter(trainloader)

--- a/beginner_source/deep_learning_60min_blitz.rst
+++ b/beginner_source/deep_learning_60min_blitz.rst
@@ -20,11 +20,12 @@ Goal of this tutorial:
 - Understand PyTorch’s Tensor library and neural networks at a high level.
 - Train a small neural network to classify images
 
-To run the tutorials below, make sure you have the `torch`_ and `torchvision`_
-packages installed.
+To run the tutorials below, make sure you have the `torch`_, `torchvision`_,
+and `matplotlib`_ packages installed.
 
 .. _torch: https://github.com/pytorch/pytorch
 .. _torchvision: https://github.com/pytorch/vision
+.. _matplotlib: https://github.com/matplotlib/matplotlib
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Fixes #940 

## Description
Added matplotlib to the list of necessary packages for running the tutorials in "Deep Learning with Pytorch: A 60 Minute Blitz". The "Training a Classifier" tutorial requires matplotlib package for showing training images.
https://pytorch.org/tutorials/beginner/deep_learning_60min_blitz.html

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnessessary issues are included into this pull request.
