### PR TITLE
fixed the dataloader usage problem in the cifar10_tutorial #80181

### DIFF
--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -104,13 +104,15 @@ def imshow(img):
 
 
 # get some random training images
-dataiter = iter(trainloader)
-images, labels = next(dataiter)
+for data in trainloader:
+    images, labels = data
 
-# show images
-imshow(torchvision.utils.make_grid(images))
-# print labels
-print(' '.join(f'{classes[labels[j]]:5s}' for j in range(batch_size)))
+    # show images
+    imshow(torchvision.utils.make_grid(images))
+    # print labels
+    print(' '.join(f'{classes[labels[j]]:5s}' for j in range(batch_size)))
+    break
+
 
 
 ########################################################################
@@ -209,12 +211,13 @@ torch.save(net.state_dict(), PATH)
 #
 # Okay, first step. Let us display an image from the test set to get familiar.
 
-dataiter = iter(testloader)
-images, labels = next(dataiter)
+for data in testloader:
+    images, labels = data
 
-# print images
-imshow(torchvision.utils.make_grid(images))
-print('GroundTruth: ', ' '.join(f'{classes[labels[j]]:5s}' for j in range(4)))
+    # print images
+    imshow(torchvision.utils.make_grid(images))
+    print('GroundTruth: ', ' '.join(f'{classes[labels[j]]:5s}' for j in range(4)))
+    break
 
 ########################################################################
 # Next, let's load back in our saved model (note: saving and re-loading the model
@@ -363,5 +366,4 @@ print(device)
 # .. _Chat with other users on Slack: https://pytorch.slack.com/messages/beginner/
 
 # %%%%%%INVISIBLE_CODE_BLOCK%%%%%%
-del dataiter
 # %%%%%%INVISIBLE_CODE_BLOCK%%%%%%


### PR DESCRIPTION
Fixes #80181

## Description
Fix the dataloader usage problem in the cifar10_tutorial reported in
https://github.com/pytorch/pytorch/issues/80181

<!--- Describe your changes in detail -->
Problem:
 iter(dataloader) has no method called next(), and therefore it throws AttributeError:
```
python cifar10_tutorial.py
Files already downloaded and verified
Files already downloaded and verified
Traceback (most recent call last):
  File "cifar10_tutorial.py", line 113, in <module>
    images, labels = dataiter.next()
AttributeError: '_MultiProcessingDataLoaderIter' object has no attribute 'next'
```
Fixed the sample code to get the first example images without problem.
```
Files already downloaded and verified
Files already downloaded and verified
bird  plane horse plane
```
## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @suraj813 @albanD