### PR TITLE
Update torch.export tutorial for 2.2

### DIFF
--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -27,7 +27,6 @@ NOT_RUN = [
     "intermediate_source/mnist_train_nas",  # used by ax_multiobjective_nas_tutorial.py
     "intermediate_source/fx_conv_bn_fuser",
     "intermediate_source/_torch_export_nightly_tutorial",  # does not work on release
-    "intermediate_source/torch_export_tutorial", # Enable when fixed for 2.2
     "advanced_source/super_resolution_with_onnxruntime",
     "advanced_source/ddp_pipeline",  # requires 4 gpus
     "advanced_source/usb_semisup_learn", # in the current form takes 140+ minutes to build - can be enabled when the build time is reduced

--- a/intermediate_source/torch_export_tutorial.py
+++ b/intermediate_source/torch_export_tutorial.py
@@ -2,7 +2,7 @@
 
 """
 torch.export Tutorial
-=============================
+===================================================
 **Author:** William Wen, Zhengxu Chen, Angela Yi
 """
 

--- a/intermediate_source/torch_export_tutorial.py
+++ b/intermediate_source/torch_export_tutorial.py
@@ -589,7 +589,7 @@ print(core_ir_ep.graph)
 def cond_predicate(x):
     """
     The conditional statement (aka predicate) passed to ``cond()`` must be one of the following:
-    - torch.Tensor with a single element
+    - ``torch.Tensor`` with a single element
     - boolean expression
     NOTE: If the `pred` is test on a dim with batch size < 2, it will be specialized.
     """

--- a/intermediate_source/torch_export_tutorial.py
+++ b/intermediate_source/torch_export_tutorial.py
@@ -210,7 +210,7 @@ print(exported_bad1_fixed(-torch.ones(3, 3)))
 # - Branch functions cannot access closure variables, except for ``self`` if the function is
 #   defined in the scope of a method.
 #
-# For more details about ``cond``, check out the `documentation <https://pytorch.org/docs/main/cond.html>`__.
+# For more details about ``cond``, check out the `cond documentation <https://pytorch.org/docs/main/cond.html>`__.
 
 ######################################################################
 # ..

--- a/intermediate_source/torch_export_tutorial.py
+++ b/intermediate_source/torch_export_tutorial.py
@@ -276,7 +276,7 @@ except Exception:
 # assumed to be static.
 #
 # The first argument of ``torch.export.Dim`` is the name for the symbolic integer, used for debugging.
-# Then we can specify an optional minimum and maximum bound (inclusive). Below, we show example usage.
+# Then we can specify an optional minimum and maximum bound (inclusive). Below, we show a usage example.
 #
 # In the example below, our input
 # ``inp1`` has an unconstrained first dimension, but the size of the second

--- a/intermediate_source/torch_export_tutorial.py
+++ b/intermediate_source/torch_export_tutorial.py
@@ -2,8 +2,8 @@
 
 """
 torch.export Tutorial
-================
-**Author:** William Wen, Zhengxu Chen
+=============================
+**Author:** William Wen, Zhengxu Chen, Angela Yi
 """
 
 ######################################################################
@@ -11,11 +11,7 @@ torch.export Tutorial
 # .. warning::
 #
 #     ``torch.export`` and its related features are in prototype status and are subject to backwards compatibility
-#     breaking changes. This tutorial provides a snapshot of ``torch.export`` usage as of PyTorch 2.1.
-#
-# .. note::
-#     The `torch.export nightly tutorial <https://pytorch.org/tutorials/intermediate/torch_export_nightly_tutorial.html>`__
-#     demonstrates some APIs that are present in the nightly binaries, but are not present in the PyTorch 2.1 release.
+#     breaking changes. This tutorial provides a snapshot of ``torch.export`` usage as of PyTorch 2.2.
 #
 # :func:`torch.export` is the PyTorch 2.X way to export PyTorch models into
 # standardized model representations, intended
@@ -37,24 +33,29 @@ torch.export Tutorial
 #
 # ``torch.export`` extracts single-graph representations from PyTorch programs
 # by tracing the target function, given example inputs.
+# ``torch.export.export()`` is the main entry point for ``torch.export``.
 #
-# The signature of ``torch.export`` is:
+# In this tutorial, ``torch.export`` and ``torch.export.export()`` are practically synonymous,
+# though ``torch.export`` generally refers to the PyTorch 2.X export process, and ``torch.export.export()``
+# generally refers to the actual function call.
 #
-# .. code:: python
+# The signature of ``torch.export.export()`` is:
+#
+# .. code-block:: python
 #
 #     export(
 #         f: Callable,
 #         args: Tuple[Any, ...],
 #         kwargs: Optional[Dict[str, Any]] = None,
 #         *,
-#         constraints: Optional[List[Constraint]] = None
+#         dynamic_shapes: Optional[Dict[str, Dict[int, Dim]]] = None
 #     ) -> ExportedProgram
 #
-# ``torch.export`` traces the tensor computation graph from calling ``f(*args, **kwargs)``
+# ``torch.export.export()`` traces the tensor computation graph from calling ``f(*args, **kwargs)``
 # and wraps it in an ``ExportedProgram``, which can be serialized or executed later with
 # different inputs. Note that while the output ``ExportedGraph`` is callable and can be
 # called in the same way as the original input callable, it is not a ``torch.nn.Module``.
-# We will detail the ``constraints`` argument later in the tutorial.
+# We will detail the ``dynamic_shapes`` argument later in the tutorial.
 
 import torch
 from torch.export import export
@@ -71,6 +72,7 @@ mod = MyModule()
 exported_mod = export(mod, (torch.randn(8, 100), torch.randn(8, 100)))
 print(type(exported_mod))
 print(exported_mod(torch.randn(8, 100), torch.randn(8, 100)))
+
 
 ######################################################################
 # Let's review some attributes of ``ExportedProgram`` that are of interest.
@@ -183,9 +185,6 @@ except Exception:
 # ``torch.export`` actually does support data-dependent control flow.
 # But these need to be expressed using control flow ops. For example,
 # we can fix the control flow example above using the ``cond`` op, like so:
-#
-# ..
-#     [TODO] link to docs about ``cond`` when it is out
 
 from functorch.experimental.control_flow import cond
 
@@ -210,6 +209,8 @@ print(exported_bad1_fixed(-torch.ones(3, 3)))
 # - Branch functions cannot mutate input or global variables.
 # - Branch functions cannot access closure variables, except for ``self`` if the function is
 #   defined in the scope of a method.
+#
+# For more details about ``cond``, check out the `documentation <https://pytorch.org/docs/main/cond.html>`__.
 
 ######################################################################
 # ..
@@ -233,12 +234,12 @@ print(exported_bad1_fixed(-torch.ones(3, 3)))
 #     print(exported_map_example(inp))
 
 ######################################################################
-# Constraints
-# -----------
+# Constraints/Dynamic Shapes
+# --------------------------
 #
 # Ops can have different specializations/behaviors for different tensor shapes, so by default,
 # ``torch.export`` requires inputs to ``ExportedProgram`` to have the same shape as the respective
-# example inputs given to the initial ``torch.export`` call.
+# example inputs given to the initial ``torch.export.export()`` call.
 # If we try to run the ``ExportedProgram`` in the example below with a tensor
 # with a different shape, we get an error:
 
@@ -259,91 +260,105 @@ except Exception:
     tb.print_exc()
 
 ######################################################################
-# We can modify the ``torch.export`` call to
-# relax some of these constraints. We use ``torch.export.dynamic_dim`` to
-# express shape constraints manually.
+# We can relax this constraint using the ``dynamic_shapes`` argument of
+# ``torch.export.export()``, which allows us to specify, using ``torch.export.Dim``
+# (`documentation <https://pytorch.org/docs/main/export.html#torch.export.Dim>`__),
+# which dimensions of the input tensors are dynamic.
 #
-# ..
-#     [TODO] link to doc of dynamic_dim when it is available
+# For each tensor argument of the input callable, we can specify a mapping from the dimension
+# to a ``torch.export.Dim``.
+# A ``torch.export.Dim`` is essentially a named symbolic integer with optional
+# minimum and maximum bounds.
 #
-# Using ``dynamic_dim`` on a tensor's dimension marks it as dynamic (i.e. unconstrained), and
-# we can provide additional upper and lower bound shape constraints.
-# The first argument of ``dynamic_dim`` is the tensor variable we wish
-# to specify a dimension constraint for. The second argument specifies
-# the dimension of the first argument the constraint applies to.
+# Then, the format of ``torch.export.export()``'s ``dynamic_shapes`` argument is a mapping
+# from the input callable's tensor argument names, to dimension --> dim mappings as described above.
+# If there is no ``torch.export.Dim`` given to a tensor argument's dimension, then that dimension is
+# assumed to be static.
+#
+# The first argument of ``torch.export.Dim`` is the name for the symbolic integer, used for debugging.
+# Then we can specify an optional minimum and maximum bound (inclusive). Below, we show example usage.
+#
 # In the example below, our input
 # ``inp1`` has an unconstrained first dimension, but the size of the second
-# dimension must be in the interval (3, 18].
+# dimension must be in the interval [4, 18].
 
-from torch.export import dynamic_dim
+from torch.export import Dim
 
-inp1 = torch.randn(10, 10)
+inp1 = torch.randn(10, 10, 2)
 
-def constraints_example1(x):
+def dynamic_shapes_example1(x):
     x = x[:, 2:]
     return torch.relu(x)
 
-constraints1 = [
-    dynamic_dim(inp1, 0),
-    3 < dynamic_dim(inp1, 1),
-    dynamic_dim(inp1, 1) <= 18,
-]
+inp1_dim0 = Dim("inp1_dim0")
+inp1_dim1 = Dim("inp1_dim1", min=4, max=18)
+dynamic_shapes1 = {
+    "x": {0: inp1_dim0, 1: inp1_dim1},
+}
 
-exported_constraints_example1 = export(constraints_example1, (inp1,), constraints=constraints1)
+exported_dynamic_shapes_example1 = export(dynamic_shapes_example1, (inp1,), dynamic_shapes=dynamic_shapes1)
 
-print(exported_constraints_example1(torch.randn(5, 5)))
+print(exported_dynamic_shapes_example1(torch.randn(5, 5, 2)))
 
 try:
-    exported_constraints_example1(torch.randn(8, 1))
+    exported_dynamic_shapes_example1(torch.randn(8, 1, 2))
 except Exception:
     tb.print_exc()
 
 try:
-    exported_constraints_example1(torch.randn(8, 20))
+    exported_dynamic_shapes_example1(torch.randn(8, 20, 2))
 except Exception:
     tb.print_exc()
 
-######################################################################
-# Note that if our example inputs to ``torch.export`` do not satisfy the constraints,
-# then we get an error.
-
-constraints1_bad = [
-    dynamic_dim(inp1, 0),
-    10 < dynamic_dim(inp1, 1),
-    dynamic_dim(inp1, 1) <= 18,
-]
 try:
-    export(constraints_example1, (inp1,), constraints=constraints1_bad)
+    exported_dynamic_shapes_example1(torch.randn(8, 8, 3))
 except Exception:
     tb.print_exc()
 
 ######################################################################
-# We can also use ``dynamic_dim`` to enforce expected equalities between
-# dimensions, for example, in matrix multiplication:
+# Note that if our example inputs to ``torch.export`` do not satisfy the constraints
+# given by ``dynamic_shapes``, then we get an error.
+
+inp1_dim1_bad = Dim("inp1_dim1_bad", min=11, max=18)
+dynamic_shapes1_bad = {
+    "x": {0: inp1_dim0, 1: inp1_dim1_bad},
+}
+
+try:
+    export(dynamic_shapes_example1, (inp1,), dynamic_shapes=dynamic_shapes1_bad)
+except Exception:
+    tb.print_exc()
+
+######################################################################
+# We can enforce that equalities between dimensions of different tensors
+# by using the same ``torch.export.Dim`` object, for example, in matrix multiplication:
 
 inp2 = torch.randn(4, 8)
 inp3 = torch.randn(8, 2)
 
-def constraints_example2(x, y):
+def dynamic_shapes_example2(x, y):
     return x @ y
 
-constraints2 = [
-    dynamic_dim(inp2, 0),
-    dynamic_dim(inp2, 1) == dynamic_dim(inp3, 0),
-    dynamic_dim(inp3, 1),
-]
+inp2_dim0 = Dim("inp2_dim0")
+inner_dim = Dim("inner_dim")
+inp3_dim1 = Dim("inp3_dim1")
 
-exported_constraints_example2 = export(constraints_example2, (inp2, inp3), constraints=constraints2)
+dynamic_shapes2 = {
+    "x": {0: inp2_dim0, 1: inner_dim},
+    "y": {0: inner_dim, 1: inp3_dim1},
+}
 
-print(exported_constraints_example2(torch.randn(2, 16), torch.randn(16, 4)))
+exported_dynamic_shapes_example2 = export(dynamic_shapes_example2, (inp2, inp3), dynamic_shapes=dynamic_shapes2)
+
+print(exported_dynamic_shapes_example2(torch.randn(2, 16), torch.randn(16, 4)))
 
 try:
-    exported_constraints_example2(torch.randn(4, 8), torch.randn(4, 2))
+    exported_dynamic_shapes_example2(torch.randn(4, 8), torch.randn(4, 2))
 except Exception:
     tb.print_exc()
 
 ######################################################################
-# We can actually use ``torch.export`` to guide us as to which constraints
+# We can actually use ``torch.export`` to guide us as to which ``dynamic_shapes`` constraints
 # are necessary. We can do this by relaxing all constraints (recall that if we
 # do not provide constraints for a dimension, the default behavior is to constrain
 # to the exact shape value of the example input) and letting ``torch.export``
@@ -352,42 +367,45 @@ except Exception:
 inp4 = torch.randn(8, 16)
 inp5 = torch.randn(16, 32)
 
-def constraints_example3(x, y):
+def dynamic_shapes_example3(x, y):
     if x.shape[0] <= 16:
         return x @ y[:, :16]
     return y
 
-constraints3 = (
-    [dynamic_dim(inp4, i) for i in range(inp4.dim())] +
-    [dynamic_dim(inp5, i) for i in range(inp5.dim())]
-)
+dynamic_shapes3 = {
+    "x": {i: Dim(f"inp4_dim{i}") for i in range(inp4.dim())},
+    "y": {i: Dim(f"inp5_dim{i}") for i in range(inp5.dim())},
+}
 
 try:
-    export(constraints_example3, (inp4, inp5), constraints=constraints3)
+    export(dynamic_shapes_example3, (inp4, inp5), dynamic_shapes=dynamic_shapes3)
 except Exception:
     tb.print_exc()
 
 ######################################################################
-# We can see that the error message suggests to us to use some additional code
-# to specify the necessary constraints. Let us use that code (exact code may differ slightly):
+# We can see that the error message gives us suggested fixes to our
+# dynamic shape constraints. Let us follow those suggestions (exact
+# suggestions may differ slightly):
 
-def specify_constraints(x, y):
-    return [
-        # x:
-        dynamic_dim(x, 0) <= 16,
+def suggested_fixes():
+    inp4_dim1 = Dim('shared_dim')
+    # suggested fixes below
+    inp4_dim0 = Dim('inp4_dim0', max=16)
+    inp5_dim1 = Dim('inp5_dim1', min=17)
+    inp5_dim0 = inp4_dim1
+    # end of suggested fixes
+    return {
+        "x": {0: inp4_dim0, 1: inp4_dim1},
+        "y": {0: inp5_dim0, 1: inp5_dim1},
+    }
 
-        # y:
-        16 < dynamic_dim(y, 1),
-        dynamic_dim(y, 0) == dynamic_dim(x, 1),
-    ]
-
-constraints3_fixed = specify_constraints(inp4, inp5)
-exported_constraints_example3 = export(constraints_example3, (inp4, inp5), constraints=constraints3_fixed)
-print(exported_constraints_example3(torch.randn(4, 32), torch.randn(32, 64)))
+dynamic_shapes3_fixed = suggested_fixes()
+exported_dynamic_shapes_example3 = export(dynamic_shapes_example3, (inp4, inp5), dynamic_shapes=dynamic_shapes3_fixed)
+print(exported_dynamic_shapes_example3(torch.randn(4, 32), torch.randn(32, 64)))
 
 ######################################################################
 # Note that in the example above, because we constrained the value of ``x.shape[0]`` in
-# ``constraints_example3``, the exported program is sound even though there is a
+# ``dynamic_shapes_example3``, the exported program is sound even though there is a
 # raw ``if`` statement.
 #
 # If you want to see why ``torch.export`` generated these constraints, you can
@@ -396,7 +414,7 @@ print(exported_constraints_example3(torch.randn(4, 32), torch.randn(32, 64)))
 
 import logging
 torch._logging.set_logs(dynamic=logging.INFO, dynamo=logging.INFO)
-exported_constraints_example3 = export(constraints_example3, (inp4, inp5), constraints=constraints3_fixed)
+exported_dynamic_shapes_example3 = export(dynamic_shapes_example3, (inp4, inp5), dynamic_shapes=dynamic_shapes3_fixed)
 
 # reset to previous values
 torch._logging.set_logs(dynamic=logging.WARNING, dynamo=logging.WARNING)
@@ -406,55 +424,14 @@ torch._logging.set_logs(dynamic=logging.WARNING, dynamo=logging.WARNING)
 # ``equality_constraints`` attributes. The logging above reveals what the symbols ``s0, s1, ...``
 # represent.
 
-print(exported_constraints_example3.range_constraints)
-print(exported_constraints_example3.equality_constraints)
-
-######################################################################
-# We can also constrain on individual values in the source code itself using
-# ``constrain_as_value`` and ``constrain_as_size``. ``constrain_as_value`` specifies
-# that a given integer value is expected to fall within the provided minimum/maximum bounds (inclusive).
-# If a bound is not provided, then it is assumed to be unbounded.
-
-from torch.export import constrain_as_size, constrain_as_value
-
-def constraints_example4(x, y):
-    b = y.item()
-    constrain_as_value(b, 3, 5)
-    if b >= 3:
-       return x.cos()
-    return x.sin()
-
-exported_constraints_example4 = export(constraints_example4, (torch.randn(3, 3), torch.tensor([4])))
-print(exported_constraints_example4(torch.randn(3, 3), torch.tensor([5])))
-try:
-    exported_constraints_example4(torch.randn(3, 3), torch.tensor([2]))
-except Exception:
-    tb.print_exc()
-
-######################################################################
-# ``constrain_as_size`` is similar to ``constrain_as_value``, except that it should be used on integer values that
-# will be used to specify tensor shapes -- in particular, the value must not be 0 or 1 because
-# many operations have special behavior for tensors with a shape value of 0 or 1.
-
-def constraints_example5(x, y):
-    b = y.item()
-    constrain_as_size(b)
-    z = torch.ones(b, 4)
-    return x.sum() + z.sum()
-
-exported_constraints_example5 = export(constraints_example5, (torch.randn(2, 2), torch.tensor([4])))
-print(exported_constraints_example5(torch.randn(2, 2), torch.tensor([5])))
-try:
-    exported_constraints_example5(torch.randn(2, 2), torch.tensor([1]))
-except Exception:
-    tb.print_exc()
+print(exported_dynamic_shapes_example3.range_constraints)
+print(exported_dynamic_shapes_example3.equality_constraints)
 
 ######################################################################
 # Custom Ops
 # ----------
 #
 # ``torch.export`` can export PyTorch programs with custom operators.
-#
 #
 # Currently, the steps to register a custom op for use by ``torch.export`` are:
 #
@@ -506,6 +483,93 @@ print(exported_custom_op_example(torch.randn(3, 3)))
 # to make it compatible with ``torch.export``.
 
 ######################################################################
+# Decompositions
+# --------------
+#
+# The graph produced by ``torch.export`` by default returns a graph containing
+# only functional ATen operators. This functional ATen operator set (or "opset") contains around 2000
+# operators, all of which are functional, that is, they do not
+# mutate or alias inputs.  You can find a list of all ATen operators
+# `here <https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/native_functions.yaml>`__
+# and you can inspect if an operator is functional by checking
+# ``op._schema.is_mutable``, for example:
+
+print(torch.ops.aten.add.Tensor._schema.is_mutable)
+print(torch.ops.aten.add_.Tensor._schema.is_mutable)
+
+######################################################################
+# By default, the environment in which you want to run the exported graph
+# should support all ~2000 of these operators.
+# However, you can use the following API on the exported program
+# if your specific environment is only able to support a subset of
+# the ~2000 operators.
+#
+# .. code-block:: python
+#     def run_decompositions(
+#         self: ExportedProgram,
+#         decomposition_table: Optional[Dict[torch._ops.OperatorBase, Callable]]
+#     ) -> ExportedProgram
+#
+# ``run_decompositions`` takes in a decomposition table, which is a mapping of
+# operators to a function specifying how to reduce, or decompose, that operator
+# into an equivalent sequence of other ATen operators.
+#
+# The default decomposition table for ``run_decompositions`` is the
+# `Core ATen decomposition table <https://github.com/pytorch/pytorch/blob/b460c3089367f3fadd40aa2cb3808ee370aa61e1/torch/_decomp/__init__.py#L252>`__
+# which will decompose the all ATen operators to the
+# `Core ATen Operator Set <https://pytorch.org/docs/main/torch.compiler_ir.html#core-aten-ir>`__
+# which consists of only ~180 operators.
+
+class M(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(3, 4)
+
+    def forward(self, x):
+        return self.linear(x)
+
+ep = export(M(), (torch.randn(2, 3),))
+print(ep.graph)
+
+core_ir_ep = ep.run_decompositions()
+print(core_ir_ep.graph)
+
+######################################################################
+# Notice that after running ``run_decompositions`` the
+# ``torch.ops.aten.t.default`` operator, which is not part of the Core ATen
+# Opset, has been replaced with ``torch.ops.aten.permute.default`` which is part
+# of the Core ATen Opset.
+#
+# Most ATen operators already have decompositions, which are located
+# `here <https://github.com/pytorch/pytorch/blob/b460c3089367f3fadd40aa2cb3808ee370aa61e1/torch/_decomp/decompositions.py>`__.
+# If you would like to use some of these existing decomposition functions,
+# you can pass in a list of operators you would like to decompose to the
+# `get_decompositions <https://github.com/pytorch/pytorch/blob/b460c3089367f3fadd40aa2cb3808ee370aa61e1/torch/_decomp/__init__.py#L191>`__
+# function, which will return a decomposition table using existing
+# decomposition implementations.
+
+class M(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(3, 4)
+
+    def forward(self, x):
+        return self.linear(x)
+
+ep = export(M(), (torch.randn(2, 3),))
+print(ep.graph)
+
+from torch._decomp import get_decompositions
+decomp_table = get_decompositions([torch.ops.aten.t.default, torch.ops.aten.transpose.int])
+core_ir_ep = ep.run_decompositions(decomp_table)
+print(core_ir_ep.graph)
+
+######################################################################
+# If there is no existing decomposition function for an ATen operator that you would
+# like to decompose, feel free to send a pull request into PyTorch
+# implementing the decomposition!
+
+######################################################################
 # ExportDB
 # --------
 #
@@ -525,8 +589,8 @@ print(exported_custom_op_example(torch.randn(3, 3)))
 def cond_predicate(x):
     """
     The conditional statement (aka predicate) passed to ``cond()`` must be one of the following:
-      - torch.Tensor with a single element
-      - boolean expression
+    - torch.Tensor with a single element
+    - boolean expression
     NOTE: If the `pred` is test on a dim with batch size < 2, it will be specialized.
     """
     pred = x.dim() > 2 and x.shape[2] > 10


### PR DESCRIPTION
Copy over the nightly tutorial for the 2.2 release, since there were API changes since 2.1.

Will fix https://github.com/pytorch/tutorials/issues/2707