### PR TITLE
Update parametrizations.py

### DIFF
--- a/intermediate_source/parametrizations.py
+++ b/intermediate_source/parametrizations.py
@@ -227,7 +227,7 @@ class CayleyMap(nn.Module):
 
     def forward(self, X):
         # (I + X)(I - X)^{-1}
-        return torch.linalg.solve(self.Id + X, self.Id - X)
+        return torch.linalg.solve(self.Id - X, self.Id + X)
 
 layer = nn.Linear(3, 3)
 parametrize.register_parametrization(layer, "weight", Skew())
@@ -301,13 +301,13 @@ class CayleyMap(nn.Module):
     def forward(self, X):
         # Assume X skew-symmetric
         # (I + X)(I - X)^{-1}
-        return torch.linalg.solve(self.Id + X, self.Id - X)
+        return torch.linalg.solve(self.Id - X, self.Id + X)
 
     def right_inverse(self, A):
         # Assume A orthogonal
         # See https://en.wikipedia.org/wiki/Cayley_transform#Matrix_map
         # (X - I)(X + I)^{-1}
-        return torch.linalg.solve(X - self.Id, self.Id + X)
+        return torch.linalg.solve(X + self.Id, self.Id - X)
 
 layer_orthogonal = nn.Linear(3, 3)
 parametrize.register_parametrization(layer_orthogonal, "weight", Skew())

--- a/intermediate_source/parametrizations.py
+++ b/intermediate_source/parametrizations.py
@@ -227,7 +227,7 @@ class CayleyMap(nn.Module):
 
     def forward(self, X):
         # (I + X)(I - X)^{-1}
-        return torch.solve(self.Id + X, self.Id - X).solution
+        return torch.linalg.solve(self.Id + X, self.Id - X)
 
 layer = nn.Linear(3, 3)
 parametrize.register_parametrization(layer, "weight", Skew())
@@ -301,13 +301,13 @@ class CayleyMap(nn.Module):
     def forward(self, X):
         # Assume X skew-symmetric
         # (I + X)(I - X)^{-1}
-        return torch.solve(self.Id + X, self.Id - X).solution
+        return torch.linalg.solve(self.Id + X, self.Id - X)
 
     def right_inverse(self, A):
         # Assume A orthogonal
         # See https://en.wikipedia.org/wiki/Cayley_transform#Matrix_map
         # (X - I)(X + I)^{-1}
-        return torch.solve(X - self.Id, self.Id + X).solution
+        return torch.linalg.solve(X - self.Id, self.Id + X)
 
 layer_orthogonal = nn.Linear(3, 3)
 parametrize.register_parametrization(layer_orthogonal, "weight", Skew())


### PR DESCRIPTION
For PyTorch 2, torch.solve => torch.linalg.solve

Fixes #2641

## Description
Code like
`    def forward(self, X):`
 `       # (I + X)(I - X)^{-1}`
`        return torch.solve(self.Id + X, self.Id - X).solution`
results in
`RuntimeError: This function was deprecated since version 1.9 and is now removed. torch.solve is deprecated in favor of torch.linalg.solve. torch.linalg.solve has its arguments reversed and does not return the LU factorization.`

Update to use `pytorch.linalg.solve`

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @albanD @sekyondaMeta @svekars @carljparker @NicolasHug @kit1980 @subramen