### PR TITLE
fix: typo error

### DIFF
--- a/beginner_source/introyt/modelsyt_tutorial.py
+++ b/beginner_source/introyt/modelsyt_tutorial.py
@@ -342,7 +342,7 @@ print(maxpool_layer(my_tensor))
 # the 6x6 input.
 # 
 # **Normalization layers** re-center and normalize the output of one layer
-# before feeding it to another. Centering the and scaling the intermediate
+# before feeding it to another. Centering them and scaling the intermediate
 # tensors has a number of beneficial effects, such as letting you use
 # higher learning rates without exploding/vanishing gradients.
 # 


### PR DESCRIPTION
In the explanation of Normalization layers, typo 'the' is changed to 'them'

Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->
There was a mistyping of a word in the tutorial explanation.
I modified it, based on the context.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
