### PR TITLE
Add missing plt.show() statement in Beginner/DCGAN Faces Tutorial

### DIFF
--- a/beginner_source/dcgan_faces_tutorial.py
+++ b/beginner_source/dcgan_faces_tutorial.py
@@ -265,7 +265,7 @@ plt.figure(figsize=(8,8))
 plt.axis("off")
 plt.title("Training Images")
 plt.imshow(np.transpose(vutils.make_grid(real_batch[0].to(device)[:64], padding=2, normalize=True).cpu(),(1,2,0)))
-
+plt.imshow()
 
 
 ######################################################################


### PR DESCRIPTION
## Description
I was following the instructions in the tutorial to set up the dataset loader and visualise its outputs according to the code block:
```python
plt.figure(figsize=(8,8))
plt.axis("off")
plt.title("Training Images")
plt.imshow(np.transpose([vutils.make_grid](https://pytorch.org/vision/stable/generated/torchvision.utils.make_grid.html#torchvision.utils.make_grid)(real_batch[0].to([device](https://pytorch.org/docs/stable/tensor_attributes.html#torch.device))[:64], padding=2, normalize=True).cpu(),(1,2,0)))
```
It configures the plt graphing options but misses the final `plt.show()` command to open GUI. I ran the code above and nothing happened.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
