### PR TITLE
Fix tutorial to avoid use of copy.deepcopy()- FX Graph Mode 

### DIFF
--- a/prototype_source/fx_graph_mode_ptq_static.rst
+++ b/prototype_source/fx_graph_mode_ptq_static.rst
@@ -214,9 +214,9 @@ Download the `torchvision resnet18 model <https://download.pytorch.org/models/re
     float_model = load_model(saved_model_dir + float_model_file).to("cpu")
     float_model.eval()
 
-    # deepcopy the model since we need to keep the original model around
-    import copy
-    model_to_quantize = copy.deepcopy(float_model)
+    # create another instance of the model since
+    # we need to keep the original model around
+    model_to_quantize = load_model(saved_model_dir + float_model_file).to("cpu")
 
 3. Set model to eval mode
 -------------------------


### PR DESCRIPTION
Fixes #2177 

## Description

Removed the use of `deepcopy.copy` to copy the `float_model`. Instead, used `load_model` to create another instance of the model, i.e., `model_to_quantize = load_model(saved_model_dir + float_model_file).to("cpu")` instead of `model_to_quantize = copy.deepcopy(float_model)`

Used `load_model` to create the copy because `float_model` is also being created using `load_model`
