### PR TITLE
[BE] Do not download audio assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,6 @@ download:
 	wget -nv -N https://s3.amazonaws.com/pytorch-tutorial-assets/cornell_movie_dialogs_corpus_v2.zip -P $(DATADIR)
 	unzip $(ZIPOPTS) $(DATADIR)/cornell_movie_dialogs_corpus_v2.zip -d beginner_source/data/
 
-	# Download dataset for beginner_source/audio_classifier_tutorial.py
-	wget -nv -N https://s3.amazonaws.com/pytorch-tutorial-assets/UrbanSound8K.tar.gz -P $(DATADIR)
-	tar $(TAROPTS) -xzf $(DATADIR)/UrbanSound8K.tar.gz -C ./beginner_source/data/
-
-
 	# Download model for advanced_source/dynamic_quantization_tutorial.py
 	wget -nv -N https://s3.amazonaws.com/pytorch-tutorial-assets/word_language_model_quantize.pth -P $(DATADIR)
 	cp $(DATADIR)/word_language_model_quantize.pth advanced_source/data/word_language_model_quantize.pth

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ librosa
 torch
 torchvision
 torchtext
-torchaudio
 torchdata
 networkx
 PyHamcrest
@@ -32,7 +31,6 @@ nbformat>=4.2.0
 datasets
 transformers
 torchmultimodal-nightly # needs to be updated to stable as soon as it's avaialable
-deep_phonemizer==0.0.17
 
 importlib-metadata==6.8.0
 


### PR DESCRIPTION
Followup after https://github.com/pytorch/tutorials/pull/2154 that moved audio tutorials to another repo
- Do not install `torchaudio`
- Do not download `UrbanSound8K.tar.gz`, which is 5+Gb
