### PR TITLE
the output of s2 should not change the number of feature maps

### DIFF
--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -61,7 +61,7 @@ class Net(nn.Module):
         # outputs a Tensor with size (N, 6, 28, 28), where N is the size of the batch
         c1 = F.relu(self.conv1(input))
         # Subsampling layer S2: 2x2 grid, purely functional,
-        # this layer does not have any parameter, and outputs a (N, 16, 14, 14) Tensor
+        # this layer does not have any parameter, and outputs a (N, 6, 14, 14) Tensor
         s2 = F.max_pool2d(c1, (2, 2))
         # Convolution layer C3: 6 input channels, 16 output channels,
         # 5x5 square convolution, it uses RELU activation function, and


### PR DESCRIPTION
`c1` outputs a Tensor with size (N, 6, 28, 28), and `s2` should not change the 6 into 16.

Fixes 2857

## Description
In the provided example in the comment section for the s2 layer, it is mentioned that s2 outputs a (N, 16, 14, 14) Tensor while its outputs a a (N, 6, 14, 14) Tensor. This is a minor typo, but may confuse the beginners.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @svekars @brycebortree @albanD