### PR TITLE
Replace  usage of copy.deepcopy() - Convolution/Batch Norm Fuser in FX

### DIFF
--- a/intermediate_source/fx_conv_bn_fuser.py
+++ b/intermediate_source/fx_conv_bn_fuser.py
@@ -104,7 +104,9 @@ def fuse_conv_bn_eval(conv, bn):
     module `C` such that C(x) == B(A(x)) in inference mode.
     """
     assert(not (conv.training or bn.training)), "Fusion only for eval!"
-    fused_conv = copy.deepcopy(conv)
+    fused_conv = type(conv)(conv.in_channels, conv.out_channels, conv.kernel_size)
+    fused_conv.load_state_dict(conv.state_dict())
+    fused_conv.eval()
 
     fused_conv.weight, fused_conv.bias = \
         fuse_conv_bn_weights(fused_conv.weight, fused_conv.bias,

--- a/intermediate_source/fx_conv_bn_fuser.py
+++ b/intermediate_source/fx_conv_bn_fuser.py
@@ -150,7 +150,9 @@ def replace_node_module(node: fx.Node, modules: Dict[str, Any], new_module: torc
 
 
 def fuse(model: torch.nn.Module) -> torch.nn.Module:
-    model = copy.deepcopy(model)
+    model, state_dict = type(model)(), model.state_dict()
+    model.load_state_dict(state_dict)
+    model.eval()
     # The first step of most FX passes is to symbolically trace our model to
     # obtain a `GraphModule`. This is a representation of our original model
     # that is functionally identical to our original model, except that we now


### PR DESCRIPTION
Fixes #2331 

## Description
Replacing the use of `copy.deepcopy()` in _Convolution/Batch Norm Fuser in FX tutorials_   with use of `load_state_dict`   as mentioned in [Deep copying PyTorch modules](https://discuss.pytorch.org/t/deep-copying-pytorch-modules/13514). 

cc @eellison @suo @gmagogsfm @jamesr66a @msaroufim @SherlockNoMad @albanD @sekyondaMeta @svekars @carljparker @NicolasHug @kit1980 @subramen