### PR TITLE
Update static quantization tutorial code link to go to mobilenetv2.py

### DIFF
--- a/advanced_source/static_quantization_tutorial.rst
+++ b/advanced_source/static_quantization_tutorial.rst
@@ -59,7 +59,7 @@ to enable quantization:
 - Replace ReLU6 with ReLU 
  
 Note: this code is taken from 
-`here <https://github.com/pytorch/vision/blob/master/torchvision/models/mobilenet.py>`_.  
+`here <https://github.com/pytorch/vision/blob/main/torchvision/models/mobilenetv2.py>`_.
 
 .. code:: python
 


### PR DESCRIPTION
The link says most of the code is from "here", but it goes to mobilenet.py which is just imports. Most of the code comes from mobilenetv2.py.

Fixes #2637

## Description
Updating one "here" link.

The link says most of the code is from "here", but it goes to mobilenet.py which is just imports.
Most of the code comes from mobilenetv2.py.

This is the first link under https://pytorch.org/tutorials/advanced/static_quantization_tutorial.html#model-architecture which includes significant code for class MobileNetV2.

As someone trying to follow the tutorial and use those links, it would make more sense to go to mobilev2.py.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @svekars @carljparker @sekyondaMeta @NicolasHug @kit1980 @subramen