### PR TITLE
Fix a typo in the inductor Windows CPU tutorial

### DIFF
--- a/prototype_source/inductor_windows_cpu.rst
+++ b/prototype_source/inductor_windows_cpu.rst
@@ -74,7 +74,7 @@ Here’s a simple example to demonstrate how to use TorchInductor:
     import torch
     def foo(x, y):
         a = torch.sin(x)
-        b = torch.cos(x)
+        b = torch.cos(y)
         return a + b
     opt_foo1 = torch.compile(foo)
     print(opt_foo1(torch.randn(10, 10), torch.randn(10, 10)))

--- a/prototype_source/inductor_windows_cpu.rst
+++ b/prototype_source/inductor_windows_cpu.rst
@@ -54,7 +54,7 @@ Set Up the Environment
    .. code-block:: sh
 
     "C:/ProgramData/miniforge3/Scripts/activate.bat"
-#. Create and activate a customer conda environment:
+#. Create and activate a custom conda environment:
  
    .. code-block:: sh
 

--- a/prototype_source/inductor_windows_cpu.rst
+++ b/prototype_source/inductor_windows_cpu.rst
@@ -79,7 +79,7 @@ Here’s a simple example to demonstrate how to use TorchInductor:
     opt_foo1 = torch.compile(foo)
     print(opt_foo1(torch.randn(10, 10), torch.randn(10, 10)))
 
-The code above returns the following output: 
+Here is the sample output that this code might return: 
 
 .. code-block:: sh
 


### PR DESCRIPTION
Follow up on https://github.com/pytorch/tutorials/pull/3062/files#r1784933084
cc @brycebortree @sekyondaMeta