### PR TITLE
Optimize DataLoader iteration in WrappedDataLoader

### DIFF
--- a/beginner_source/nn_tutorial.py
+++ b/beginner_source/nn_tutorial.py
@@ -790,8 +790,7 @@ class WrappedDataLoader:
         return len(self.dl)
 
     def __iter__(self):
-        batches = iter(self.dl)
-        for b in batches:
+        for b in self.dl:
             yield (self.func(*b))
 
 train_dl, valid_dl = get_data(train_ds, valid_ds, bs)


### PR DESCRIPTION
Fixes #1757 

## Description

The commit removes redundant iter() calls in the WrappedDataLoader class, optimizing the iteration process. Previously, iter() was called when initializing the iterator and again within the for loop, which was unnecessary. The code is now clearer and more efficient by eliminating the redundant call.

Previously
```python
def __iter__(self):
        batches = iter(self.dl)
        for b in batches:
            yield (self.func(*b))
```

Modified
```python
def __iter__(self):
        for b in self.dl:
            yield (self.func(*b))
```

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred to in the description (see above "Fixes #1757")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included in this pull request.


cc @suraj813 @svekars 