### PR TITLE
Set global device back to cpu at the end of tutorial

### DIFF
--- a/recipes_source/recipes/changing_default_device.py
+++ b/recipes_source/recipes/changing_default_device.py
@@ -43,7 +43,7 @@ mod = torch.nn.Linear(20, 30)
 print(mod.weight.device)
 print(mod(torch.randn(128, 20)).device)
 
-# And then gloablly return it back to CPU
+# And then globally return it back to CPU
 torch.set_default_device('cpu')
 
 ################################################################

--- a/recipes_source/recipes/changing_default_device.py
+++ b/recipes_source/recipes/changing_default_device.py
@@ -43,6 +43,9 @@ mod = torch.nn.Linear(20, 30)
 print(mod.weight.device)
 print(mod(torch.randn(128, 20)).device)
 
+# And then gloablly return it back to CPU
+torch.set_default_device('cpu')
+
 ################################################################
 # This function imposes a slight performance cost on every Python
 # call to the torch API (not just factory functions). If this


### PR DESCRIPTION
We are using sphinx to render those tutorials, which does not start a new process to render, so one needs to restore global state to default value, by calling `torch.set_default_device('cpu')`
