### PR TITLE
Fix 2 incorrect argument positioning in Tutorial

### DIFF
--- a/beginner_source/saving_loading_models.py
+++ b/beginner_source/saving_loading_models.py
@@ -153,7 +153,7 @@ functions to be familiar with:
 # .. code:: python
 #
 #    model = TheModelClass(*args, **kwargs)
-#    model.load_state_dict(torch.load(PATH), weights_only=True)
+#    model.load_state_dict(torch.load(PATH, weights_only=True))
 #    model.eval()
 #
 # .. note::
@@ -407,7 +407,7 @@ functions to be familiar with:
 # .. code:: python
 #
 #    modelB = TheModelBClass(*args, **kwargs)
-#    modelB.load_state_dict(torch.load(PATH), strict=False, weights_only=True)
+#    modelB.load_state_dict(torch.load(PATH, weights_only=True), strict=False)
 #
 # Partially loading a model or loading a partial model are common
 # scenarios when transfer learning or training a new complex model.


### PR DESCRIPTION
Fixes #3041 

## Description
1. "weights_only" is augument of torch.load, not for model.load_state_dict

Here is the doc:
https://pytorch.org/docs/stable/generated/torch.load.html

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
