### PR TITLE
Fix inconsistencies in fgsm_tutorial

### DIFF
--- a/beginner_source/fgsm_tutorial.py
+++ b/beginner_source/fgsm_tutorial.py
@@ -308,7 +308,7 @@ def test( model, device, test_loader, epsilon ):
         # Collect ``datagrad``
         data_grad = data.grad.data
 
-       # Denormalize the data
+        # Denormalize the data
         data_denorm = denorm(data)
 
         # Call FGSM Attack

--- a/beginner_source/fgsm_tutorial.py
+++ b/beginner_source/fgsm_tutorial.py
@@ -233,11 +233,10 @@ def fgsm_attack(image, epsilon, data_grad):
     # Return the perturbed image
     return perturbed_image
 
-# denormalize the tensors before performing an FGSM attack
-# because FGSM only works with the original unnormalized image
+# restores the tensors to their original scale
 def denorm(batch, mean=[0.1307], std=[0.3081]):
     """
-    Denormalizes a batch of tensors.
+    Convert a batch of tensors to their original scale.
 
     Args:
         batch (torch.Tensor): Batch of normalized tensors.
@@ -245,7 +244,7 @@ def denorm(batch, mean=[0.1307], std=[0.3081]):
         std (torch.Tensor or list): Standard deviation used for normalization.
 
     Returns:
-        torch.Tensor: Denormalized batch of tensors.
+        torch.Tensor: batch of tensors without normalization applied to them.
     """
     if isinstance(mean, list):
         mean = torch.tensor(mean).to(device)
@@ -308,7 +307,7 @@ def test( model, device, test_loader, epsilon ):
         # Collect ``datagrad``
         data_grad = data.grad.data
 
-        # Denormalize the data
+        # Restore the data to its original scale
         data_denorm = denorm(data)
 
         # Call FGSM Attack

--- a/beginner_source/fgsm_tutorial.py
+++ b/beginner_source/fgsm_tutorial.py
@@ -160,20 +160,27 @@ use_cuda=True
 class Net(nn.Module):
     def __init__(self):
         super(Net, self).__init__()
-        self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
-        self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
-        self.conv2_drop = nn.Dropout2d()
-        self.fc1 = nn.Linear(320, 50)
-        self.fc2 = nn.Linear(50, 10)
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
 
     def forward(self, x):
-        x = F.relu(F.max_pool2d(self.conv1(x), 2))
-        x = F.relu(F.max_pool2d(self.conv2_drop(self.conv2(x)), 2))
-        x = x.view(-1, 320)
-        x = F.relu(self.fc1(x))
-        x = F.dropout(x, training=self.training)
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
         x = self.fc2(x)
-        return F.log_softmax(x, dim=1)
+        output = F.log_softmax(x, dim=1)
+        return output
 
 # MNIST Test dataset and dataloader declaration
 test_loader = torch.utils.data.DataLoader(

--- a/beginner_source/fgsm_tutorial.py
+++ b/beginner_source/fgsm_tutorial.py
@@ -186,6 +186,7 @@ class Net(nn.Module):
 test_loader = torch.utils.data.DataLoader(
     datasets.MNIST('../data', train=False, download=True, transform=transforms.Compose([
             transforms.ToTensor(),
+            transforms.Normalize((0.1307,), (0.3081,))
             ])), 
         batch_size=1, shuffle=True)
 

--- a/beginner_source/fgsm_tutorial.py
+++ b/beginner_source/fgsm_tutorial.py
@@ -198,7 +198,7 @@ device = torch.device("cuda" if (use_cuda and torch.cuda.is_available()) else "c
 model = Net().to(device)
 
 # Load the pretrained model
-model.load_state_dict(torch.load(pretrained_model, map_location='cpu'))
+model.load_state_dict(torch.load(pretrained_model, map_location=device))
 
 # Set the model in evaluation mode. In this case this is for the Dropout layers
 model.eval()


### PR DESCRIPTION
Fixes #1032 

## Description

1. The architecture of the model is changed. The tutorial says that it uses the same MNIST model from [pytorch/examples/mnist](https://github.com/pytorch/examples/tree/master/mnist). However, the dimensions of the convolutional layers were different. Therefore, the exact model is copy-pasted as is.
2. The model in the MNIST example was trained using a transform in the data loader that normalized the data using `mean=0.1307` and `std=0.3081`. However, no normalization was being applied in this example. Thus, the same normalization is applied to the `test_loader` in this example.
3. The `state_dict` of the MNIST was being loaded on the CPU even though `use_cuda=True` and `device` is being dynamically defined. Therefore, `map_location=device` instead of `cpu`
4. A denormalization function is added to unnormalize the data before applying FGSM on it, since FGSM takes unnormalized input
5. The `test` function is modified. After computing the gradient of the normalized data, the data is unnormalized. FGSM is then applied on unnormalized data. Finally, the perturbed data is again normalized before applying the model on it. 

I also checked the code without step 5, i.e., not performing normalization and denormalization inside the `test` function. The observation was that the accuracy stayed the same between 98-99%, although it was supposed to fall. Applying step 5 rectified this issue.


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
