### PR TITLE
Pin tensordict to 0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ jinja2==3.0.3
 pytorch-lightning
 torchx
 torchrl==0.2.0
+tensordict==0.2.0
 ax-platform
 nbformat>=4.2.0
 datasets


### PR DESCRIPTION
See https://github.com/pytorch/tensordict/issues/547

Should fix https://github.com/pytorch/tutorials/actions/runs/6659680370/job/18099294856 and prevent tutorials CI regress from the sudden updates of the dependencies
