### PR TITLE
Fixes module 'get_filesystem' error

### DIFF
--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -66,7 +66,7 @@ from torch.utils.tensorboard import SummaryWriter
 
 # In case you are using an environment that has TensorFlow installed,
 # such as Google Colab, uncomment the following code to avoid
-# a bug with saving embeddings to your tensorboard directory
+# a bug with saving embeddings to your TensorBoard directory
 
 # import tensorflow as tf
 # import tensorboard as tb

--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -64,6 +64,13 @@ import numpy as np
 # PyTorch TensorBoard support
 from torch.utils.tensorboard import SummaryWriter
 
+# In case you are using an environment that has TensorFlow installed,
+# such as Google Colab, uncomment the following code to avoid
+# a bug with saving embeddings to your tensorboard directory
+
+# import tensorflow as tf
+# import tensorboard as tb
+# tf.io.gfile = tb.compat.tensorflow_stub.io.gfile
 
 ######################################################################
 # Showing Images in TensorBoard


### PR DESCRIPTION
Fixes #1919 

## Description

The following error occurs when running the notebook in Google Colab (which has TensorFlow installed):

    ---------------------------------------------------------------------------
    AttributeError                            Traceback (most recent call last)
    [<ipython-input-9-cff6eb059fb9>](https://localhost:8080/#) in <module>()
         16 writer.add_embedding(features,
         17                     metadata=class_labels,
    ---> 18                     label_img=images.unsqueeze(1))
         19 writer.flush()
         20 writer.close()
    
    [/usr/local/lib/python3.7/dist-packages/torch/utils/tensorboard/writer.py](https://localhost:8080/#) in add_embedding(self, mat, metadata, label_img, global_step, tag, metadata_header)
        808         save_path = os.path.join(self._get_file_writer().get_logdir(), subdir)
        809 
    --> 810         fs = tf.io.gfile.get_filesystem(save_path)
        811         if fs.exists(save_path):
        812             if fs.isdir(save_path):
    
    AttributeError: module 'tensorflow._api.v2.io.gfile' has no attribute 'get_filesystem'
    
The proposed (temporary) fix is to add the following code:

    import tensorflow as tf
    import tensorboard as tb
    tf.io.gfile = tb.compat.tensorflow_stub.io.gfile
    
I added the code and a helpful comment, but kept the code commented to ensure it only needs to be executed by users running in Colab or other TensorFlow-enabled environments. This approach avoids introducing unnecessary dependencies.

cc @aaronenyeshi @chaekit