### PR TITLE
Fix dependencies and kernel crash in captumyt.py

### DIFF
--- a/beginner_source/introyt/captumyt.py
+++ b/beginner_source/introyt/captumyt.py
@@ -158,7 +158,7 @@ from matplotlib.colors import LinearSegmentedColormap
 # now.
 # 
 
-model = models.resnet101(weights='IMAGENET1K_V1')
+model = models.resnet18(weights='IMAGENET1K_V1')
 model = model.eval()
 
 

--- a/beginner_source/introyt/captumyt.py
+++ b/beginner_source/introyt/captumyt.py
@@ -98,21 +98,24 @@ Installation
 Before you get started, you need to have a Python environment with:
 
 -  Python version 3.6 or higher
--  For the Captum Insights example, Flask 1.1 or higher
+-  For the Captum Insights example, Flask 1.1 or higher and Flask-Compress
+   (the latest version is recommended)
 -  PyTorch version 1.2 or higher (the latest version is recommended)
 -  TorchVision version 0.6 or higher (the latest version is recommended)
 -  Captum (the latest version is recommended)
+-  Matplotlib version 3.3.4, since Captum currently uses a Matplotlib
+   function whose arguments have been renamed in later versions
 
 To install Captum in an Anaconda or pip virtual environment, use the
 appropriate command for your environment below:
 
 With ``conda``::
 
-    conda install pytorch torchvision captum -c pytorch
+    conda install pytorch torchvision captum flask-compress matplotlib=3.3.4 -c pytorch
 
 With ``pip``::
 
-    pip install torch torchvision captum
+    pip install torch torchvision captum matplotlib==3.3.4 Flask-Compress
 
 Restart this notebook in the environment you set up, and you’re ready to
 go!


### PR DESCRIPTION
Fixes #2290 

## Description

The following changes are proposed:

1. Flask-compress is explicitly installed because it is needed for the Captum Insights example. It is not installed in Google Colab, although `flask==2.2.4` is there.
2. `matplotlib==3.3.4` ([ref](https://github.com/pytorch/captum/issues/1136#issuecomment-1540202585)) is installed because Captum uses an older version of a matplotlib function whose arguments have been renamed recently. Check the following stack trace to confirm:

        ---------------------------------------------------------------------------
        ValueError                                Traceback (most recent call last)
        [<ipython-input-12-3e00f13e4ddc>](https://localhost:8080/#) in <cell line: 2>()
              1 # Show the original image for comparison
        ----> 2 _ = viz.visualize_image_attr(None, 
              3                              np.transpose(transformed_img.squeeze().cpu().detach().numpy(), (1,2,0)),
              4                              method="original_image",
              5                              title="Original Image")
        
        4 frames
        [/usr/local/lib/python3.10/dist-packages/captum/attr/_utils/visualization.py](https://localhost:8080/#) in visualize_image_attr(attr, original_image, method, sign, plt_fig_axis, outlier_perc, cmap, alpha_overlay, show_colorbar, title, fig_size, use_pyplot)
            248     plt_axis.set_yticklabels([])
            249     plt_axis.set_xticklabels([])
        --> 250     plt_axis.grid(b=False)
            251 
            252     heat_map = None
        
        [/usr/local/lib/python3.10/dist-packages/matplotlib/axes/_base.py](https://localhost:8080/#) in grid(self, visible, which, axis, **kwargs)
           3192         _api.check_in_list(['x', 'y', 'both'], axis=axis)
           3193         if axis in ['x', 'both']:
        -> 3194             self.xaxis.grid(visible, which=which, **kwargs)
           3195         if axis in ['y', 'both']:
           3196             self.yaxis.grid(visible, which=which, **kwargs)
        
        [/usr/local/lib/python3.10/dist-packages/matplotlib/axis.py](https://localhost:8080/#) in grid(self, visible, which, **kwargs)
           1658             gridkw['gridOn'] = (not self._major_tick_kw['gridOn']
           1659                                 if visible is None else visible)
        -> 1660             self.set_tick_params(which='major', **gridkw)
           1661         self.stale = True
           1662 
        
        [/usr/local/lib/python3.10/dist-packages/matplotlib/axis.py](https://localhost:8080/#) in set_tick_params(self, which, reset, **kwargs)
            930         """
            931         _api.check_in_list(['major', 'minor', 'both'], which=which)
        --> 932         kwtrans = self._translate_tick_params(kwargs)
            933 
            934         # the kwargs are stored in self._major/minor_tick_kw so that any
        
        [/usr/local/lib/python3.10/dist-packages/matplotlib/axis.py](https://localhost:8080/#) in _translate_tick_params(kw, reverse)
           1074         for key in kw_:
           1075             if key not in allowed_keys:
        -> 1076                 raise ValueError(
           1077                     "keyword %s is not recognized; valid keywords are %s"
           1078                     % (key, allowed_keys))
        
        ValueError: keyword grid_b is not recognized; valid keywords are ['size', 'width', 'color', 'tickdir', 'pad', 'labelsize', 'labelcolor', 'zorder', 'gridOn', 'tick1On', 'tick2On', 'label1On', 'label2On', 'length', 'direction', 'left', 'bottom', 'right', 'top', 'labelleft', 'labelbottom', 'labelright', 'labeltop', 'labelrotation', 'grid_agg_filter', 'grid_alpha', 'grid_animated', 'grid_antialiased', 'grid_clip_box', 'grid_clip_on', 'grid_clip_path', 'grid_color', 'grid_dash_capstyle', 'grid_dash_joinstyle', 'grid_dashes', 'grid_data', 'grid_drawstyle', 'grid_figure', 'grid_fillstyle', 'grid_gapcolor', 'grid_gid', 'grid_in_layout', 'grid_label', 'grid_linestyle', 'grid_linewidth', 'grid_marker', 'grid_markeredgecolor', 'grid_markeredgewidth', 'grid_markerfacecolor', 'grid_markerfacecoloralt', 'grid_markersize', 'grid_markevery', 'grid_mouseover', 'grid_path_effects', 'grid_picker', 'grid_pickradius', 'grid_rasterized', 'grid_sketch_params', 'grid_snap', 'grid_solid_capstyle', 'grid_solid_joinstyle', 'grid_transform', 'grid_url', 'grid_visible', 'grid_xdata', 'grid_ydata', 'grid_zorder', 'grid_aa', 'grid_c', 'grid_ds', 'grid_ls', 'grid_lw', 'grid_mec', 'grid_mew', 'grid_mfc', 'grid_mfcalt', 'grid_ms']

3. The kernel crash issue in #2290 happens due to insufficient RAM when running the following line: `attributions_ig = integrated_gradients.attribute(input_img, target=pred_label_idx, n_steps=200)`. This is likely because the currently used model `resnet101` is too large. I even used `resnet50` but faced the same issue. I did not face this issue with `resnet18`, so I replaced `resnet101` with `resnet18`.


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @suraj813