### PR TITLE
Add 'Introduction to ONNX' at 'Deploying PyTorch Models in Production'

### DIFF
--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -10,6 +10,7 @@ REPO_ROOT = Path(__file__).parent.parent
 
 NOT_RUN = [
     "beginner_source/basics/intro",  # no code
+    "beginner_source/onnx/intro_onnx",
     "beginner_source/translation_transformer",
     "beginner_source/profiler",
     "beginner_source/saving_loading_models",

--- a/beginner_source/onnx/README.txt
+++ b/beginner_source/onnx/README.txt
@@ -1,0 +1,7 @@
+ONNX
+----
+
+1. intro_onnx.py
+    Learn the Basics of ONNX
+    https://pytorch.org/tutorials/onnx/intro_onnx.html
+

--- a/beginner_source/onnx/intro_onnx.py
+++ b/beginner_source/onnx/intro_onnx.py
@@ -1,0 +1,50 @@
+"""
+**Introduction to ONNX**
+
+Introduction to ONNX
+====================
+
+Authors:
+`Thiago Crepaldi <https://github.com/thiagocrepaldi>`_,
+
+`Open Neural Network eXchange (ONNX) <https://onnx.ai/>`_ is an open standard
+format for representing machine learning models. The ``torch.onnx`` module provides APIs to
+capture the computation graph from a native PyTorch :class:`torch.nn.Module` model and convert
+it into an `ONNX graph <https://github.com/onnx/onnx/blob/main/docs/IR.md>`_.
+
+The exported model can be consumed by any of the many
+`runtimes that support ONNX <https://onnx.ai/supported-tools.html#deployModel>`_,
+including Microsoft's `ONNX Runtime <https://www.onnxruntime.ai>`_.
+
+.. Note::
+    Currently there are two flavors of ONNX exporter APIs,
+    but this tutorial will focus on the ``torch.onnx.dynamo_export``.
+
+TorchDynamo engine is leveraged to hook into Python's frame evaluation API and dynamically rewrite its
+bytecode into an  `FX graph <https://pytorch.org/docs/stable/fx.html>`_.
+The resulting FX Graph is polished before it is finally translated into an
+`ONNX graph <https://github.com/onnx/onnx/blob/main/docs/IR.md>`_.
+
+The main advantage of this approach is that the `FX graph <https://pytorch.org/docs/stable/fx.html>`_ is captured using
+bytecode analysis that preserves the dynamic nature of the model instead of using traditional static tracing techniques.
+
+Dependencies
+------------
+
+The ONNX exporter depends on extra Python packages:
+
+  - `ONNX <https://onnx.ai>`_
+  - `ONNX Script <https://onnxscript.ai>`_
+
+They can be installed through `pip <https://pypi.org/project/pip/>`_:
+
+.. code-block:: bash
+
+  pip install --upgrade onnx onnxscript
+
+.. include:: /beginner_source/basics/onnx_toc.txt
+
+.. toctree::
+   :hidden:
+
+"""

--- a/index.rst
+++ b/index.rst
@@ -272,6 +272,16 @@ What's new in PyTorch tutorials?
    :tags: Text
 
 
+.. ONNX
+
+.. customcarditem::
+   :header: (optional) Exporting a PyTorch Model to ONNX using TorchScript backend and Running it using ONNX Runtime
+   :card_description:  Convert a model defined in PyTorch into the ONNX format and then run it with ONNX Runtime.
+   :image: _static/img/thumbnails/cropped/optional-Exporting-a-Model-from-PyTorch-to-ONNX-and-Running-it-using-ONNX-Runtime.png
+   :link: advanced/super_resolution_with_onnxruntime.html
+   :tags: ONNX,Production
+
+
 .. Reinforcement Learning
 
 .. customcarditem::
@@ -327,13 +337,6 @@ What's new in PyTorch tutorials?
    :image: _static/img/thumbnails/cropped/Loading-a-TorchScript-Model-in-Cpp.png
    :link: advanced/cpp_export.html
    :tags: Production,TorchScript
-
-.. customcarditem::
-   :header: (optional) Exporting a Model from PyTorch to ONNX and Running it using ONNX Runtime
-   :card_description:  Convert a model defined in PyTorch into the ONNX format and then run it with ONNX Runtime.
-   :image: _static/img/thumbnails/cropped/optional-Exporting-a-Model-from-PyTorch-to-ONNX-and-Running-it-using-ONNX-Runtime.png
-   :link: advanced/super_resolution_with_onnxruntime.html
-   :tags: Production
 
 .. Code Transformations with FX
 
@@ -918,6 +921,7 @@ Additional Resources
    :hidden:
    :caption: Deploying PyTorch Models in Production
 
+   beginner/onnx/intro_onnx
    intermediate/flask_rest_api_tutorial
    beginner/Intro_to_TorchScript_tutorial
    advanced/cpp_export


### PR DESCRIPTION
This PR adds a ONNX page to the left menu
'Deploying PyTorch Models in Production' that will  act as a placeholder for the series of ONNX export tutorials based on Torch Dynamo backend

A table of content tree page will have static URL
https://pytorch.org/tutorials/beginner/onnx/intro_onnx.html that will be referenced on PyTorch user document for torch.onnx module
