### PR TITLE
Properly uncommenting code in introyt1 tutorial

### DIFF
--- a/beginner_source/introyt/introyt1_tutorial.py
+++ b/beginner_source/introyt/introyt1_tutorial.py
@@ -304,22 +304,22 @@ transform = transforms.Compose(
 #    standard deviations (second tuple) of the rgb values of the images in
 #    the dataset. You can calculate these values yourself by running these
 #    few lines of code:
-#          ```
-#           from torch.utils.data import ConcatDataset
-#           transform = transforms.Compose([transforms.ToTensor()])
-#           trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
-#                                        download=True, transform=transform)
-#
-#           #stack all train images together into a tensor of shape 
-#           #(50000, 3, 32, 32)
-#           x = torch.stack([sample[0] for sample in ConcatDataset([trainset])])
-#           
-#           #get the mean of each channel            
-#           mean = torch.mean(x, dim=(0,2,3)) #tensor([0.4914, 0.4822, 0.4465])
-#           std = torch.std(x, dim=(0,2,3)) #tensor([0.2470, 0.2435, 0.2616])  
-# 
-#          ```   
-# 
+
+from torch.utils.data import ConcatDataset
+transform = transforms.Compose([transforms.ToTensor()])
+trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
+                            download=True, transform=transform)
+
+#stack all train images together into a tensor of shape 
+#(50000, 3, 32, 32)
+x = torch.stack([sample[0] for sample in ConcatDataset([trainset])])
+
+#get the mean of each channel            
+mean = torch.mean(x, dim=(0,2,3)) #tensor([0.4914, 0.4822, 0.4465])
+std = torch.std(x, dim=(0,2,3)) #tensor([0.2470, 0.2435, 0.2616])  
+
+
+##########################################################################
 # There are many more transforms available, including cropping, centering,
 # rotation, and reflection.
 # 
@@ -327,7 +327,6 @@ transform = transforms.Compose(
 # 32x32 color image tiles representing 10 classes of objects: 6 of animals
 # (bird, cat, deer, dog, frog, horse) and 4 of vehicles (airplane,
 # automobile, ship, truck):
-# 
 
 trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
                                         download=True, transform=transform)


### PR DESCRIPTION
Fixes #2814

## Description
Some code was wrongly commented within the introduction to Pytorch tutorial as pointed out in issue #2814. This PR fixes it. 

## Checklist
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
