### PR TITLE
resolve issue 1818 by modifying mean and standard deviation in the transforms.Normalize

### DIFF
--- a/.github/workflows/docathon-label-sync.yml
+++ b/.github/workflows/docathon-label-sync.yml
@@ -1,7 +1,7 @@
 name: Docathon Labels Sync
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, edited]
 
 jobs:

--- a/beginner_source/introyt/introyt1_tutorial.py
+++ b/beginner_source/introyt/introyt1_tutorial.py
@@ -288,7 +288,7 @@ import torchvision.transforms as transforms
 
 transform = transforms.Compose(
     [transforms.ToTensor(),
-     transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+     transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2470, 0.2435, 0.2616))])
 
 
 ##########################################################################
@@ -297,9 +297,28 @@ transform = transforms.Compose(
 # -  ``transforms.ToTensor()`` converts images loaded by Pillow into 
 #    PyTorch tensors.
 # -  ``transforms.Normalize()`` adjusts the values of the tensor so
-#    that their average is zero and their standard deviation is 0.5. Most
+#    that their average is zero and their standard deviation is 1.0. Most
 #    activation functions have their strongest gradients around x = 0, so
 #    centering our data there can speed learning.
+#    The values passed to the transform are the means (first tuple) and the
+#    standard deviations (second tuple) of the rgb values of the images in
+#    the dataset. You can calculate these values yourself by running these
+#    few lines of code:
+#          ```
+#           from torch.utils.data import ConcatDataset
+#           transform = transforms.Compose([transforms.ToTensor()])
+#           trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
+#                                        download=True, transform=transform)
+#
+#           #stack all train images together into a tensor of shape 
+#           #(50000, 3, 32, 32)
+#           x = torch.stack([sample[0] for sample in ConcatDataset([trainset])])
+#           
+#           #get the mean of each channel            
+#           mean = torch.mean(x, dim=(0,2,3)) #tensor([0.4914, 0.4822, 0.4465])
+#           std = torch.std(x, dim=(0,2,3)) #tensor([0.2470, 0.2435, 0.2616])  
+# 
+#          ```   
 # 
 # There are many more transforms available, including cropping, centering,
 # rotation, and reflection.


### PR DESCRIPTION
Fixes #1818

## Description
Modified `transforms.Normalize` mean and standard deviation values to reflect CIFAR10 train mean and standard deviations

from 
```python
transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
```
to 
```python
transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2470, 0.2435, 0.2616))])
```

Modified the docstring to reflect the change, that the new mean and standard deviation will be 0 and 1, respectively. Also, additional details were added to explain how those values were generated: 

```python
#   The values passed to the transform are the means (first tuple) and the
#    standard deviations (second tuple) of the rgb values of the images in
#    the dataset. You can calculate these values yourself by running these
#    few lines of code:
#          ```
#           from torch.utils.data import ConcatDataset
#           transform = transforms.Compose([transforms.ToTensor()])
#           trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
#                                        download=True, transform=transform)
#
#           #stack all train images together into a tensor of shape 
#           #(50000, 3, 32, 32)
#           x = torch.stack([sample[0] for sample in ConcatDataset([trainset])])
#           
#           #get the mean of each channel            
#           mean = torch.mean(x, dim=(0,2,3)) #tensor([0.4914, 0.4822, 0.4465])
#           std = torch.std(x, dim=(0,2,3)) #tensor([0.2470, 0.2435, 0.2616])  
# 
#          ```   
```

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #1818")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @suraj813