### PR TITLE
Small fixes to torch.compile tutorial

### DIFF
--- a/intermediate_source/torch_compile_tutorial.py
+++ b/intermediate_source/torch_compile_tutorial.py
@@ -250,7 +250,7 @@ print("~" * 10)
 #
 # We remark that the speedup numbers presented in this tutorial are for
 # demonstration purposes only. Official speedup values can be seen at the
-# `TorchInductor performance dashboard <https://hud.pytorch.org/benchmark/compilers>`__
+# `TorchInductor performance dashboard <https://hud.pytorch.org/benchmark/compilers>`__.
 
 ######################################################################
 # Comparison to TorchScript and FX Tracing


### PR DESCRIPTION
Add link to PT2 benchmarks for official speedup numbers.

Replace `evaluate` function by calling the model/optimized model.