### PR TITLE
fix xeon_run_cpu.html link

### DIFF
--- a/recipes_source/recipes_index.rst
+++ b/recipes_source/recipes_index.rst
@@ -278,7 +278,7 @@ Recipes are bite-sized, actionable examples of how to use specific PyTorch featu
    :header: CPU launcher script for optimal performance on Intel® Xeon
    :card_description: How to use launcher script for optimal runtime configurations on Intel® Xeon CPUs.
    :image: ../_static/img/thumbnails/cropped/profiler.png
-   :link: ../recipes/recipes/xeon_run_cpu.html
+   :link: ../recipes/xeon_run_cpu.html
    :tags: Model-Optimization
 
 .. customcarditem::

--- a/recipes_source/recipes_index.rst
+++ b/recipes_source/recipes_index.rst
@@ -275,8 +275,8 @@ Recipes are bite-sized, actionable examples of how to use specific PyTorch featu
    :tags: Model-Optimization
 
 .. customcarditem::
-   :header: CPU launcher script for optimal performance on Intel® Xeon
-   :card_description: How to use launcher script for optimal runtime configurations on Intel® Xeon CPUs.
+   :header: Optimizing CPU Performance on Intel® Xeon® with run_cpu Script
+   :card_description: How to use run_cpu script for optimal runtime configurations on Intel® Xeon CPUs.
    :image: ../_static/img/thumbnails/cropped/profiler.png
    :link: ../recipes/xeon_run_cpu.html
    :tags: Model-Optimization

--- a/recipes_source/xeon_run_cpu.rst
+++ b/recipes_source/xeon_run_cpu.rst
@@ -1,4 +1,4 @@
-Optimizing PyTorch Inference with Intel® Xeon® Scalable Processors
+Optimizing CPU Performance on Intel® Xeon® with run_cpu Script
 ======================================================================
 
 There are several configuration options that can impact the performance of PyTorch inference when executed on Intel® Xeon® Scalable Processors.


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

## Description
To correct the link in index.rst for xeon_run_cpu.html. (previous PR #2931)

Hi @svekars I'm not quite sure about the principles which docs should be put into the 2nd-tier `recipes` subfolder. If this tutorial should be moved to the subfolder instead of changing the link in index.rst, please let me know so that I'll update this PR.


cc @svekars @brycebortree