### PR TITLE
Loading nn.Module from checkpoint tutorial (non ghstack)

### DIFF
--- a/recipes_source/recipes/module_load_state_dict_tips.py
+++ b/recipes_source/recipes/module_load_state_dict_tips.py
@@ -50,6 +50,7 @@ state_dict = torch.load('checkpoint.pth')
 m = SomeModule(1000)
 m.load_state_dict(state_dict)
 
+#############################################################################
 # The second example does not use any of the features listed above and will be
 # less compute and memory efficient for loading a checkpoint. In the following
 # sections, we will discuss each of the features in further detail.
@@ -57,7 +58,7 @@ m.load_state_dict(state_dict)
 #####################################################################################
 # Using ``torch.load(mmap=True)``
 # -------------------------------
-# First, let us consider what happens when we load the checkpoint with``torch.load``.
+# First, let us consider what happens when we load the checkpoint with ``torch.load``.
 # When we save a checkpoint with ``torch.save``, tensor storages are tagged with the device they are
 # saved on. With ``torch.load``, tensor storages will be loaded to the device
 # they were tagged with (unless this behavior is overridden using the
@@ -66,8 +67,7 @@ m.load_state_dict(state_dict)
 # loaded into CPU RAM, which can be undesirable when:
 #
 # * CPU RAM is smaller than the size of the checkpoint.
-# * Waiting for the entire checkpoint to be loaded into RAM before
-#    performing, for example, some per-tensor processing.
+# * Waiting for the entire checkpoint to be loaded into RAM before performing, for example, some per-tensor processing.
 
 start_time = time.time()
 state_dict = torch.load('checkpoint.pth')
@@ -114,10 +114,11 @@ m = SomeModule(1000)
 # This allocates memory for all parameters/buffers and initializes them per
 # the default initialization schemes defined in ``SomeModule.__init__()``, which
 # is wasteful when we want to load a checkpoint for the following reasons:
-# * The result of the initialization kernels will be overwritten by ``load_state_dict()``
-#    without ever being used, so initialization is wasteful.
-# * We are allocating memory for these parameters/buffers in RAM while ``torch.load`` of
-#    the saved state dictionary also allocates memory in RAM for the parameters/buffers in the checkpoint.
+#
+# * The result of the initialization kernels will be overwritten by ``load_state_dict()`` without ever being used, so
+#   initialization is wasteful.
+# * We are allocating memory for these parameters/buffers in RAM while ``torch.load`` of the saved state dictionary also
+#   allocates memory in RAM for the parameters/buffers in the checkpoint.
 #
 # In order to solve these two problems, we can use the ``torch.device()``
 # context manager with ``device='meta'`` when we instantiate the ``nn.Module()``.

--- a/recipes_source/recipes/module_load_state_dict_tips.py
+++ b/recipes_source/recipes/module_load_state_dict_tips.py
@@ -1,0 +1,107 @@
+"""
+
+Tips for Loading an `nn.Module` from a Checkpoint
+=================================================
+
+In this tutorial, we will share some tips for loading a model from a checkpoint.
+In particular, we will discuss
+
+
+1.  The `mmap` keyword argument on `torch.load`
+2.  The `torch.device()` context manager
+3.  The `assign` keyword argument on `nn.Module.load_state_dict()`
+
+The following snippet of code illustrates the use of the above three utilities.
+"""
+
+import torch
+
+state_dict = torch.load('checkpoint.pth', mmap=True)
+with torch.device('meta'):
+  meta_m = SomeModule()
+meta_m.load_state_dict(state_dict, assign=True)
+
+###############################################################################
+# Taking a step back, let us inspect the following more vanilla code snippet
+# that does not use any of the features listed above
+
+state_dict = torch.load('checkpoint.pth')
+m = SomeModule()
+m.load_state_dict(state_dict)
+
+###############################################################################
+# At `torch.save` time, tensor storages are tagged with the device they are
+# saved on. At `torch.load` time, tensor storages will be loaded to the device
+# they were tagged with (unless this behavior is overridden using the
+# `map_location` flag). For ease of explanation, let us assume that the tensors
+# were saved on CPU. This means that on the first line
+
+state_dict = torch.load('checkpoint.pth')
+
+###############################################################################
+# all tensor storages will be loaded into CPU RAM, which can be problematic when
+#     1. CPU RAM is smaller than the size of the checkpoint
+#     2. waiting for the entire checkpoint to be loaded into RAM before
+#        doing for example some per-tensor processing
+#
+# The `mmap` keyword argument to `torch.load` attempts to solve the above two
+# problems by using an [`mmap` call](https://man7.org/linux/man-pages/man2/mmap.2.html)
+# on the checkpoint, so that tensor storages are memory-mapped and when they are
+# fetched from disk to memory is managed by the OS.
+#
+# Next, we consider the creation of the module.
+
+m = SomeModule()
+
+###############################################################################
+# This allocates memory for all parameters/buffers and initializes them per
+# the default initialization schemes defined in `SomeModule.__init__()`, which
+# is wasteful when we want to load a checkpoint as
+#     1. We are running the initialization kernels where the results are
+#        immediately overwritten by `load_state_dict()`
+#     2. We are allocating memory for these parameters/buffers in RAM while
+#        `torch.load` of the saved state dictionary also allocates memory for
+#        the parameters/buffers in the checkpoint.
+#
+# In order to solve these two problems, we can use the `torch.device()`
+# context manager with `device='meta'` when we instantiate the `nn.Module()`.
+
+with torch.device('meta'):
+  meta_m = SomeModule()
+
+###############################################################################
+# The [`torch.device()`](https://pytorch.org/docs/main/tensor_attributes.html#torch-device)
+# context manager makes sure that factory calls will be performed as if they
+# were passed device as an argument. However, it does not affect factory
+# function calls which are called with an explicit device argument.
+#
+# Tensors on the `meta` device do not carry data. However, they possess all
+# other metadata a tensor carries such as `.size()` and `.stride()`,
+# `.requires_grad` etc.
+#
+# Next, we consider the loading of the state dictionary.
+
+m.load_state_dict(state_dict)
+
+###############################################################################
+# `nn.Module.load_state_dict()` is usually implemented via an in-place
+# `param_in_model.copy_(param_in_state_dict)` (i.e. a copy from the
+# parameter/buffer with the corresponding key in the state dictionary into
+# the parameters/buffers in the `nn.Module`).
+#
+# However, an in-place copy into a tensor on the `meta` device is a no-op.
+# In order to avoid this, we can pass the `assign=True` keyword argument to
+# `load_state_dict()`.
+
+meta_m.load_state_dict(state_dict, assign=True)
+
+###############################################################################
+# A caveat here is that since optimizers hold a reference to
+# `nn.Module.parameters()`, the optimizer must be initialized after the module
+# is loaded from state dict if `assign=True` is passed.
+
+###############################################################################
+# To recap, in this tutorial, we learned about `torch.load(mmap=True)`, the
+# `torch.device()` context manager with `device=meta` and the
+# `nn.Module.load_state_dict(assign=True)` and how these tools could be used
+# to aid when loading a model from a checkpoint.

--- a/recipes_source/recipes/module_load_state_dict_tips.py
+++ b/recipes_source/recipes/module_load_state_dict_tips.py
@@ -1,112 +1,129 @@
 """
 
-Tips for Loading an `nn.Module` from a Checkpoint
-=================================================
+Tips for Loading an ``nn.Module`` from a Checkpoint
+===================================================
 
 In this tutorial, we will share some tips for loading a model from a checkpoint.
 In particular, we will discuss
 
 
-1.  The `mmap` keyword argument on `torch.load`
-2.  The `torch.device()` context manager
-3.  The `assign` keyword argument on `nn.Module.load_state_dict()`
+1.  The ``mmap`` keyword argument on ``torch.load``
+2.  The ``torch.device()`` context manager
+3.  The ``assign`` keyword argument on ``nn.Module.load_state_dict()``
 
-The following snippet of code illustrates the use of the above three utilities.
+.. note::
+   This recipe requires PyTorch 2.1.0 or later.
 """
 
+
+########################################
+# Let us consider a simple ``nn.Module``
 import torch
 from torch import nn
+import time
 
 class SomeModule(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, size):
         super().__init__()
-        self.linears = nn.ModuleList([nn.Linear(1, 1) for i in range(10)])
+        self.linears = nn.ModuleList([nn.Linear(size, size) for i in range(10)])
 
     def forward(self, x):
         return self.linears(x)
 
 
-m = SomeModule()
+m = SomeModule(1000)
 torch.save(m.state_dict(), 'checkpoint.pth')
+
+
+#################################################################
+# The follow snippet demonstrates the use of the three utilities.
+
 state_dict = torch.load('checkpoint.pth', mmap=True)
 with torch.device('meta'):
-  meta_m = SomeModule()
+  meta_m = SomeModule(1000)
 meta_m.load_state_dict(state_dict, assign=True)
 
-###############################################################################
+#############################################################################
 # Taking a step back, let us inspect the following more vanilla code snippet
-# that does not use any of the features listed above
+# that does not use any of the features listed above:
 
 state_dict = torch.load('checkpoint.pth')
-m = SomeModule()
+m = SomeModule(1000)
 m.load_state_dict(state_dict)
 
-###############################################################################
-# At `torch.save` time, tensor storages are tagged with the device they are
-# saved on. At `torch.load` time, tensor storages will be loaded to the device
+#################################################################################
+# At ``torch.save`` time, tensor storages are tagged with the device they are
+# saved on. At ``torch.load`` time, tensor storages will be loaded to the device
 # they were tagged with (unless this behavior is overridden using the
-# `map_location` flag). For ease of explanation, let us assume that the tensors
+# ``map_location`` flag). For ease of explanation, let us assume that the tensors
 # were saved on CPU. This means that on the first line
 
+start_time = time.time()
 state_dict = torch.load('checkpoint.pth')
+end_time = time.time()
+print(f"loading time without mmap={end_time - start_time}")
 
-###############################################################################
+################################################################################
 # All tensor storages will be loaded into CPU RAM, which can be problematic when
 #     1. CPU RAM is smaller than the size of the checkpoint
 #     2. waiting for the entire checkpoint to be loaded into RAM before
 #        doing for example some per-tensor processing
 #
-# The `mmap` keyword argument to `torch.load` attempts to solve the above two
-# problems by using an [`mmap` call](https://man7.org/linux/man-pages/man2/mmap.2.html)
-# on the checkpoint, so that tensor storages are memory-mapped and when they are
-# fetched from disk to memory is managed by the OS.
+# The ``mmap`` keyword argument to ``torch.load`` attempts to solve the above two
+# problems. As its name implies, the ``mmap`` keyword argument to ``torch.load``
+# makes use of an `mmap call <https://man7.org/linux/man-pages/man2/mmap.2.html>`_
+# which maps a file on disk into virtual memory and lets the OS handle loading and
+# unloading into physical memory automatically. When this flag is passed, tensor
+# storages will be memory-mapped.
 
+start_time = time.time()
 state_dict = torch.load('checkpoint.pth', mmap=True)
-
+end_time = time.time()
+print(f"loading time with mmap={end_time - start_time}")
 
 ################################################################################
-# For example
+# As mentioned above, one can use this argument to do per-tensor processing on a
+# checkpoint without loading all tensor storages into memory upfront. For example,
 
-# def my_special_routine(t):
-#     # for example, post training quantization and move t to device
-#     pass
+def my_special_routine(t, device):
+    # this could be a much fancier operation
+    return t.to(dtype=torch.bfloat16, device=device)
 
-# def my_processing_function(key, device):
-#     t = state_dict[key]
-#     processed_t = my_special_routine(t)
-#     del t
-#     return processed_t
+def my_processing_function(key, device):
+    t = state_dict[key]
+    processed_t = my_special_routine(t, device)
+    del t
+    return processed_t
 
-# for key in state_dict.keys():
-#     device = 'cuda' + str(int(key[0]) % 8)
-#     state_dict[key] = my_processing_function(key, device)
+for key in state_dict.keys():
+    device = torch.device('cuda:' + str(int(key.lstrip("linears.")[0]) % 8))
+    state_dict[key] = my_processing_function(key, device)
 
-
+##############################################
 # Next, we consider the creation of the module.
-
-m = SomeModule()
+m = SomeModule(1000)
 
 ###############################################################################
 # This allocates memory for all parameters/buffers and initializes them per
-# the default initialization schemes defined in `SomeModule.__init__()`, which
+# the default initialization schemes defined in ``SomeModule.__init__()``, which
 # is wasteful when we want to load a checkpoint as
-#     1. We are running the initialization kernels where the results are
-#        immediately overwritten by `load_state_dict()`
+#     1. The result of the initialization kernels will be overwritten by
+#        `load_state_dict()` without ever being used, so initialization is
+#         wasteful.
 #     2. We are allocating memory for these parameters/buffers in RAM while
-#        `torch.load` of the saved state dictionary also allocates memory for
+#        ``torch.load`` of the saved state dictionary also allocates memory for
 #        the parameters/buffers in the checkpoint.
 #
-# In order to solve these two problems, we can use the `torch.device()`
-# context manager with `device='meta'` when we instantiate the `nn.Module()`.
+# In order to solve these two problems, we can use the ``torch.device()``
+# context manager with ``device='meta'`` when we instantiate the ``nn.Module()``.
 
 with torch.device('meta'):
-  meta_m = SomeModule()
+  new_m = SomeModule(1000)
 
-###############################################################################
-# The [`torch.device()`](https://pytorch.org/docs/main/tensor_attributes.html#torch-device)
+############################################################################################
+# The `torch.device() <https://pytorch.org/docs/main/tensor_attributes.html#torch-device>` _
 # context manager makes sure that factory calls will be performed as if they
-# were passed device as an argument. However, it does not affect factory
-# function calls which are called with an explicit device argument.
+# were passed device as an argument.
 #
 # Tensors on the `meta` device do not carry data. However, they possess all
 # other metadata a tensor carries such as ```.size()`` and ```.stride()``,
@@ -120,18 +137,19 @@ m.load_state_dict(state_dict)
 # ``nn.Module.load_state_dict()`` is usually implemented via an in-place
 # ``param_in_model.copy_(param_in_state_dict)`` (i.e. a copy from the
 # parameter/buffer with the corresponding key in the state dictionary into
-# the parameters/buffers in the `nn.Module`).
+# the parameters/buffers in the ``nn.Module```).
 #
-# However, an in-place copy into a tensor on the ``meta``` device is a no-op.
-# In order to avoid this, we can pass the `assign=True` keyword argument to
+# However, an in-place copy into a tensor on the ``meta`` device is a no-op.
+# In order to avoid this, we can pass the ``assign=True`` keyword argument to
 # ``load_state_dict()``.
-
-meta_m.load_state_dict(state_dict, assign=True)
-
-###############################################################################
+#
 # A caveat here is that since optimizers hold a reference to
 # ``nn.Module.parameters()``, the optimizer must be initialized after the module
-# is loaded from state dict if `assign=True` is passed.
+# is loaded from state dict if ``assign=True`` is passed.
+
+new_m.load_state_dict(state_dict, assign=True)
+# This MUST be done AFTER the load_state_dict with assign.
+opt = torch.optim.SGD(new_m.parameters(), lr=1e-3)
 
 ###############################################################################
 # To recap, in this tutorial, we learned about ``torch.load(mmap=True)``, the

--- a/recipes_source/recipes/module_load_state_dict_tips.py
+++ b/recipes_source/recipes/module_load_state_dict_tips.py
@@ -15,7 +15,19 @@ The following snippet of code illustrates the use of the above three utilities.
 """
 
 import torch
+from torch import nn
 
+class SomeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linears = nn.ModuleList([nn.Linear(1, 1) for i in range(10)])
+
+    def forward(self, x):
+        return self.linears(x)
+
+
+m = SomeModule()
+torch.save(m.state_dict(), 'checkpoint.pth')
 state_dict = torch.load('checkpoint.pth', mmap=True)
 with torch.device('meta'):
   meta_m = SomeModule()
@@ -39,7 +51,7 @@ m.load_state_dict(state_dict)
 state_dict = torch.load('checkpoint.pth')
 
 ###############################################################################
-# all tensor storages will be loaded into CPU RAM, which can be problematic when
+# All tensor storages will be loaded into CPU RAM, which can be problematic when
 #     1. CPU RAM is smaller than the size of the checkpoint
 #     2. waiting for the entire checkpoint to be loaded into RAM before
 #        doing for example some per-tensor processing
@@ -48,7 +60,28 @@ state_dict = torch.load('checkpoint.pth')
 # problems by using an [`mmap` call](https://man7.org/linux/man-pages/man2/mmap.2.html)
 # on the checkpoint, so that tensor storages are memory-mapped and when they are
 # fetched from disk to memory is managed by the OS.
-#
+
+state_dict = torch.load('checkpoint.pth', mmap=True)
+
+
+################################################################################
+# For example
+
+# def my_special_routine(t):
+#     # for example, post training quantization and move t to device
+#     pass
+
+# def my_processing_function(key, device):
+#     t = state_dict[key]
+#     processed_t = my_special_routine(t)
+#     del t
+#     return processed_t
+
+# for key in state_dict.keys():
+#     device = 'cuda' + str(int(key[0]) % 8)
+#     state_dict[key] = my_processing_function(key, device)
+
+
 # Next, we consider the creation of the module.
 
 m = SomeModule()
@@ -76,32 +109,32 @@ with torch.device('meta'):
 # function calls which are called with an explicit device argument.
 #
 # Tensors on the `meta` device do not carry data. However, they possess all
-# other metadata a tensor carries such as `.size()` and `.stride()`,
-# `.requires_grad` etc.
+# other metadata a tensor carries such as ```.size()`` and ```.stride()``,
+# ``.requires_grad`` etc.
 #
 # Next, we consider the loading of the state dictionary.
 
 m.load_state_dict(state_dict)
 
 ###############################################################################
-# `nn.Module.load_state_dict()` is usually implemented via an in-place
-# `param_in_model.copy_(param_in_state_dict)` (i.e. a copy from the
+# ``nn.Module.load_state_dict()`` is usually implemented via an in-place
+# ``param_in_model.copy_(param_in_state_dict)`` (i.e. a copy from the
 # parameter/buffer with the corresponding key in the state dictionary into
 # the parameters/buffers in the `nn.Module`).
 #
-# However, an in-place copy into a tensor on the `meta` device is a no-op.
+# However, an in-place copy into a tensor on the ``meta``` device is a no-op.
 # In order to avoid this, we can pass the `assign=True` keyword argument to
-# `load_state_dict()`.
+# ``load_state_dict()``.
 
 meta_m.load_state_dict(state_dict, assign=True)
 
 ###############################################################################
 # A caveat here is that since optimizers hold a reference to
-# `nn.Module.parameters()`, the optimizer must be initialized after the module
+# ``nn.Module.parameters()``, the optimizer must be initialized after the module
 # is loaded from state dict if `assign=True` is passed.
 
 ###############################################################################
-# To recap, in this tutorial, we learned about `torch.load(mmap=True)`, the
-# `torch.device()` context manager with `device=meta` and the
-# `nn.Module.load_state_dict(assign=True)` and how these tools could be used
+# To recap, in this tutorial, we learned about ``torch.load(mmap=True)``, the
+# ``torch.device()`` context manager with ``device=meta`` and the
+# ``nn.Module.load_state_dict(assign=True)`` and how these tools could be used
 # to aid when loading a model from a checkpoint.

--- a/recipes_source/recipes/module_load_state_dict_tips.py
+++ b/recipes_source/recipes/module_load_state_dict_tips.py
@@ -33,8 +33,8 @@ class SomeModule(torch.nn.Module):
 m = SomeModule(1000)
 torch.save(m.state_dict(), 'checkpoint.pth')
 
-##############################################################################
-# The follow snippet demonstrates the use of the the ``mmap`` keyword argument
+#################################################################################
+# The following snippet demonstrates the use of the the ``mmap`` keyword argument
 # to ``torch.load``, the ``torch.device()`` context manager and the ``assign``
 # keyword argument to ``nn.Module.load_state_dict()``.
 

--- a/recipes_source/recipes/module_load_state_dict_tips.py
+++ b/recipes_source/recipes/module_load_state_dict_tips.py
@@ -3,9 +3,8 @@
 Tips for Loading an ``nn.Module`` from a Checkpoint
 ===================================================
 
-In this tutorial, we will share some tips for loading a model from a checkpoint.
-In particular, we will discuss
-
+If you're loading a checkpoint and want to reduce compute and memory as much as possible,
+this tutorial shares some recommended practices. In particular, we will discuss
 
 1.  The ``mmap`` keyword argument on ``torch.load``
 2.  The ``torch.device()`` context manager
@@ -34,7 +33,6 @@ class SomeModule(torch.nn.Module):
 m = SomeModule(1000)
 torch.save(m.state_dict(), 'checkpoint.pth')
 
-
 #################################################################
 # The follow snippet demonstrates the use of the three utilities.
 
@@ -52,23 +50,25 @@ m = SomeModule(1000)
 m.load_state_dict(state_dict)
 
 #################################################################################
+# Using ``torch.load(mmap=True)``
+# -------------------------------
+# First let us consider what happens when we ``torch.load`` the checkpoint.
 # At ``torch.save`` time, tensor storages are tagged with the device they are
 # saved on. At ``torch.load`` time, tensor storages will be loaded to the device
 # they were tagged with (unless this behavior is overridden using the
 # ``map_location`` flag). For ease of explanation, let us assume that the tensors
-# were saved on CPU. This means that on the first line
+# were saved on CPU. This means that on the first line all tensor storages will be
+# loaded into CPU RAM, which can be undesirable when
+#     1. CPU RAM is smaller than the size of the checkpoint
+#     2. Waiting for the entire checkpoint to be loaded into RAM before
+#        doing for example some per-tensor processing
 
 start_time = time.time()
 state_dict = torch.load('checkpoint.pth')
 end_time = time.time()
 print(f"loading time without mmap={end_time - start_time}")
 
-################################################################################
-# All tensor storages will be loaded into CPU RAM, which can be problematic when
-#     1. CPU RAM is smaller than the size of the checkpoint
-#     2. waiting for the entire checkpoint to be loaded into RAM before
-#        doing for example some per-tensor processing
-#
+#################################################################################
 # The ``mmap`` keyword argument to ``torch.load`` attempts to solve the above two
 # problems. As its name implies, the ``mmap`` keyword argument to ``torch.load``
 # makes use of an `mmap call <https://man7.org/linux/man-pages/man2/mmap.2.html>`_
@@ -81,10 +81,9 @@ state_dict = torch.load('checkpoint.pth', mmap=True)
 end_time = time.time()
 print(f"loading time with mmap={end_time - start_time}")
 
-################################################################################
+######################################################################################
 # As mentioned above, one can use this argument to do per-tensor processing on a
-# checkpoint without loading all tensor storages into memory upfront. For example,
-
+# checkpoint without loading all tensor storages into CPU memory upfront. For example,
 def my_special_routine(t, device):
     # this could be a much fancier operation
     return t.to(dtype=torch.bfloat16, device=device)
@@ -100,35 +99,34 @@ for key in state_dict.keys():
     state_dict[key] = my_processing_function(key, device)
 
 ##############################################
+# Using ``torch.device('meta')``
+# ------------------------------
 # Next, we consider the creation of the module.
 m = SomeModule(1000)
 
-###############################################################################
+#######################################################################################################
 # This allocates memory for all parameters/buffers and initializes them per
 # the default initialization schemes defined in ``SomeModule.__init__()``, which
 # is wasteful when we want to load a checkpoint as
-#     1. The result of the initialization kernels will be overwritten by
-#        `load_state_dict()` without ever being used, so initialization is
-#         wasteful.
-#     2. We are allocating memory for these parameters/buffers in RAM while
-#        ``torch.load`` of the saved state dictionary also allocates memory for
-#        the parameters/buffers in the checkpoint.
+#     1. The result of the initialization kernels will be overwritten by ``load_state_dict()``
+#        without ever being used, so initialization is wasteful.
+#     2. We are allocating memory for these parameters/buffers in RAM while ``torch.load`` of
+#        the saved state dictionary also allocates memory for the parameters/buffers in the checkpoint.
 #
 # In order to solve these two problems, we can use the ``torch.device()``
 # context manager with ``device='meta'`` when we instantiate the ``nn.Module()``.
-
+#
+# The `torch.device() <https://pytorch.org/docs/main/tensor_attributes.html#torch-device>`_
+# context manager makes sure that factory calls will be performed as if they
+# were passed the specified ``device`` as an argument. Tensors on ``torch.device('meta')`` do not
+# carry data. However, they possess all other metadata a tensor carries such as ``.size()``, ``.stride()``
+# and ``.requires_grad`` etc.
 with torch.device('meta'):
   new_m = SomeModule(1000)
 
-############################################################################################
-# The `torch.device() <https://pytorch.org/docs/main/tensor_attributes.html#torch-device>` _
-# context manager makes sure that factory calls will be performed as if they
-# were passed device as an argument.
-#
-# Tensors on the `meta` device do not carry data. However, they possess all
-# other metadata a tensor carries such as ```.size()`` and ```.stride()``,
-# ``.requires_grad`` etc.
-#
+########################################################
+# Using ``load_state_dict(assign=True)``
+# --------------------------------------
 # Next, we consider the loading of the state dictionary.
 
 m.load_state_dict(state_dict)
@@ -137,7 +135,7 @@ m.load_state_dict(state_dict)
 # ``nn.Module.load_state_dict()`` is usually implemented via an in-place
 # ``param_in_model.copy_(param_in_state_dict)`` (i.e. a copy from the
 # parameter/buffer with the corresponding key in the state dictionary into
-# the parameters/buffers in the ``nn.Module```).
+# the parameter/buffer in the ``nn.Module``).
 #
 # However, an in-place copy into a tensor on the ``meta`` device is a no-op.
 # In order to avoid this, we can pass the ``assign=True`` keyword argument to
@@ -152,7 +150,7 @@ new_m.load_state_dict(state_dict, assign=True)
 opt = torch.optim.SGD(new_m.parameters(), lr=1e-3)
 
 ###############################################################################
-# To recap, in this tutorial, we learned about ``torch.load(mmap=True)``, the
-# ``torch.device()`` context manager with ``device=meta`` and the
-# ``nn.Module.load_state_dict(assign=True)`` and how these tools could be used
-# to aid when loading a model from a checkpoint.
+# To recap, in this tutorial we learned about ``torch.load(mmap=True)``, the
+# ``torch.device()`` context manager with ``device=meta`` and
+# ``nn.Module.load_state_dict(assign=True)`` as well as how these tools could
+# be used to aid when loading a model from a checkpoint.

--- a/recipes_source/recipes_index.rst
+++ b/recipes_source/recipes_index.rst
@@ -130,6 +130,13 @@ Recipes are bite-sized, actionable examples of how to use specific PyTorch featu
    :link: ../recipes/recipes/reasoning_about_shapes.html
    :tags: Basics
 
+.. customcarditem::
+   :header: Tips for Loading an nn.Module from a Checkpoint
+   :card_description: Learn tips for loading an nn.Module from a checkpoint.
+   :image: ../_static/img/thumbnails/cropped/generic-pytorch-logo.png
+   :link: ../recipes/recipes/module_load_state_dict_tips.html
+   :tags: Basics
+
 .. Interpretability
 
 .. customcarditem::


### PR DESCRIPTION
Added tutorial for some utilities for loading checkpoint 

1.  The ``mmap`` keyword argument on ``torch.load``
2.  The ``torch.device()`` context manager
3.  The ``assign`` keyword argument on ``nn.Module.load_state_dict()``
