### PR TITLE
Modifying data_parallel_tutorial.py to enable multiple GPU support

### DIFF
--- a/beginner_source/blitz/data_parallel_tutorial.py
+++ b/beginner_source/blitz/data_parallel_tutorial.py
@@ -9,7 +9,7 @@ It's very easy to use GPUs with PyTorch. You can put the model on a GPU:
 
 .. code:: python
 
-    device = torch.device("cuda:0")
+    device = torch.device("cuda")
     model.to(device)
 
 Then, you can copy all your tensors to the GPU:

--- a/beginner_source/blitz/data_parallel_tutorial.py
+++ b/beginner_source/blitz/data_parallel_tutorial.py
@@ -57,7 +57,7 @@ data_size = 100
 ######################################################################
 # Device
 #
-device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 ######################################################################
 # Dummy DataSet


### PR DESCRIPTION
Fixes #2563

## Description
Modifying data_parallel_tutorial.py, by removing the specification "cuda:0," you enable the use of multiple GPUs. When you specify the index "0," it restricts the computation to only the GPU at index 0. However, if your system has multiple GPUs available, PyTorch will automatically distribute the computation across all available GPUs, resulting in faster training for deep learning tasks. This flexibility allows you to take full advantage of your GPU resources and potentially reduce training times when working with multiple GPUs.

## Checklist

- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @sekyondaMeta @svekars @carljparker @NicolasHug @kit1980 @subramen