### PR TITLE
Remove sphinx theme from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,1 @@
-[submodule "src/pytorch-sphinx-theme"]
-	path = src/pytorch-sphinx-theme
-	url = https://github.com/pytorch/pytorch_sphinx_theme
+


### PR DESCRIPTION
Because we import the theme [here](https://github.com/pytorch/tutorials/blob/main/.ci/docker/requirements.txt#L47), we don't really need it as a submodule. It also seem to generate some unneeded [paths](https://docs-preview.pytorch.org/pytorch/tutorials/3035/sitemap.xml) in the sitemap.