### PR TITLE
Fix #3023 - Upgrade pygame version to 2.6.0

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -64,7 +64,7 @@ pyopengl
 gymnasium[mujoco]==0.27.0
 timm
 iopath
-pygame==2.1.2
+pygame==2.6.0
 pycocotools
 semilearn==0.3.2
 torchao==0.0.3


### PR DESCRIPTION
This allows one to install pygame binaries for Python-3.11/3.12 runtime, while PyGame-2.1.2 was only available up to python-3.10, see https://pypi.org/project/pygame/2.1.2/#files
Fixes #3023 