### PR TITLE
Fix formatting

### DIFF
--- a/recipes_source/recipes/tuning_guide.py
+++ b/recipes_source/recipes/tuning_guide.py
@@ -464,7 +464,7 @@ torch.backends.cudnn.benchmark = True
 # perform the required gradient all-reduce.
 
 ###############################################################################
-# Match the order of layers in constructors and during the execution if using ``DistributedDataParallel``(find_unused_parameters=True)
+# Match the order of layers in constructors and during the execution if using ``DistributedDataParallel(find_unused_parameters=True)``
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # `torch.nn.parallel.DistributedDataParallel <https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html#torch.nn.parallel.DistributedDataParallel>`_
 # with ``find_unused_parameters=True`` uses the order of layers and parameters


### PR DESCRIPTION
Before this PR, the header shows literal backticks instead of fixed font.

> ``DistributedDataParallel``(find_unused_parameters=True)