### PR TITLE
Change order of optimizer.step() in documentation

### DIFF
--- a/beginner_source/basics/optimization_tutorial.py
+++ b/beginner_source/basics/optimization_tutorial.py
@@ -134,9 +134,9 @@ optimizer = torch.optim.SGD(model.parameters(), lr=learning_rate)
 
 #####################################
 # Inside the training loop, optimization happens in three steps:
-#  * Call ``optimizer.zero_grad()`` to reset the gradients of model parameters. Gradients by default add up; to prevent double-counting, we explicitly zero them at each iteration.
 #  * Backpropagate the prediction loss with a call to ``loss.backward()``. PyTorch deposits the gradients of the loss w.r.t. each parameter.
 #  * Once we have our gradients, we call ``optimizer.step()`` to adjust the parameters by the gradients collected in the backward pass.
+#  * Call ``optimizer.zero_grad()`` to reset the gradients of model parameters. Gradients by default add up; to prevent double-counting, we explicitly zero them at each iteration.
 
 
 ########################################


### PR DESCRIPTION
Commit be6e86342233bdc932deace52d7388073fbb66b4 changed the order of optimization steps in the "# Backpropagation" section of the code (see lines 161 to 163). This commit updates the order of optimization steps in the description/comments to match the code.