### PR TITLE
Update .pyspelling.yml

### DIFF
--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -19,7 +19,7 @@ matrix:
         - open: '\.\.\s+(figure|literalinclude|math|image|grid)::'
           close: '\n'
         # Exclude roles:
-        - open: ':(?:(class|py:mod|mod|func)):`'
+        - open: ':(?:(class|py:mod|mod|func|meth|obj)):`'
           content: '[^`]*'
           close: '`'
         # Exclude reStructuredText hyperlinks
@@ -70,7 +70,7 @@ matrix:
       - open: ':figure:.*'
         close: '\n'
       # Ignore reStructuredText roles
-      - open: ':(?:(class|file|func|math|ref|octicon)):`'
+      - open: ':(?:(class|file|func|math|ref|octicon|meth|obj)):`'
         content: '[^`]*'
         close: '`'
       - open: ':width:'


### PR DESCRIPTION
Exclude :meth: and :obj: from spellcheck.  