### PR TITLE
Update PT Cheat page to stop referencing torchscript

### DIFF
--- a/beginner_source/ptcheat.rst
+++ b/beginner_source/ptcheat.rst
@@ -22,26 +22,11 @@ Neural Network API
     import torch.nn as nn                     # neural networks
     import torch.nn.functional as F           # layers, activations and more
     import torch.optim as optim               # optimizers e.g. gradient descent, ADAM, etc.
-    from torch.jit import script, trace       # hybrid frontend decorator and tracing jit
 
 See `autograd <https://pytorch.org/docs/stable/autograd.html>`__,
 `nn <https://pytorch.org/docs/stable/nn.html>`__,
 `functional <https://pytorch.org/docs/stable/nn.html#torch-nn-functional>`__
 and `optim <https://pytorch.org/docs/stable/optim.html>`__
-
-TorchScript and JIT
--------------------
-
-.. code-block:: python
-
-    torch.jit.trace()         # takes your module or function and an example 
-                              # data input, and traces the computational steps 
-                              # that the data encounters as it progresses through the model
-
-    @script                   # decorator used to indicate data-dependent 
-                              # control flow within the code being traced
-
-See `Torchscript <https://pytorch.org/docs/stable/jit.html>`__
 
 ONNX
 ----
@@ -225,8 +210,10 @@ Optimizers
 
     opt = optim.x(model.parameters(), ...)      # create optimizer
     opt.step()                                  # update weights
-    optim.X                                     # where X is SGD, Adadelta, Adagrad, Adam, 
-                                                # AdamW, SparseAdam, Adamax, ASGD, 
+    opt.zero_grad()                             # clear the gradients
+    optim.X                                     # where X is SGD, AdamW, Adam,
+                                                # Adafactor, NAdam, RAdam, Adadelta,
+                                                # Adagrad, SparseAdam, Adamax, ASGD,
                                                 # LBFGS, RMSprop or Rprop
 
 See `optimizers <https://pytorch.org/docs/stable/optim.html>`__


### PR DESCRIPTION
## Description
Updates the pt cheat page to
- no longer mention jit/torchscript
- mention zero_grad for optim
- update the list of optims

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
