### PR TITLE
remove duplicated code in torch_compile_tutorial.py

### DIFF
--- a/intermediate_source/torch_compile_tutorial.py
+++ b/intermediate_source/torch_compile_tutorial.py
@@ -166,7 +166,6 @@ print("compile:", timed(lambda: evaluate_opt(model, inp))[1])
 # see a significant improvement compared to eager.
 
 eager_times = []
-compile_times = []
 for i in range(N_ITERS):
     inp = generate_data(16)[0]
     _, eager_time = timed(lambda: evaluate(model, inp))


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
This PR removes duplicated code `compile_times = []` in `torch_compile_tutorial.py`

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @williamwen42 @msaroufim