### PR TITLE
fix: rm `use_cuda` param

### DIFF
--- a/recipes_source/recipes/profiler_recipe.py
+++ b/recipes_source/recipes/profiler_recipe.py
@@ -73,7 +73,6 @@ inputs = torch.randn(5, 3, 224, 224)
 # - ``record_shapes`` - whether to record shapes of the operator inputs;
 # - ``profile_memory`` - whether to report amount of memory consumed by
 #   model's Tensors;
-# - ``use_cuda`` - whether to measure execution time of CUDA kernels.
 #
 # Note: when using CUDA, profiler also shows the runtime CUDA events
 # occurring on the host.


### PR DESCRIPTION
this PR removes the `use_cuda` param as it originally shows below:
https://pytorch.org/tutorials/recipes/recipes/profiler_recipe.html#pytorch-profiler
![image](https://github.com/user-attachments/assets/788aba8d-c9e6-45bf-8e11-b9f44563e780)

Actually, the param `use_cuda` is deprecated
![image](https://github.com/user-attachments/assets/0ead2d76-a41c-45ae-8755-3e74f5980ab5)
If this param is still in tutorials, it would mislead someone.  


cc @aaronenyeshi @chaekit @subramen