### PR TITLE
Add model.eval() in neural_style_tutorial.py

### DIFF
--- a/advanced_source/neural_style_tutorial.py
+++ b/advanced_source/neural_style_tutorial.py
@@ -423,6 +423,9 @@ def run_style_transfer(cnn, normalization_mean, normalization_std,
     # We want to optimize the input and not the model parameters so we
     # update all the requires_grad fields accordingly
     input_img.requires_grad_(True)
+    # We also put the model in evaluation mode, so that specific layers 
+    # such as dropout or batch normalization layers behave correctly. 
+    model.eval()
     model.requires_grad_(False)
 
     optimizer = get_input_optimizer(input_img)


### PR DESCRIPTION
Fixes #1736 

## Description
Set model to evaluation mode along with requires_grad_(False) in Neural Style Transfer tutorial.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnessessary issues are included into this pull request.
