### PR TITLE
Redirect from the old torchrec tutorial to the new one

### DIFF
--- a/intermediate_source/torchrec_tutorial.rst
+++ b/intermediate_source/torchrec_tutorial.rst
@@ -1,0 +1,10 @@
+Introduction to TorchRec
+========================
+
+There is a newer tutorial on this topic.
+
+Redirecting...
+
+.. raw:: html
+
+   <meta http-equiv="Refresh" content="0; url='https://pytorch.org/tutorials/intermediate/torchrec_intro_tutorial.html'" />


### PR DESCRIPTION
Add a redirect to the new torchrect tutorial
