### PR TITLE
corrected comment regarding .train and .eval

### DIFF
--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -214,13 +214,14 @@ for epoch in range(1):  # loop over the dataset multiple times
             # Check against the validation set
             running_vloss = 0.0
             
-            net.train(False) # Don't need to track gradents for validation
+            # In evaluation mode some model specific operations can be omitted eg. dropout layer
+            net.train(False) # Switching to evaluation mode, eg. turning off regularisation
             for j, vdata in enumerate(validation_loader, 0):
                 vinputs, vlabels = vdata
                 voutputs = net(vinputs)
                 vloss = criterion(voutputs, vlabels)
                 running_vloss += vloss.item()
-            net.train(True) # Turn gradients back on for training
+            net.train(True) # Switching back to training mode, eg. turning on regularisation
             
             avg_loss = running_loss / 1000
             avg_vloss = running_vloss / len(validation_loader)


### PR DESCRIPTION
Fixes #1756

## Description
Corrected the comment mentioning the use of `.train(True)` and `.train(False)`.

## Checklist
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @suraj813 @aaronenyeshi @chaekit @jcarreiro @sekyondaMeta @svekars @carljparker @NicolasHug @kit1980 @subramen