### PR TITLE
Update pyspelling config to skip code-blocks with 3+ indents. 

### DIFF
--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -45,6 +45,10 @@ matrix:
         - open: '\.\. (code-block|math)::.*$\n*'
           content: '(?P<first>(^(?P<indent>[ ]+).*$\n))(?P<other>(^([ \t]+.*|[ \t]*)$\n)*)'
           close: '(^(?![ \t]+.*$))'
+        # Ignore code-block dirs with 3+ spaces
+        - open: '\.\. (code-block)::.*$\n*'
+          content: '\s{3,}.*'
+          close: '\n'
   - pyspelling.filters.markdown:
   - pyspelling.filters.html:
       ignores:


### PR DESCRIPTION
Update pyspelling config to skip code-blocks with 3+ indents. 