### PR TITLE
Added warnings to select Pytorch mobile tutorials directing users to ExecuTorch 

### DIFF
--- a/beginner_source/chatbot_tutorial.py
+++ b/beginner_source/chatbot_tutorial.py
@@ -84,8 +84,7 @@ Chatbot Tutorial
 # Preparations
 # ------------
 #
-# To start, Download the data ZIP file
-# `here <https://zissou.infosci.cornell.edu/convokit/datasets/movie-corpus/movie-corpus.zip>`__
+# To get started, `download <https://zissou.infosci.cornell.edu/convokit/datasets/movie-corpus/movie-corpus.zip>`__ the Movie-Dialogs Corpus zip file.
 
 # and put in a ``data/`` directory under the current directory.
 #

--- a/beginner_source/deeplabv3_on_android.rst
+++ b/beginner_source/deeplabv3_on_android.rst
@@ -5,6 +5,10 @@ Image Segmentation DeepLabV3 on Android
 
 **Reviewed by**: `Jeremiah Chung <https://github.com/jeremiahschung>`_
 
+.. note::
+    PyTorch Mobile is no longer actively supported. Please check out `ExecuTorch <https://pytorch.org/executorch-overview>`_, PyTorch’s all-new on-device inference library. You can also review our `end-to-end workflows <https://github.com/pytorch/executorch/tree/main/examples/portable#readme>`_ and review the `source code for DeepLabV3 <https://github.com/pytorch/executorch/tree/main/examples/models/deeplab_v3>`_.
+
+
 Introduction
 ------------
 

--- a/beginner_source/deeplabv3_on_android.rst
+++ b/beginner_source/deeplabv3_on_android.rst
@@ -5,7 +5,7 @@ Image Segmentation DeepLabV3 on Android
 
 **Reviewed by**: `Jeremiah Chung <https://github.com/jeremiahschung>`_
 
-.. note::
+.. warning::
     PyTorch Mobile is no longer actively supported. Please check out `ExecuTorch <https://pytorch.org/executorch-overview>`_, PyTorch’s all-new on-device inference library. You can also review our `end-to-end workflows <https://github.com/pytorch/executorch/tree/main/examples/portable#readme>`_ and review the `source code for DeepLabV3 <https://github.com/pytorch/executorch/tree/main/examples/models/deeplab_v3>`_.
 
 

--- a/prototype_source/lite_interpreter.rst
+++ b/prototype_source/lite_interpreter.rst
@@ -3,8 +3,7 @@
 
 This tutorial has been moved to https://pytorch.org/tutorials/recipes/mobile_interpreter.html
 
-It will redirect in 3 seconds.
 
 .. raw:: html
 
-   <meta http-equiv="Refresh" content="3; url='https://pytorch.org/tutorials/recipes/mobile_interpreter.html'" />
+   <meta http-equiv="Refresh" content="0; url='https://pytorch.org/tutorials/recipes/mobile_interpreter.html'" />

--- a/prototype_source/lite_interpreter.rst
+++ b/prototype_source/lite_interpreter.rst
@@ -1,0 +1,10 @@
+(Prototype) Introduce lite interpreter workflow in Android and iOS
+=======================
+
+This tutorial has been moved to https://pytorch.org/tutorials/recipes/mobile_interpreter.html
+
+It will redirect in 3 seconds.
+
+.. raw:: html
+
+   <meta http-equiv="Refresh" content="3; url='https://pytorch.org/tutorials/recipes/mobile_interpreter.html'" />

--- a/recipes_source/mobile_interpreter.rst
+++ b/recipes_source/mobile_interpreter.rst
@@ -3,6 +3,9 @@
 
 **Author**: `Chen Lai <https://github.com/cccclai>`_, `Martin Yuan <https://github.com/iseeyuan>`_
 
+.. warning::
+    PyTorch Mobile is no longer actively supported. Please check out `ExecuTorch <https://pytorch.org/executorch-overview>`_, PyTorch’s all-new on-device inference library. You can also review our new documentation to learn more about how to build `iOS <https://pytorch.org/executorch/stable/demo-apps-ios.html>`_ and `Android <https://pytorch.org/executorch/stable/demo-apps-android.html>`_ apps with ExecuTorch.
+
 Introduction
 ------------
 

--- a/recipes_source/mobile_perf.rst
+++ b/recipes_source/mobile_perf.rst
@@ -1,6 +1,9 @@
 Pytorch Mobile Performance Recipes
 ==================================
 
+.. warning::
+    PyTorch Mobile is no longer actively supported. Please check out `ExecuTorch <https://pytorch.org/executorch-overview>`_, PyTorch’s all-new on-device inference library. You can also learn more about `quantization <https://pytorch.org/executorch/stable/quantization-overview.html>`_, `Hardware acceleration (op fusion using hw) <https://pytorch.org/executorch/stable/examples-end-to-end-to-lower-model-to-delegate.html>`_, and `benchmarking <https://pytorch.org/executorch/stable/sdk-profiling.html>`_ on ExecuTorch’s documentation pages.
+
 Introduction
 ----------------
 Performance (aka latency) is crucial to most, if not all,
@@ -245,7 +248,7 @@ For example, using ResNet-50 and running the following script:
 
 
 
-you would get the following result: 
+you would get the following result:
 
 ::
 

--- a/recipes_source/ptmobile_recipes_summary.rst
+++ b/recipes_source/ptmobile_recipes_summary.rst
@@ -1,6 +1,9 @@
 Summary of PyTorch Mobile Recipes
 =====================================
 
+.. warning::
+    Note: PyTorch Mobile is no longer actively supported. Please check out `ExecuTorch <https://pytorch.org/executorch-overview>`_, PyTorch’s all-new on-device inference library. You can also review these `ExecuTorch examples <https://github.com/pytorch/executorch/tree/main/examples#readme>`_.
+
 This summary provides a top level overview of recipes for PyTorch Mobile to help developers choose which recipes to follow for their PyTorch-powered mobile app development.
 
 Introduction


### PR DESCRIPTION
Addresses https://www.internalfb.com/tasks/my_tasks?t=200046828

Preview links for changed files:

- https://docs-preview.pytorch.org/pytorch/tutorials/3016/beginner/deeplabv3_on_android.html
- https://docs-preview.pytorch.org/pytorch/tutorials/3016/recipes/mobile_perf.html
- https://docs-preview.pytorch.org/pytorch/tutorials/3016/recipes/ptmobile_recipes_summary.html
- https://docs-preview.pytorch.org/pytorch/tutorials/3016/prototype/lite_interpreter.html (Note: this file was renamed so this URL now redirects to https://docs-preview.pytorch.org/pytorch/tutorials/3016/recipes/mobile_interpreter.html, which is added in this PR.)


## Description

This PR adds warnings to select Pytorch mobile tutorials directing users to ExecuTorch.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.


cc @svekars @brycebortree