### PR TITLE
[TorchFix] Update deprecated TorchVision `pretrained` parameters

### DIFF
--- a/prototype_source/numeric_suite_tutorial.py
+++ b/prototype_source/numeric_suite_tutorial.py
@@ -28,7 +28,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torchvision
-from torchvision import datasets
+from torchvision import models, datasets
 import torchvision.transforms as transforms
 import os
 import torch.quantization
@@ -43,7 +43,7 @@ from torch.quantization import (
 # Then we load the pretrained float ResNet18 model, and quantize it into qmodel. We cannot compare two arbitrary models, only a float model and the quantized model derived from it can be compared.
 
 
-float_model = torchvision.models.quantization.resnet18(pretrained=True, quantize=False)
+float_model = torchvision.models.quantization.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1, quantize=False)
 float_model.to('cpu')
 float_model.eval()
 float_model.fuse_model()
@@ -199,7 +199,7 @@ act_compare_dict = ns.get_matching_activations(float_model, qmodel)
 #
 # Notice before each call of ``compare_model_outputs()`` and ``compare_model_stub()`` we need to have clean float and quantized model. This is because ``compare_model_outputs()`` and ``compare_model_stub()`` modify float and quantized model inplace, and it will cause unexpected results if call one right after another.
 
-float_model = torchvision.models.quantization.resnet18(pretrained=True, quantize=False)
+float_model = torchvision.models.quantization.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1, quantize=False)
 float_model.to('cpu')
 float_model.eval()
 float_model.fuse_model()

--- a/recipes_source/recipes/Captum_Recipe.py
+++ b/recipes_source/recipes/Captum_Recipe.py
@@ -42,12 +42,12 @@ Model Interpretability using Captum
 # 
 
 import torchvision
-from torchvision import transforms
+from torchvision import models, transforms
 from PIL import Image
 import requests
 from io import BytesIO
 
-model = torchvision.models.resnet18(pretrained=True).eval()
+model = torchvision.models.resnet18(weights=models.ResNet18_Weights.IMAGENET1K_V1).eval()
 
 response = requests.get("https://image.freepik.com/free-photo/two-beautiful-puppies-cat-dog_58409-6024.jpg")
 img = Image.open(BytesIO(response.content))


### PR DESCRIPTION
For TorchVision models, `pretrained` parameters have been deprecated in favor of "Multi-weight support API" - see https://pytorch.org/vision/0.15/models.html