### PR TITLE
Enable torchvision_tutorial

### DIFF
--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -26,7 +26,6 @@ NOT_RUN = [
     "beginner_source/text_sentiment_ngrams_tutorial", # not building with 2.3 RC, might be able to turn on with GA
     "beginner_source/t5_tutorial", # re-enable after this is fixed: https://github.com/pytorch/text/issues/1756
     "intermediate_source/mnist_train_nas",  # used by ax_multiobjective_nas_tutorial.py
-    "intermediate_source/torchvision_tutorial", # disable due to RuntimeError: DataLoader worker (pid(s) 20092) exited unexpectedly
     "intermediate_source/fx_conv_bn_fuser",
     "intermediate_source/_torch_export_nightly_tutorial",  # does not work on release
     "advanced_source/super_resolution_with_onnxruntime",

--- a/intermediate_source/torchvision_tutorial.py
+++ b/intermediate_source/torchvision_tutorial.py
@@ -382,14 +382,12 @@ def get_transform(train):
 # expects during training and inference time on sample data.
 import utils
 
-
 model = torchvision.models.detection.fasterrcnn_resnet50_fpn(weights="DEFAULT")
 dataset = PennFudanDataset('data/PennFudanPed', get_transform(train=True))
 data_loader = torch.utils.data.DataLoader(
     dataset,
     batch_size=2,
     shuffle=True,
-    num_workers=4,
     collate_fn=utils.collate_fn
 )
 
@@ -433,7 +431,6 @@ data_loader = torch.utils.data.DataLoader(
     dataset,
     batch_size=2,
     shuffle=True,
-    num_workers=4,
     collate_fn=utils.collate_fn
 )
 
@@ -441,7 +438,6 @@ data_loader_test = torch.utils.data.DataLoader(
     dataset_test,
     batch_size=1,
     shuffle=False,
-    num_workers=4,
     collate_fn=utils.collate_fn
 )
 


### PR DESCRIPTION
Fixes #2843 

## Description
`torch.utils.data` have platform specific behavior in multiprocessing see https://pytorch.org/docs/stable/data.html#platform-specific-behaviors

In order to run the tutorial as a script and as a notebook on all platforms, the number of workers was changed accordingly to the platform.


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @datumbox @nairbv @fmassa @NicolasHug @YosuaMichael @sekyondaMeta @svekars @kit1980 @brycebortree