### PR TITLE
Fix typo in Environment Variable section of dist_tuto.rst

### DIFF
--- a/intermediate_source/dist_tuto.rst
+++ b/intermediate_source/dist_tuto.rst
@@ -569,7 +569,7 @@ finally handshake with them.
 -  ``WORLD_SIZE``: The total number of processes, so that the master
    knows how many workers to wait for.
 -  ``RANK``: Rank of each process, so they will know whether it is the
-   master of a worker.
+   master or a worker.
 
 **Shared File System**
 


### PR DESCRIPTION
## Description
Super small fix! Fixes a typo in the Environment Variable section of dist_tuto.rst.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @svekars @brycebortree @tstatler