### PR TITLE
Render a non-empty plot in Mario-RL tutorial

### DIFF
--- a/intermediate_source/mario_rl_tutorial.py
+++ b/intermediate_source/mario_rl_tutorial.py
@@ -711,17 +711,18 @@ class MetricLogger:
                 f"{datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S'):>20}\n"
             )
 
-        for metric in ["ep_rewards", "ep_lengths", "ep_avg_losses", "ep_avg_qs"]:
-            plt.plot(getattr(self, f"moving_avg_{metric}"))
-            plt.savefig(getattr(self, f"{metric}_plot"))
+        for metric in ["ep_lengths", "ep_avg_losses", "ep_avg_qs", "ep_rewards"]:
             plt.clf()
+            plt.plot(getattr(self, f"moving_avg_{metric}"), label=f"moving_avg_{metric}")
+            plt.legend()
+            plt.savefig(getattr(self, f"{metric}_plot"))
 
 
 ######################################################################
 # Let’s play!
 # """""""""""""""
 #
-# In this example we run the training loop for 10 episodes, but for Mario to truly learn the ways of
+# In this example we run the training loop for 40 episodes, but for Mario to truly learn the ways of
 # his world, we suggest running the loop for at least 40,000 episodes!
 #
 use_cuda = torch.cuda.is_available()
@@ -735,7 +736,7 @@ mario = Mario(state_dim=(4, 84, 84), action_dim=env.action_space.n, save_dir=sav
 
 logger = MetricLogger(save_dir)
 
-episodes = 10
+episodes = 40
 for e in range(episodes):
 
     state = env.reset()


### PR DESCRIPTION
Fixes #1607

## Description
This PR makes a few changes in order to render a non-empty plot in the doc HTML.
- Ups the number of episodes run so that there are enough data points to plot (w/ 10 episodes, only one data point would be available due to a save every 20)
- Clears the plot at the beginning of the loop that plots all 4 metrics; this ensure the plot is not cleared on the final iteration and results in something being displayed
- Adds a legend to the plot so that the rendered image contains some context and isn't just a random straight line

New rendering:
<img width="716" alt="Screenshot 2023-06-01 at 1 52 23 PM" src="https://github.com/pytorch/tutorials/assets/31816267/06b3a8e5-887b-4ab5-bf73-dbb11ee395c5">


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @vmoens @nairbv @svekars @carljparker