### PR TITLE
Replace dtype static list with a reference to data type doc

### DIFF
--- a/beginner_source/introyt/tensors_deeper_tutorial.py
+++ b/beginner_source/introyt/tensors_deeper_tutorial.py
@@ -228,18 +228,7 @@ print(c)
 # integer with the ``.to()`` method. Note that ``c`` contains all the same
 # values as ``b``, but truncated to integers.
 # 
-# Available data types include:
-# 
-# -  ``torch.bool``
-# -  ``torch.int8``
-# -  ``torch.uint8``
-# -  ``torch.int16``
-# -  ``torch.int32``
-# -  ``torch.int64``
-# -  ``torch.half``
-# -  ``torch.float``
-# -  ``torch.double``
-# -  ``torch.bfloat``
+# For more information, see the `data types documentation <https://pytorch.org/docs/stable/tensor_attributes.html#torch.dtype>`__.
 # 
 # Math & Logic with PyTorch Tensors
 # ---------------------------------


### PR DESCRIPTION
Fixes #2901 

## Description
in the pytorch dtype doc(link in below) is torch.bfloat16, but in tutorial istorch.bfloat , this might be mislead user to created dtype=torch.bfloat and get an error, might be better to make improvements: 

- Using doc link replace with static dtype explanation


tutorial link: https://pytorch.org/tutorials/beginner/introyt/tensors_deeper_tutorial.html
doc link: https://pytorch.org/docs/stable/tensor_attributes.html#torch.dtype

**tutorial is ``torch.bfloat``**
<img width="1487" alt="image" src="https://github.com/pytorch/tutorials/assets/54812088/46a34a01-9805-46c9-9775-488476c2e108">

**Got error when try to create**
![image](https://github.com/pytorch/tutorials/assets/54812088/9f7cd735-4b7b-47c9-8b0a-cb46ca39a198)

**Should be ``dtype=torch.bfloat16``**
![image](https://github.com/pytorch/tutorials/assets/54812088/bf06bf88-553a-4760-be40-1b8136101e50)

** Test Result: Local compile pages **

![image](https://github.com/pytorch/tutorials/assets/54812088/c6fc0d4e-cd33-4e4b-956e-f66b125b2a52)



## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @albanD @sekyondaMeta @svekars @kit1980 @brycebortree