### PR TITLE
PT2E QAT Move model to eval before convert

### DIFF
--- a/prototype_source/pt2e_quant_x86_inductor.rst
+++ b/prototype_source/pt2e_quant_x86_inductor.rst
@@ -286,11 +286,11 @@ The PyTorch 2 Export QAT flow is largely similar to the PTQ flow:
 
   # train omitted
 
-  converted_model = convert_pt2e(prepared_model)
-  # we have a model with aten ops doing integer computations when possible
-
   # move the quantized model to eval mode, equivalent to `m.eval()`
   torch.ao.quantization.move_exported_model_to_eval(converted_model)
+
+  converted_model = convert_pt2e(prepared_model)
+  # we have a model with aten ops doing integer computations when possible
 
   # Lower the model into Inductor
   with torch.no_grad():


### PR DESCRIPTION
## Description
As https://github.com/pytorch/pytorch/pull/130395 introduced a robust DCE pass, it exposed an issue with the QAT Conv-BN folding path when we write testcase and usage. Since we have fixed this in the PyTorch main branch in https://github.com/pytorch/pytorch/pull/130598, we should update the tutorial accordingly.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @jerryzh168 @z-a-f @vkuzo @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @ZailiWang @ZhaoqiongZ @Xia-Weiwen @sekahler2 @CaoE @zhuhaozhe @Valentine233