### PR TITLE
Fix `CayleyMap`'s `right_inverse`, s/X/A

### DIFF
--- a/intermediate_source/parametrizations.py
+++ b/intermediate_source/parametrizations.py
@@ -306,8 +306,8 @@ class CayleyMap(nn.Module):
     def right_inverse(self, A):
         # Assume A orthogonal
         # See https://en.wikipedia.org/wiki/Cayley_transform#Matrix_map
-        # (X - I)(X + I)^{-1}
-        return torch.linalg.solve(X + self.Id, self.Id - X)
+        # (A - I)(A + I)^{-1}
+        return torch.linalg.solve(A + self.Id, self.Id - A)
 
 layer_orthogonal = nn.Linear(3, 3)
 parametrize.register_parametrization(layer_orthogonal, "weight", Skew())


### PR DESCRIPTION
This makes it correct.

Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.


cc @albanD