### PR TITLE
Fix cropping to include last column and last row

### DIFF
--- a/beginner_source/data_loading_tutorial.py
+++ b/beginner_source/data_loading_tutorial.py
@@ -268,8 +268,8 @@ class RandomCrop(object):
         h, w = image.shape[:2]
         new_h, new_w = self.output_size
 
-        top = np.random.randint(0, h - new_h)
-        left = np.random.randint(0, w - new_w)
+        top = np.random.randint(0, h - new_h + 1)
+        left = np.random.randint(0, w - new_w + 1)
 
         image = image[top: top + new_h,
                       left: left + new_w]
@@ -294,7 +294,7 @@ class ToTensor(object):
 
 ######################################################################
 # .. note::
-#     In the example above, `RandomCrop` uses an external library's random number generator 
+#     In the example above, `RandomCrop` uses an external library's random number generator
 #     (in this case, Numpy's `np.random.int`). This can result in unexpected behavior with `DataLoader`
 #     (see `here <https://pytorch.org/docs/stable/notes/faq.html#my-data-loader-workers-return-identical-random-numbers>`_).
 #     In practice, it is safer to stick to PyTorch's random number generator, e.g. by using `torch.randint` instead.


### PR DESCRIPTION
Fixes #876

## Description

I have updated image cropping lines to include last row and column. Earlier the top index was from `[0, h - new_h)` where `h` is the height of the image and `new_h` is the height of the cropped image. 

Consider a case where `new_h = 3` and `h = 4`. In this case, top index can only be 0 and hence the last row will never get started. To fix this, I have updated `np.random.randint` to sample from `[0, h - new_h + 1)` for choosing last row and for chosing last column, I have update the func to sample from `[0, w - new_w + 1)`
 
## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnessessary issues are included into this pull request.
