### PR TITLE
[BugFix] Fix Mario device error

### DIFF
--- a/intermediate_source/mario_rl_tutorial.py
+++ b/intermediate_source/mario_rl_tutorial.py
@@ -350,7 +350,7 @@ class Mario:
 class Mario(Mario):  # subclassing for continuity
     def __init__(self, state_dim, action_dim, save_dir):
         super().__init__(state_dim, action_dim, save_dir)
-        self.memory = TensorDictReplayBuffer(storage=LazyMemmapStorage(100000))
+        self.memory = TensorDictReplayBuffer(storage=LazyMemmapStorage(100000, device=torch.device("cpu")))
         self.batch_size = 32
 
     def cache(self, state, next_state, action, reward, done):
@@ -369,11 +369,11 @@ class Mario(Mario):  # subclassing for continuity
         state = first_if_tuple(state).__array__()
         next_state = first_if_tuple(next_state).__array__()
 
-        state = torch.tensor(state, device=self.device)
-        next_state = torch.tensor(next_state, device=self.device)
-        action = torch.tensor([action], device=self.device)
-        reward = torch.tensor([reward], device=self.device)
-        done = torch.tensor([done], device=self.device)
+        state = torch.tensor(state)
+        next_state = torch.tensor(next_state)
+        action = torch.tensor([action])
+        reward = torch.tensor([reward])
+        done = torch.tensor([done])
 
         # self.memory.append((state, next_state, action, reward, done,))
         self.memory.add(TensorDict({"state": state, "next_state": next_state, "action": action, "reward": reward, "done": done}, batch_size=[]))
@@ -382,7 +382,7 @@ class Mario(Mario):  # subclassing for continuity
         """
         Retrieve a batch of experiences from memory
         """
-        batch = self.memory.sample(self.batch_size)
+        batch = self.memory.sample(self.batch_size).to(self.device)
         state, next_state, action, reward, done = (batch.get(key) for key in ("state", "next_state", "action", "reward", "done"))
         return state, next_state, action.squeeze(), reward.squeeze(), done.squeeze()
 


### PR DESCRIPTION
Fixes the following error:

```
Unexpected failing examples:
/var/lib/jenkins/workspace/intermediate_source/mario_rl_tutorial.py failed leaving traceback:
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/intermediate_source/mario_rl_tutorial.py", line 760, in <module>
    q, loss = mario.learn()
  File "/var/lib/jenkins/workspace/intermediate_source/mario_rl_tutorial.py", line 600, in learn
    td_est = self.td_estimate(state, action)
  File "/var/lib/jenkins/workspace/intermediate_source/mario_rl_tutorial.py", line 494, in td_estimate
    current_Q = self.net(state, model="online")[
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/var/lib/jenkins/workspace/intermediate_source/mario_rl_tutorial.py", line 445, in forward
    return self.online(input)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/container.py", line 217, in forward
    input = module(input)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/conv.py", line 463, in forward
    return self._conv_forward(input, self.weight, self.bias)
  File "/opt/conda/lib/python3.10/site-packages/torch/nn/modules/conv.py", line 459, in _conv_forward
    return F.conv2d(input, weight, bias, self.stride,
  File "/opt/conda/lib/python3.10/site-packages/tensordict/memmap.py", line 417, in __torch_function__
    ret = func(*args, **kwargs)
RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same or input should be a MKLDNN tensor and weight is a dense tensor

```