### PR TITLE
Enable antialias on marioRL

### DIFF
--- a/intermediate_source/mario_rl_tutorial.py
+++ b/intermediate_source/mario_rl_tutorial.py
@@ -199,7 +199,7 @@ class ResizeObservation(gym.ObservationWrapper):
 
     def observation(self, observation):
         transforms = T.Compose(
-            [T.Resize(self.shape), T.Normalize(0, 255)]
+            [T.Resize(self.shape, antialias=True), T.Normalize(0, 255)]
         )
         observation = transforms(observation).squeeze(0)
         return observation


### PR DESCRIPTION
Fixes #2650

## Description
<!--- Describe your changes in detail -->
Enabling antialias for compatibility with newer versions of PyTorch.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @vmoens @nairbv @sekyondaMeta @svekars @carljparker @NicolasHug @kit1980 @subramen