### PR TITLE
Remove the unexpected words in tensorboardyt_tutorial.py

### DIFF
--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -249,7 +249,7 @@ writer.flush()
 # 
 # TensorBoard can also be used to examine the data flow within your model.
 # To do this, call the ``add_graph()`` method with a model and sample
-# input. When you open
+# input:
 # 
 
 # Again, grab a single mini-batch of images


### PR DESCRIPTION
## Description
Remove extra words in `tensorboardyt_tutorial.py`. See the changed text for details. The removed words should be typos.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
