### PR TITLE
Update tensordict link in intersphinx mapping

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -79,7 +79,7 @@ extensions = [
 
 intersphinx_mapping = {
     "torch": ("https://pytorch.org/docs/stable/", None),
-    "tensordict": ("https://pytorch-labs.github.io/tensordict/", None),
+    "tensordict": ("https://pytorch.github.io/tensordict/", None),
     "torchrl": ("https://pytorch.org/rl/", None),
     "torchaudio": ("https://pytorch.org/audio/stable/", None),
     "torchtext": ("https://pytorch.org/text/stable/", None),


### PR DESCRIPTION
Since tensordict has moved to pytorch.org from pytorch-labs, updating the intersphinx mapping to reflect the change. This will fix the following build warning:

```
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://pytorch-labs.github.io/tensordict/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://pytorch-labs.github.io/tensordict/objects.inv
```