### PR TITLE
Update data_loading_tutorial.py, correct iterator vs iterable

### DIFF
--- a/beginner_source/data_loading_tutorial.py
+++ b/beginner_source/data_loading_tutorial.py
@@ -366,7 +366,7 @@ for i, sample in enumerate(transformed_dataset):
 # -  Shuffling the data
 # -  Load the data in parallel using ``multiprocessing`` workers.
 #
-# ``torch.utils.data.DataLoader`` is an iterator which provides all these
+# ``torch.utils.data.DataLoader`` is an iterable which provides all these
 # features. Parameters used below should be clear. One parameter of
 # interest is ``collate_fn``. You can specify how exactly the samples need
 # to be batched using ``collate_fn``. However, default collate should work


### PR DESCRIPTION
DataLoader doesn't implement `__next__()` therefore it can't be in iterator



## Description
```python
    dl = torch.utils.data.DataLoader(dataset, batch_size=2)
    X, y = next(dl)
           ^^^^^^^^
TypeError: 'DataLoader' object is not an iterator
```
https://docs.python.org/3/glossary.html#term-iterator
https://docs.python.org/3/glossary.html#term-iterable

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @svekars @brycebortree @albanD