### PR TITLE
Use optimizer.zero_grad(set_to_none=True) instead of optimizer.zero_g…

### DIFF
--- a/beginner_source/transfer_learning_tutorial.py
+++ b/beginner_source/transfer_learning_tutorial.py
@@ -172,7 +172,7 @@ def train_model(model, criterion, optimizer, scheduler, num_epochs=25):
                     labels = labels.to(device)
 
                     # zero the parameter gradients
-                    optimizer.zero_grad()
+                    optimizer.zero_grad(set_to_none=True)
 
                     # forward
                     # track history if only in train


### PR DESCRIPTION
…rad()



## Description
<!--- Describe your changes in detail -->
This parameter sets the grads to none rather than zero, generally reducing memory footprint and improving performance. The risk is that the grads will appear and behave differently if the user tries to access and manually perform ops on it.

References:
https://pytorch.org/docs/master/generated/torch.optim.Optimizer.zero_grad.html#torch.optim.Optimizer.zero_grad
https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] I have not created an issue fixed by this trivial tutorial patch.
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @albanD