### PR TITLE
Update the hyperlink in torch_compile_user_defined_triton_kernel_tutorial.py

### DIFF
--- a/recipes_source/torch_compile_user_defined_triton_kernel_tutorial.py
+++ b/recipes_source/torch_compile_user_defined_triton_kernel_tutorial.py
@@ -167,5 +167,5 @@ else:
 # See Also
 # ---------
 #
-# * `Compiling the Optimizers: <https://pytorch.org/tutorials/recipes/compiling_optimizer.html>`__
-# * `Implementing High-Performance Transformers with Scaled Dot Product Attention<https://pytorch.org/tutorials/intermediate/scaled_dot_product_attention_tutorial.html>`__
+# * `Compiling the Optimizers <https://pytorch.org/tutorials/recipes/compiling_optimizer.html>`__
+# * `Implementing High-Performance Transformers with Scaled Dot Product Attention <https://pytorch.org/tutorials/intermediate/scaled_dot_product_attention_tutorial.html>`__


### PR DESCRIPTION


## Description
hyperlink is broken
![image](https://github.com/pytorch/tutorials/assets/7495155/9be952d1-562d-427c-967d-242f513d579b)





cc @svekars @brycebortree