### PR TITLE
Fix tutorial dependencies install

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -18,6 +18,8 @@ sudo apt-get install -y --no-install-recommends unzip p7zip-full sox libsox-dev 
 # NS: Path to python runtime should already be part of docker container
 # export PATH=/opt/conda/bin:$PATH
 rm -rf src
+# NS: ghstack is not needed to build tutorials and right now it forces importlib to be downgraded to 3.X 
+pip uninstall ghstack
 pip install -r $DIR/../requirements.txt
 
 #Install PyTorch Nightly for test.

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -15,7 +15,8 @@ sudo apt-get update || sudo apt-get install libgnutls30
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends unzip p7zip-full sox libsox-dev libsox-fmt-all rsync
 
-export PATH=/opt/conda/bin:$PATH
+# NS: Path to python runtime should already be part of docker container
+# export PATH=/opt/conda/bin:$PATH
 rm -rf src
 pip install -r $DIR/../requirements.txt
 

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -19,8 +19,8 @@ sudo apt-get install -y --no-install-recommends unzip p7zip-full sox libsox-dev 
 # export PATH=/opt/conda/bin:$PATH
 rm -rf src
 # NS: ghstack is not needed to build tutorials and right now it forces importlib to be downgraded to 3.X 
-pip uninstall ghstack
-pip install -r $DIR/../requirements.txt
+pip uninstall -y ghstack
+pip install --progress-bar off -r $DIR/../requirements.txt
 
 #Install PyTorch Nightly for test.
 # Nightly - pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,8 @@ boto3
 pandas
 requests
 scikit-image
-scipy
+scipy==1.11.1
+numba==0.57.1
 pillow==9.3.0
 wget
 gym-super-mario-bros==7.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,9 +34,7 @@ transformers
 torchmultimodal-nightly # needs to be updated to stable as soon as it's avaialable
 deep_phonemizer==0.0.17
 
-# the following is necessary due to https://github.com/python/importlib_metadata/issues/411
-importlib-metadata < 5.0; python_version <= "3.7"
-importlib-metadata; python_version > "3.7"
+importlib-metadata==6.8.0
 
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
`/opt/conda/bin` folder contains default Python (3.11 after the last update) rather than the one specified promised by the docker container (which is installed in the environment)

Remove explicit `PATH` to stick to Python-3.10 installed as part of the container (as `torchx` is yet not available for Python-3.11)

Also, uninstall `ghstack` to prevent downgrade `importlib-metadata` from `6.8.0` to `3.X`.
Pin `importlib-metadata`, `scipy`, `numba` versions. 

Minor: Add `--progress-bar off` option, to keep logs readable.
