### PR TITLE
[export] Remove interactive aoti compilation

### DIFF
--- a/intermediate_source/torch_export_tutorial.py
+++ b/intermediate_source/torch_export_tutorial.py
@@ -652,7 +652,7 @@ print(res)
 #
 #    import torch._export
 #    import torch._inductor
-
+#
 #    # Note: these APIs are subject to change
 #    # Compile the exported program to a .so using ``AOTInductor``
 #    with torch.no_grad():

--- a/intermediate_source/torch_export_tutorial.py
+++ b/intermediate_source/torch_export_tutorial.py
@@ -513,6 +513,7 @@ print(torch.ops.aten.add_.Tensor._schema.is_mutable)
 # the ~2000 operators.
 #
 # .. code-block:: python
+#
 #     def run_decompositions(
 #         self: ExportedProgram,
 #         decomposition_table: Optional[Dict[torch._ops.OperatorBase, Callable]]
@@ -646,18 +647,21 @@ print(res)
 res = torch.compile(ep.module(), backend="inductor")(inp)
 print(res)
 
-import torch._export
-import torch._inductor
+######################################################################
+# .. code-block:: python
+#
+#     import torch._export
+#     import torch._inductor
 
-# Note: these APIs are subject to change
-# Compile the exported program to a .so using AOTInductor
-with torch.no_grad():
-    so_path = torch._inductor.aot_compile(ep.module(), [inp])
-# Load and run the .so file in Python.
-# To load and run it in a C++ environment, see: 
-# https://pytorch.org/docs/main/torch.compiler_aot_inductor.html
-res = torch._export.aot_load(so_path, device="cuda")(inp)
-print(res)
+#     # Note: these APIs are subject to change
+#     # Compile the exported program to a .so using AOTInductor
+#     with torch.no_grad():
+#     so_path = torch._inductor.aot_compile(ep.module(), [inp])
+#
+#     # Load and run the .so file in Python.
+#     # To load and run it in a C++ environment, see:
+#     # https://pytorch.org/docs/main/torch.compiler_aot_inductor.html
+#     res = torch._export.aot_load(so_path, device="cuda")(inp)
 
 ######################################################################
 # Conclusion

--- a/intermediate_source/torch_export_tutorial.py
+++ b/intermediate_source/torch_export_tutorial.py
@@ -650,18 +650,18 @@ print(res)
 ######################################################################
 # .. code-block:: python
 #
-#     import torch._export
-#     import torch._inductor
+#    import torch._export
+#    import torch._inductor
 
-#     # Note: these APIs are subject to change
-#     # Compile the exported program to a .so using AOTInductor
-#     with torch.no_grad():
-#     so_path = torch._inductor.aot_compile(ep.module(), [inp])
+#    # Note: these APIs are subject to change
+#    # Compile the exported program to a .so using ``AOTInductor``
+#    with torch.no_grad():
+#    so_path = torch._inductor.aot_compile(ep.module(), [inp])
 #
-#     # Load and run the .so file in Python.
-#     # To load and run it in a C++ environment, see:
-#     # https://pytorch.org/docs/main/torch.compiler_aot_inductor.html
-#     res = torch._export.aot_load(so_path, device="cuda")(inp)
+#    # Load and run the .so file in Python.
+#    # To load and run it in a C++ environment, see:
+#    # https://pytorch.org/docs/main/torch.compiler_aot_inductor.html
+#    res = torch._export.aot_load(so_path, device="cuda")(inp)
 
 ######################################################################
 # Conclusion


### PR DESCRIPTION
Fixes build failure by moving aot inductor compilation part into just text, not interactive. 