### PR TITLE
Update modelsyt_tutorial.py

### DIFF
--- a/beginner_source/introyt/modelsyt_tutorial.py
+++ b/beginner_source/introyt/modelsyt_tutorial.py
@@ -95,7 +95,7 @@ for param in tinymodel.linear2.parameters():
 # The most basic type of neural network layer is a *linear* or *fully
 # connected* layer. This is a layer where every input influences every
 # output of the layer to a degree specified by the layer’s weights. If a
-# model has *m* inputs and *n* outputs, the weights will be an *m* x *n*
+# model has *m* inputs and *n* outputs, the weights will be an *n* x *m*
 # matrix. For example:
 # 
 


### PR DESCRIPTION
Looks like the weight matrix for the "torch.nn.Linear" class with m inputs and n outputs should be n x m,
 
I was checking the code for  torch.nn.Linear class, I came across the following code

 self.weight = Parameter(torch.empty((out_features, in_features), **factory_kwargs))

Please ignore this in case I have got it wrong

Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
