### PR TITLE
Replace the out of date super init method

### DIFF
--- a/beginner_source/basics/optimization_tutorial.py
+++ b/beginner_source/basics/optimization_tutorial.py
@@ -49,7 +49,7 @@ test_dataloader = DataLoader(test_data, batch_size=64)
 
 class NeuralNetwork(nn.Module):
     def __init__(self):
-        super(NeuralNetwork, self).__init__()
+        super().__init__()
         self.flatten = nn.Flatten()
         self.linear_relu_stack = nn.Sequential(
             nn.Linear(28*28, 512),


### PR DESCRIPTION
According to this docs: https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L379

We should use super().__init__() than Super(NeuralNetwork, self).__init__()