### PR TITLE
Including reference to teacher_forcing_ratio and padding_idx to seq2seq_translation_tutorial

### DIFF
--- a/intermediate_source/seq2seq_translation_tutorial.py
+++ b/intermediate_source/seq2seq_translation_tutorial.py
@@ -547,7 +547,7 @@ class AttnDecoderRNN(nn.Module):
 # to ensure that all sequences have the same length. To do this, we initialize
 # the input_ids and target_ids to the same 2D 0s array.
 #
-# This is why we included padding_idx in our embedding layers.
+# This is why we included ``padding_idx`` in our embedding layers.
 # padding_idx will set every input where the value is equal to padding_idx
 # to be zero-ed out. We set padding_idx=0 in our embedding layers, as we
 # are padding our sentences with 0s.

--- a/intermediate_source/seq2seq_translation_tutorial.py
+++ b/intermediate_source/seq2seq_translation_tutorial.py
@@ -548,7 +548,7 @@ class AttnDecoderRNN(nn.Module):
 # the input_ids and target_ids to the same 2D 0s array.
 #
 # This is why we included ``padding_idx`` in our embedding layers.
-# padding_idx will set every input where the value is equal to padding_idx
+# ``padding_idx`` will set every input where the value is equal to ``padding_idx``
 # to be zero-ed out. We set ``padding_idx=0`` in our embedding layers, as we
 # are padding our sentences with 0s.
 #

--- a/intermediate_source/seq2seq_translation_tutorial.py
+++ b/intermediate_source/seq2seq_translation_tutorial.py
@@ -549,7 +549,7 @@ class AttnDecoderRNN(nn.Module):
 #
 # This is why we included ``padding_idx`` in our embedding layers.
 # padding_idx will set every input where the value is equal to padding_idx
-# to be zero-ed out. We set padding_idx=0 in our embedding layers, as we
+# to be zero-ed out. We set ``padding_idx=0`` in our embedding layers, as we
 # are padding our sentences with 0s.
 #
 

--- a/intermediate_source/seq2seq_translation_tutorial.py
+++ b/intermediate_source/seq2seq_translation_tutorial.py
@@ -715,7 +715,7 @@ def train(train_dataloader, encoder, decoder, n_epochs, learning_rate=0.001,
 #
 
 import matplotlib.pyplot as plt
-plt.switch_backend('TkAgg')
+plt.switch_backend('agg')
 import matplotlib.ticker as ticker
 import numpy as np
 
@@ -832,12 +832,8 @@ def showAttention(input_sentence, output_words, attentions):
     fig.colorbar(cax)
 
     # Set up axes
-    input_words = [''] + input_sentence.split(' ') + ['<EOS>']
-
-    ax.set_xticks(range(len(input_words)))
-    ax.set_yticks(range(1 + len(output_words)))
-
-    ax.set_xticklabels(input_words, rotation=90)
+    ax.set_xticklabels([''] + input_sentence.split(' ') +
+                       ['<EOS>'], rotation=90)
     ax.set_yticklabels([''] + output_words)
 
     # Show label at every tick


### PR DESCRIPTION
Fixes #[2840](https://github.com/pytorch/tutorials/issues/2840)

## Description
I have added details regarding teacher_forcing_ratio, as well as padding_idx. I agree that padding_idx needs to be set to 0 to properly handle the padding.

I do think having batch processing is still meaningful, even if the sentences are short (max 10 words in the tutorial).

I didn't want to include too much discussion about the pros/cons of batch processing and padding, as I feel that might be out of scope.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @albanD @jbschlosser