### PR TITLE
Pin torchrl deps to 0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ tensorboard
 jinja2==3.0.3
 pytorch-lightning
 torchx
-torchrl==0.1.1
+torchrl==0.2.0
 ax-platform
 nbformat>=4.2.0
 datasets

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ tensorboard
 jinja2==3.0.3
 pytorch-lightning
 torchx
-torchrl
+torchrl==0.1.1
 ax-platform
 nbformat>=4.2.0
 datasets


### PR DESCRIPTION
As latests seems to be incompatible with latest tensordict release, see https://github.com/pytorch/rl/issues/1606
