### PR TITLE
Add logging to last episode

### DIFF
--- a/intermediate_source/mario_rl_tutorial.py
+++ b/intermediate_source/mario_rl_tutorial.py
@@ -778,7 +778,7 @@ for e in range(episodes):
 
     logger.log_episode()
 
-    if e % 20 == 0:
+    if (e % 20 == 0) or (e == episodes - 1):
         logger.record(episode=e, epsilon=mario.exploration_rate, step=mario.curr_step)
 
 


### PR DESCRIPTION
Fixes #2651

## Description
Improved the episode functionality by ensuring that episodes are logged properly, preventing unnecessary episode runs without logging.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @vmoens @nairbv @sekyondaMeta @svekars @carljparker @NicolasHug @kit1980 @subramen