### PR TITLE
Update super_resolution_with_onnxruntime.py

### DIFF
--- a/advanced_source/super_resolution_with_onnxruntime.py
+++ b/advanced_source/super_resolution_with_onnxruntime.py
@@ -16,10 +16,7 @@ For this tutorial, you will need to install `ONNX <https://github.com/onnx/onnx>
 and `ONNX Runtime <https://github.com/microsoft/onnxruntime>`__.
 You can get binary builds of ONNX and ONNX Runtime with
 ``pip install onnx onnxruntime``.
-Note that ONNX Runtime is compatible with Python versions 3.5 to 3.7.
-
-``NOTE``: This tutorial needs PyTorch master branch which can be installed by following
-the instructions `here <https://github.com/pytorch/pytorch#from-source>`__
+ONNX Runtime recommends using the latest stable runtime for PyTorch.
 
 """
 


### PR DESCRIPTION
Fix for #1781
"tutorials/advanced_source/super_resolution_with_onnxruntime.py is maybe outdated?"

References to requirements are out of date according to ONNX documentation (https://onnxruntime.ai/docs/reference/compatibility.html) which recommends the latest stable PyTorch version. 

Rather than manually update the version number with the current stable version (e.g., 2.0.1), as long as ONNX maintains compatibility with the lastest stable version that reference should be sufficient and constantly up to date.

Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnessessary issues are included into this pull request.
