### PR TITLE
Change links to the newest examples

### DIFF
--- a/intermediate_source/FSDP_adavnced_tutorial.rst
+++ b/intermediate_source/FSDP_adavnced_tutorial.rst
@@ -74,8 +74,8 @@ summarization using WikiHow dataset.  The main focus of this tutorial is to
 highlight different available features in FSDP that are helpful for training
 large scale model above 3B parameters. Also, we cover specific features for
 Transformer based models. The code for this tutorial is available in  `Pytorch
-Examples
-<https://github.com/HamidShojanazeri/examples/tree/FSDP_example/distributed/FSDP/>`__.
+examples
+<https://github.com/pytorch/examples/tree/main/distributed/FSDP/>`__.
 
 
 *Setup*
@@ -97,13 +97,13 @@ Please create a `data` folder, download the WikiHow dataset from `wikihowAll.csv
 `wikihowSep.cs <https://ucsb.app.box.com/s/7yq601ijl1lzvlfu4rjdbbxforzd2oag>`__,
 and place them in the `data` folder.  We will use the wikihow dataset from
 `summarization_dataset
-<https://github.com/HamidShojanazeri/examples/blob/FSDP_example/distributed/FSDP/summarization_dataset.py>`__.
+<https://github.com/pytorch/examples/blob/main/distributed/FSDP/summarization_dataset.py>`__.
 
 Next, we add the following code snippets to a Python script “T5_training.py”.
 
 .. note::
    The full source code for this tutorial is available in `PyTorch examples
-   <https://github.com/HamidShojanazeri/examples/tree/FSDP_example/distributed/FSDP>`__.
+   <https://github.com/pytorch/examples/tree/main/distributed/FSDP/>`__.
 
 1.3  Import necessary packages:
 


### PR DESCRIPTION
The current links are poiting to older examples on an individual repo. This PR replaces those links with the PyTorch upstream examples repo. Also, adding consistency in how examples are referenced to point to the links.

Fixes #2447

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @sekyondaMeta @svekars @carljparker @NicolasHug @kit1980 @subramen