### PR TITLE
SDPA tutorial requires newer CUDA, so host it on an A10G

### DIFF
--- a/.jenkins/get_files_to_run.py
+++ b/.jenkins/get_files_to_run.py
@@ -46,6 +46,9 @@ def calculate_shards(all_files: List[str], num_shards: int = 20) -> List[List[st
     needs_gpu_nvidia_medium = list(
         filter(lambda x: get_needs_machine(x) == "gpu.nvidia.large", all_files,)
     )
+    needs_a10g = list(
+        filter(lambda x: get_needs_machine(x) == "linux.g5.4xlarge.nvidia.gpu", all_files,)
+    )
     for filename in needs_gpu_nvidia_small_multi:
         # currently, the only job that uses gpu.nvidia.small.multi is the 0th worker,
         # so we'll add all the jobs that need this machine to the 0th worker
@@ -55,6 +58,11 @@ def calculate_shards(all_files: List[str], num_shards: int = 20) -> List[List[st
         # currently, the only job that uses gpu.nvidia.large is the 1st worker,
         # so we'll add all the jobs that need this machine to the 1st worker
         add_to_shard(1, filename)
+        all_other_files.remove(filename)
+    for filename in needs_a10g:
+        # currently, workers 2-5th use linux.g5.4xlarge.nvidia.gpu, so, arbitrarily,
+        # we'll add all the jobs that need this machine to the 5th worker
+        add_to_shard(5, filename)
         all_other_files.remove(filename)
 
     sorted_files = sorted(all_other_files, key=get_duration, reverse=True,)

--- a/.jenkins/metadata.json
+++ b/.jenkins/metadata.json
@@ -30,5 +30,8 @@
   },
   "intermediate_source/torch_compile_tutorial.py": {
     "needs": "gpu.nvidia.large"
+  },
+  "intermediate_source/scaled_dot_product_attention_tutorial.py": {
+    "needs": "linux.g5.4xlarge.nvidia.gpu"
   }
 }


### PR DESCRIPTION
## Description
Should fix the fact that I run into tutorial build issues when the sharding algorithm punts the tutorial to a different worker that has too old of a GPU. 
```
RuntimeError: Found Tesla M60 which is too old to be supported by the triton GPU compiler, which is used as the backend. Triton only supports devices of CUDA Capability >= 7.0, but your device is of CUDA capability 5.2
```

Error logs: https://github.com/pytorch/tutorials/actions/runs/6281857867/job/17060687817

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
