### PR TITLE
Disable usb_semisup_learn.html

### DIFF
--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -30,6 +30,7 @@ NOT_RUN = [
     "intermediate_source/torch_export_tutorial", # Enable when fixed for 2.2
     "advanced_source/super_resolution_with_onnxruntime",
     "advanced_source/ddp_pipeline",  # requires 4 gpus
+    "advanced/usb_semisup_learn", # in the current form takes 140+ minutes to build - can be enabled when the build time is reduced
     "prototype_source/fx_graph_mode_ptq_dynamic",
     "prototype_source/maskedtensor_sparsity", # Enable when fixed for 2.2
     "prototype_source/vmap_recipe",

--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -30,7 +30,7 @@ NOT_RUN = [
     "intermediate_source/torch_export_tutorial", # Enable when fixed for 2.2
     "advanced_source/super_resolution_with_onnxruntime",
     "advanced_source/ddp_pipeline",  # requires 4 gpus
-    "advanced/usb_semisup_learn", # in the current form takes 140+ minutes to build - can be enabled when the build time is reduced
+    "advanced_source/usb_semisup_learn", # in the current form takes 140+ minutes to build - can be enabled when the build time is reduced
     "prototype_source/fx_graph_mode_ptq_dynamic",
     "prototype_source/maskedtensor_sparsity", # Enable when fixed for 2.2
     "prototype_source/vmap_recipe",


### PR DESCRIPTION
Disabling the advanced_source/usb_semisup_learn.py as it takes 140 minutes to build.
