### PR TITLE
Change formatting of code blocks in Tensorboard profiler tutorial

### DIFF
--- a/intermediate_source/tensorboard_profiler_tutorial.py
+++ b/intermediate_source/tensorboard_profiler_tutorial.py
@@ -18,7 +18,7 @@ Setup
 -----
 To install ``torch`` and ``torchvision`` use the following command:
 
-::
+.. code-block::
 
    pip install torch torchvision
 
@@ -160,7 +160,7 @@ prof.stop()
 #
 # Install PyTorch Profiler TensorBoard Plugin.
 #
-# ::
+# .. code-block::
 #
 #     pip install torch_tb_profiler
 #
@@ -168,7 +168,7 @@ prof.stop()
 ######################################################################
 # Launch the TensorBoard.
 #
-# ::
+# .. code-block::
 #
 #     tensorboard --logdir=./log
 #
@@ -176,7 +176,7 @@ prof.stop()
 ######################################################################
 # Open the TensorBoard profile URL in Google Chrome browser or Microsoft Edge browser.
 #
-# ::
+# .. code-block::
 #
 #     http://localhost:6006/#pytorch_profiler
 #
@@ -287,7 +287,7 @@ prof.stop()
 # In this example, we follow the "Performance Recommendation" and set ``num_workers`` as below,
 # pass a different name such as ``./log/resnet18_4workers`` to ``tensorboard_trace_handler``, and run it again.
 #
-# ::
+# .. code-block::
 #
 #     train_loader = torch.utils.data.DataLoader(train_set, batch_size=32, shuffle=True, num_workers=4)
 #
@@ -316,7 +316,7 @@ prof.stop()
 #
 # You can try it by using existing example on Azure
 #
-# ::
+# .. code-block::
 #
 #     pip install azure-storage-blob
 #     tensorboard --logdir=https://torchtbprofiler.blob.core.windows.net/torchtbprofiler/demo/memory_demo_1_10
@@ -366,7 +366,7 @@ prof.stop()
 #
 # You can try it by using existing example on Azure:
 #
-# ::
+# .. code-block::
 #
 #     pip install azure-storage-blob
 #     tensorboard --logdir=https://torchtbprofiler.blob.core.windows.net/torchtbprofiler/demo/distributed_bert


### PR DESCRIPTION
Fixes #1901

## Description
After these changes, the HTML is being rendered as it was before (expected behavior), but the corresponding code blocks in the Colab notebook will be rendered properly.

Before (following link from tutorial HTML):
<img width="538" alt="Screenshot 2023-06-01 at 11 23 59 AM" src="https://github.com/pytorch/tutorials/assets/31816267/a0223d3a-c61d-455f-9fae-413b13b360de">


After (rendered in VSCode):
<img width="919" alt="Screenshot 2023-06-01 at 11 24 27 AM" src="https://github.com/pytorch/tutorials/assets/31816267/86e6fa87-0e6e-4bf1-9b35-89604412ee01">


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnessessary issues are included into this pull request.
