### PR TITLE
Pin torch version to 2.3 and rebuild docker image

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -13,7 +13,7 @@ tqdm==4.66.1
 numpy==1.24.4
 matplotlib
 librosa
-torch
+torch==2.3
 torchvision
 torchtext
 torchdata


### PR DESCRIPTION
pin torch version to most recent (2.3) to trigger docker rebuild
This way if we (or a pr author) wants to update the torch version they can just change the pin