### PR TITLE
DTensor has moved to the public namespace

### DIFF
--- a/beginner_source/dist_overview.rst
+++ b/beginner_source/dist_overview.rst
@@ -35,7 +35,7 @@ Sharding primitives
 
 ``DTensor`` and ``DeviceMesh`` are primitives used to build parallelism in terms of sharded or replicated tensors on N-dimensional process groups.
 
-- `DTensor <https://github.com/pytorch/pytorch/blob/main/torch/distributed/_tensor/README.md>`__ represents a tensor that is sharded and/or replicated, and communicates automatically to reshard tensors as needed by operations.
+- `DTensor <https://github.com/pytorch/pytorch/blob/main/torch/distributed/tensor/README.md>`__ represents a tensor that is sharded and/or replicated, and communicates automatically to reshard tensors as needed by operations.
 - `DeviceMesh <https://pytorch.org/docs/stable/distributed.html#devicemesh>`__ abstracts the accelerator device communicators into a multi-dimensional array, which manages the underlying ``ProcessGroup`` instances for collective communications in multi-dimensional parallelisms.  Try out our `Device Mesh Recipe <https://pytorch.org/tutorials/recipes/distributed_device_mesh.html>`__ to learn more.
 
 Communications APIs

--- a/recipes_source/distributed_comm_debug_mode.rst
+++ b/recipes_source/distributed_comm_debug_mode.rst
@@ -21,7 +21,7 @@ of parallel strategies to scale up distributed training. However, the lack of in
 between existing solutions poses a significant challenge, primarily due to the absence of a
 unified abstraction that can bridge these different parallelism strategies. To address this
 issue, PyTorch has proposed `DistributedTensor(DTensor)
-<https://github.com/pytorch/pytorch/blob/main/torch/distributed/_tensor/examples/comm_mode_features_example.py>`_
+<https://github.com/pytorch/pytorch/blob/main/torch/distributed/tensor/examples/comm_mode_features_example.py>`_
 which abstracts away the complexities of tensor communication in distributed training,
 providing a seamless user experience. However, when dealing with existing parallelism solutions and
 developing parallelism solutions using the unified abstraction like DTensor, the lack of transparency
@@ -194,7 +194,7 @@ Below is the interactive module tree visualization that you can use to upload yo
             <input type="file" id="file-input" accept=".json">
           </div>
         <div id="tree-container"></div>
-        <script src="https://cdn.jsdelivr.net/gh/pytorch/pytorch@main/torch/distributed/_tensor/debug/comm_mode_broswer_visual.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/pytorch/pytorch@main/torch/distributed/tensor/debug/comm_mode_broswer_visual.js"></script>
     </body>
     </html>
 
@@ -207,4 +207,4 @@ JSON outputs in the embedded visual browser.
 
 For more detailed information about ``CommDebugMode``, see
 `comm_mode_features_example.py
-<https://github.com/pytorch/pytorch/blob/main/torch/distributed/_tensor/examples/comm_mode_features_example.py>`_
+<https://github.com/pytorch/pytorch/blob/main/torch/distributed/tensor/examples/comm_mode_features_example.py>`_


### PR DESCRIPTION
Fixes #3083

## Description

DTensor has moved to the public namespace and references need to be updated following up pytorch/pytorch#134203. 

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
