### PR TITLE
Add `gtag()` helper function used by star-rating

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -17,7 +17,11 @@ if((window.location.href.indexOf("/prototype/")!= -1) && (window.location.href.i
 {{ super() }}
 <script>
 
-  
+<!--
+  Helper function to make it easier to call dataLayer.push()
+-->
+function gtag(){window.dataLayer.push(arguments);}
+
 //add microsoft link
 
 if(window.location.href.indexOf("/beginner/basics/")!= -1)


### PR DESCRIPTION
Originally proposed this change in the `pytorch/pytorch_sphinx_theme` repo as PR#188, but SveKars suggested we try it out in `pytorch/tutorials` which does not have as large a scope.

Fixes #2696

## Description
Add JavaScript helper function used by star-rating code...as well as other customer JavaScript in the turtorials.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
