### PR TITLE
torch_compile_user_defined_triton_kernel_tutorial.py typo correction

### DIFF
--- a/recipes_source/torch_compile_user_defined_triton_kernel_tutorial.py
+++ b/recipes_source/torch_compile_user_defined_triton_kernel_tutorial.py
@@ -152,7 +152,7 @@ else:
 # * **Tensor Subclasses:** Currently, there is no support for
 #   tensor subclasses and other advanced features.
 # * **Triton Features:** While ``triton.heuristics`` can be used either standalone or
-#   before ``triton.autotune``, it cannot be used after ```triton.autotune``. This
+#   before ``triton.autotune``, it cannot be used after ``triton.autotune``. This
 #   implies that if ``triton.heuristics`` and ``triton.autotune`` are to be used
 #   together, ``triton.heuristics`` must be used first.
 #


### PR DESCRIPTION
Fixes #3045

## Description

Replace \`\`triton.autotune\`\` with \`\`triton.autotune\`\` in line 155.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
