### PR TITLE
Qasim fix typo transformer tutorial

### DIFF
--- a/beginner_source/transformer_tutorial.py
+++ b/beginner_source/transformer_tutorial.py
@@ -149,7 +149,7 @@ class PositionalEncoding(nn.Module):
 # into ``batch_size`` columns. If the data does not divide evenly into
 # ``batch_size`` columns, then the data is trimmed to fit. For instance, with
 # the alphabet as the sequence (total length of 26) and a batch size of 4, 
-# we would divide the letters into sequences of length 6, resulting in 4 such sequences:
+# we would divide the alphabet into sequences of length 6, resulting in 4 such sequences:
 #
 # .. math::
 #   \begin{bmatrix}

--- a/beginner_source/transformer_tutorial.py
+++ b/beginner_source/transformer_tutorial.py
@@ -148,7 +148,7 @@ class PositionalEncoding(nn.Module):
 # Given a 1-D vector of sequential data, ``batchify()`` arranges the data
 # into ``batch_size`` columns. If the data does not divide evenly into
 # ``batch_size`` columns, then the data is trimmed to fit. For instance, with
-# the alphabet as the data (total length of 26) and `batch_size=4`, we would
+# the alphabet as the data (total length of 26) and ``batch_size=4``, we would
 # divide the alphabet into sequences of length 6, resulting in 4 such sequences:
 #
 # .. math::

--- a/beginner_source/transformer_tutorial.py
+++ b/beginner_source/transformer_tutorial.py
@@ -148,7 +148,7 @@ class PositionalEncoding(nn.Module):
 # Given a 1-D vector of sequential data, ``batchify()`` arranges the data
 # into ``batch_size`` columns. If the data does not divide evenly into
 # ``batch_size`` columns, then the data is trimmed to fit. For instance, with
-# the alphabet as the sequence (total length of 26) and a batch size of 4, 
+# the alphabet as the data (total length of 26) and a batch size of 4, 
 # we would divide the alphabet into sequences of length 6, resulting in 4 such sequences:
 #
 # .. math::

--- a/beginner_source/transformer_tutorial.py
+++ b/beginner_source/transformer_tutorial.py
@@ -148,8 +148,8 @@ class PositionalEncoding(nn.Module):
 # Given a 1-D vector of sequential data, ``batchify()`` arranges the data
 # into ``batch_size`` columns. If the data does not divide evenly into
 # ``batch_size`` columns, then the data is trimmed to fit. For instance, with
-# the alphabet as the data (total length of 26) and a batch size of 4, 
-# we would divide the alphabet into sequences of length 6, resulting in 4 such sequences:
+# the alphabet as the data (total length of 26) and `batch_size=4`, we would
+# divide the alphabet into sequences of length 6, resulting in 4 such sequences:
 #
 # .. math::
 #   \begin{bmatrix}

--- a/beginner_source/transformer_tutorial.py
+++ b/beginner_source/transformer_tutorial.py
@@ -148,8 +148,8 @@ class PositionalEncoding(nn.Module):
 # Given a 1-D vector of sequential data, ``batchify()`` arranges the data
 # into ``batch_size`` columns. If the data does not divide evenly into
 # ``batch_size`` columns, then the data is trimmed to fit. For instance, with
-# the alphabet as the data (total length of 26) and ``batch_size=4``, we would
-# divide the alphabet into 4 sequences of length 6:
+# the alphabet as the sequence (total length of 26) and a batch size of 4, 
+# we would divide the letters into sequences of length 6, resulting in 4 such sequences:
 #
 # .. math::
 #   \begin{bmatrix}


### PR DESCRIPTION
Fixes #1037 

## Description
Changed the text,

> we would divide the alphabet into 4 sequences of length 6

to 

> we would divide the alphabet into sequences of length 6, resulting in 4 such sequences

With this, the reader knows that a tensor of shape (seq_length, batch_size) is being created, consistent with the shape of the tensor returned by the `batchify` function