### PR TITLE
Add torch.cuda.empty_cache() to the reset_seeds function

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -87,6 +87,7 @@ intersphinx_mapping = {
 # -- Sphinx-gallery configuration --------------------------------------------
 
 def reset_seeds(gallery_conf, fname):
+    torch.cuda.empty_cache()
     torch.manual_seed(42)
     torch.set_default_device(None)
     random.seed(10)


### PR DESCRIPTION
Adding torch.cuda.empty_cache() to the reset_seeds function to solve CUDA out of memory error when adding the Inductor tutorial.
