### PR TITLE
Update saveloadrun_tutorial.py to fix a broken link

### DIFF
--- a/beginner_source/basics/saveloadrun_tutorial.py
+++ b/beginner_source/basics/saveloadrun_tutorial.py
@@ -57,8 +57,8 @@ torch.save(model, 'model.pth')
 ########################
 # We can then load the model as demonstrated below.
 #
-# As described in `Saving and loading torch.nn.Modules <pytorch.org/docs/main/notes/serialization.html#saving-and-loading-torch-nn-modules>`__,
-# saving ``state_dict``s is considered the best practice. However,
+# As described in `Saving and loading torch.nn.Modules <https://pytorch.org/docs/main/notes/serialization.html#saving-and-loading-torch-nn-modules>`_,
+# saving ``state_dict`` is considered the best practice. However,
 # below we use ``weights_only=False`` because this involves loading the
 # model, which is a legacy use case for ``torch.save``.
 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

Update https://pytorch.org/tutorials/beginner/basics/saveloadrun_tutorial to fix a broken link and some formatting.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.


cc @svekars @brycebortree @sekyondaMeta