### PR TITLE
[Tutorial][PTD] Deprecate `Training Transformer models using Distributed Data Parallel and Pipeline Parallelism` and redirect the page to parallelism APIs

### DIFF
--- a/advanced_source/ddp_pipeline.rst
+++ b/advanced_source/ddp_pipeline.rst
@@ -1,0 +1,10 @@
+Training Transformer models using Distributed Data Parallel and Pipeline Parallelism
+====================================================================================
+
+This tutorial has been deprecated.
+
+Redirecting to latest parallelism APIs in 3 seconds...
+
+.. raw:: html
+
+   <meta http-equiv="Refresh" content="3; url='https://pytorch.org/tutorials/beginner/dist_overview.html#parallelism-apis'" />


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

## Description
As title.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [] Only one issue is addressed in this pull request
- [] Labels from the issue that this PR is fixing are added to this pull request
- [] No unnecessary issues are included into this pull request.
