### PR TITLE
fix typo in loading model from disk code

### DIFF
--- a/beginner_source/saving_loading_models.py
+++ b/beginner_source/saving_loading_models.py
@@ -153,7 +153,7 @@ functions to be familiar with:
 # .. code:: python
 #
 #    model = TheModelClass(*args, **kwargs)
-#    model.load_state_dict(torch.load(PATH), weights_only=True)
+#    model.load_state_dict(torch.load(PATH, weights_only=True))
 #    model.eval()
 #
 # .. note::


### PR DESCRIPTION
## Description
To load the model from disk, the `weights_only` parameter is for `torch.load` and not for `load_state_dict`. This pull request fixes the error.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
