### PR TITLE
Implements the canonical vanilla RNN rather than the current RNN

### DIFF
--- a/intermediate_source/char_rnn_classification_tutorial.py
+++ b/intermediate_source/char_rnn_classification_tutorial.py
@@ -179,14 +179,13 @@ print(lineToTensor('Jones').size())
 # graph itself. This means you can implement a RNN in a very "pure" way,
 # as regular feed-forward layers.
 #
-# This RNN module (mostly copied from `the PyTorch for Torch users
-# tutorial <https://pytorch.org/tutorials/beginner/former_torchies/
-# nn_tutorial.html#example-2-recurrent-net>`__)
-# is just 2 linear layers which operate on an input and hidden state, with
-# a ``LogSoftmax`` layer after the output.
+# This RNN module implements a "vanilla RNN" an is just 3 linear layers 
+# which operate on an input and hidden state, with a ``LogSoftmax`` layer 
+# after the output.
 #
 
 import torch.nn as nn
+import torch.nn.functional as F
 
 class RNN(nn.Module):
     def __init__(self, input_size, hidden_size, output_size):
@@ -194,13 +193,13 @@ class RNN(nn.Module):
 
         self.hidden_size = hidden_size
 
-        self.i2h = nn.Linear(input_size + hidden_size, hidden_size)
+        self.i2h = nn.Linear(input_size, hidden_size)
+        self.h2h = nn.Linear(hidden_size, hidden_size)
         self.h2o = nn.Linear(hidden_size, output_size)
         self.softmax = nn.LogSoftmax(dim=1)
 
     def forward(self, input, hidden):
-        combined = torch.cat((input, hidden), 1)
-        hidden = self.i2h(combined)
+        hidden = F.tanh(self.i2h(input) + self.h2h(hidden))
         output = self.h2o(hidden)
         output = self.softmax(output)
         return output, hidden


### PR DESCRIPTION
The current RNN module does not implement the canonical "vanilla RNN" which consists of 3 linear layers, and a tanh operated on the sum of the projected x_t and h_{t-1}

The current implementation is confusing since it doesn't implement the canonical vanilla RNN. 

Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.


cc @albanD