### PR TITLE
Changed the use of Deepcopy to keep the original model to torch.save(…

### DIFF
--- a/prototype_source/fx_graph_mode_ptq_dynamic.py
+++ b/prototype_source/fx_graph_mode_ptq_dynamic.py
@@ -238,9 +238,9 @@ qconfig_mapping = (QConfigMapping()
     .set_object_type(nn.LSTM, default_dynamic_qconfig)
     .set_object_type(nn.Linear, default_dynamic_qconfig)
 )
-# Deepcopying the original model because quantization api changes the model inplace and we want
+# Saving the original model because quantization api changes the model inplace and we want
 # to keep the original model for future comparison
-model_to_quantize = copy.deepcopy(model)
+model_to_quantize = torch.save(model)
 prepared_model = prepare_fx(model_to_quantize, qconfig_mapping, example_inputs)
 print("prepared model:", prepared_model)
 quantized_model = convert_fx(prepared_model)


### PR DESCRIPTION
…) to save the original model for future comparision

Fixes #2334

## Description
I changed the use of deepcopy.copy to torch.save, to create a copy of the original torch model

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x ] Only one issue is addressed in this pull request
- [x ] Labels from the issue that this PR is fixing are added to this pull request
- [x ] No unnessessary issues are included into this pull request.
@docathon-h1-2023 #docathon-h1-2023