### PR TITLE
Change batchify desc to remove ambiguity

### DIFF
--- a/beginner_source/transformer_tutorial.py
+++ b/beginner_source/transformer_tutorial.py
@@ -149,7 +149,7 @@ class PositionalEncoding(nn.Module):
 # into ``batch_size`` columns. If the data does not divide evenly into
 # ``batch_size`` columns, then the data is trimmed to fit. For instance, with
 # the alphabet as the data (total length of 26) and ``batch_size=4``, we would
-# divide the alphabet into 4 sequences of length 6:
+# divide the alphabet into sequences of length 6, resulting in 4 of such sequences.
 #
 # .. math::
 #   \begin{bmatrix}


### PR DESCRIPTION
Fixes #1037 

## Description
Changed the text,

> we would divide the alphabet into 4 sequences of length 6

to 

> we would divide the alphabet into sequences of length 6, resulting in 4 such sequences

With this, the reader knows that a tensor of shape (seq_length, batch_size) is being created, which is consistent with the shape of the tensor returned by the `batchify` function