### PR TITLE
Update introyt1_tutorial.py: change comment on torch.std_mean()

### DIFF
--- a/beginner_source/introyt/introyt1_tutorial.py
+++ b/beginner_source/introyt/introyt1_tutorial.py
@@ -120,7 +120,7 @@ print('\nSingular value decomposition of r:')
 print(torch.svd(r))
 
 # ...and statistical and aggregate operations:
-print('\nAverage and standard deviation of r:')
+print('\nStandard deviation and Average of r:')
 print(torch.std_mean(r))
 print('\nMaximum value of r:')
 print(torch.max(r))


### PR DESCRIPTION
- Changes comment on torch.std_mean(): from `Average and Standard deviation` to `Standard deviation to Average`.

## Description
- As `torch.std_mean()` outputs std first and mean second, it's misleading to narrate as Average and std. Therefore, I'd like to change the order of words in the relevant comment as this.

## Checklist

- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [X] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [X] No unnecessary issues are included into this pull request.
