### PR TITLE
docs: Improve example by adding missing import

### DIFF
--- a/beginner_source/basics/data_tutorial.py
+++ b/beginner_source/basics/data_tutorial.py
@@ -120,6 +120,7 @@ plt.show()
 
 import os
 import pandas as pd
+from torch.utils.data import Dataset
 from torchvision.io import read_image
 
 class CustomImageDataset(Dataset):


### PR DESCRIPTION
Fixes #3050

## Description
The example "Creating a Custom Dataset for your files" was missing the import `from torch.utils.data import Dataset`. Since other imports are shown and the purpose of this example is to show how to create a custom dataset, this import is crucial and should be added.

## Checklist
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @subramen @albanD @jbschlosser