### PR TITLE
Update torch_compile_tutorial.py to use unused parameter

### DIFF
--- a/intermediate_source/torch_compile_tutorial.py
+++ b/intermediate_source/torch_compile_tutorial.py
@@ -69,7 +69,7 @@ if not gpu_ok:
 
 def foo(x, y):
     a = torch.sin(x)
-    b = torch.cos(x)
+    b = torch.cos(y)
     return a + b
 opt_foo1 = torch.compile(foo)
 print(opt_foo1(torch.randn(10, 10), torch.randn(10, 10)))
@@ -80,7 +80,7 @@ print(opt_foo1(torch.randn(10, 10), torch.randn(10, 10)))
 @torch.compile
 def opt_foo2(x, y):
     a = torch.sin(x)
-    b = torch.cos(x)
+    b = torch.cos(y)
     return a + b
 print(opt_foo2(torch.randn(10, 10), torch.randn(10, 10)))
 


### PR DESCRIPTION
I noticed when reading through these docs that the two examples did not use the parameter 'y'. I assume it was meant to be used so I updated the code in the examples. Another possibility is that we don't need param 'y' and only need 'x'. Let me know if that is the case and I will fix this :)
