### PR TITLE
Update ray to 2.7.2

### DIFF
--- a/beginner_source/hyperparameter_tuning_tutorial.py
+++ b/beginner_source/hyperparameter_tuning_tutorial.py
@@ -52,6 +52,9 @@ from ray import tune
 from ray.air import Checkpoint, session
 from ray.tune.schedulers import ASHAScheduler
 
+# FIXME: migrate to ray.train.Checkpoint and remove following line
+os.environ["RAY_AIR_NEW_PERSISTENCE_MODE"]="0"
+
 ######################################################################
 # Most of the imports are needed for building the PyTorch model. Only the last three
 # imports are for Ray Tune.

--- a/beginner_source/hyperparameter_tuning_tutorial.py
+++ b/beginner_source/hyperparameter_tuning_tutorial.py
@@ -52,7 +52,7 @@ from ray import tune
 from ray.air import Checkpoint, session
 from ray.tune.schedulers import ASHAScheduler
 
-# FIXME: migrate to ray.train.Checkpoint and remove following line
+# TODO: Migrate to ray.train.Checkpoint and remove following line
 os.environ["RAY_AIR_NEW_PERSISTENCE_MODE"]="0"
 
 ######################################################################
@@ -455,8 +455,8 @@ if __name__ == "__main__":
     # Fixes ``AttributeError: '_LoggingTee' object has no attribute 'fileno'``.
     # This is only needed to run with sphinx-build.
     import sys
-
-    sys.stdout.fileno = lambda: False
+    if not not hasattr(sys.stdout, "encoding"):
+        sys.stdout.encoding = "latin1"
     # sphinx_gallery_end_ignore
     # You can change the number of GPUs per trial here:
     main(num_samples=10, max_num_epochs=10, gpus_per_trial=0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ bs4
 awscliv2==2.1.1
 flask
 spacy==3.4.1
-ray[tune]==2.9.3
+ray[tune]==2.7.2
 tensorboard
 jinja2==3.1.3
 pytorch-lightning

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ bs4
 awscliv2==2.1.1
 flask
 spacy==3.4.1
-ray[tune]==2.4.0
+ray[tune]==2.9.3
 tensorboard
 jinja2==3.1.3
 pytorch-lightning


### PR DESCRIPTION
To address numerous CVE that older Ray releases were affected by see https://www.anyscale.com/blog/update-on-ray-cves-cve-2023-6019-cve-2023-6020-cve-2023-6021-cve-2023-48022-cve-2023-48023

Use legacy APIs by setting `RAY_AIR_NEW_PERSISTENCE_MODE` environment variable to zero.
Please note, that this increases tutorial runtime from 4 to 10 min