### PR TITLE
Add usage of int8-mixed-bf16 quantization with X86InductorQuantizer

### DIFF
--- a/prototype_source/pt2e_quant_ptq_x86_inductor.rst
+++ b/prototype_source/pt2e_quant_ptq_x86_inductor.rst
@@ -175,6 +175,8 @@ In a more advanced scenario, int8-mixed-bf16 quantization comes into play. In th
 a Convolution or GEMM operator produces BFloat16 output data type instead of Float32 in the absence
 of a subsequent quantization node. Subsequently, the BFloat16 tensor seamlessly propagates through
 subsequent pointwise operators, effectively minimizing memory usage and potentially enhancing performance.
+The utilization of this feature mirrors that of regular BFloat16 Autocast, as simple as wrapping the
+script within the BFloat16 Autocast context.
 
 ::
 

--- a/prototype_source/pt2e_quant_ptq_x86_inductor.rst
+++ b/prototype_source/pt2e_quant_ptq_x86_inductor.rst
@@ -165,11 +165,25 @@ After we get the quantized model, we will further lower it to the inductor backe
 
 ::
 
-    optimized_model = torch.compile(converted_model)
+    with torch.no_grad():
+        optimized_model = torch.compile(converted_model)
 
-    # Running some benchmark
-    optimized_model(*example_inputs)
+        # Running some benchmark
+        optimized_model(*example_inputs)
 
+In a more advanced scenario, int8-mixed-bf16 quantization comes into play. In this instance,
+a Convolution or GEMM operator produces BFloat16 output data type instead of Float32 in the absence
+of a subsequent quantization node. Subsequently, the BFloat16 tensor seamlessly propagates through
+subsequent pointwise operators, effectively minimizing memory usage and potentially enhancing performance.
+
+::
+
+    with torch.autocast(device_type="cpu", dtype=torch.bfloat16, enabled=True), torch.no_grad():
+        # Turn on Autocast to use int8-mixed-bf16 quantization
+        optimized_model = torch.compile(converted_model)
+
+        # Running some benchmark
+        optimized_model(*example_inputs)
 
 Put all these codes together, we will have the toy example code.
 Please note that since the Inductor ``freeze`` feature does not turn on by default yet, run your example code with ``TORCHINDUCTOR_FREEZING=1``.


### PR DESCRIPTION
## Description
Add usage of int8-mixed-bf16 quantization in X86InductorQuantizer.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @sekyondaMeta @svekars @carljparker @NicolasHug @kit1980 @subramen