### PR TITLE
Fix: add event sync in fsdp tutorial

### DIFF
--- a/intermediate_source/FSDP_tutorial.rst
+++ b/intermediate_source/FSDP_tutorial.rst
@@ -251,6 +251,7 @@ We add the following code snippets to a python script “FSDP_mnist.py”.
         init_end_event.record()
 
         if rank == 0:
+            init_end_event.synchronize()
             print(f"CUDA event elapsed time: {init_start_event.elapsed_time(init_end_event) / 1000}sec")
             print(f"{model}")
 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

## Description

The event should be synchronized before calling `elapsed_time` to ensure that the corresponding event has completed. This change is necessary to avoid runtime errors related to incomplete events.

For more details, refer to the relevant code in the PyTorch repository:
- [CUDAEvent.h#L157](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/cuda/CUDAEvent.h#L157)

### Example Code

```python
import torch
def case():
    torch.cuda.set_device(0)

    init_start_event = torch.cuda.Event(enable_timing=True)
    init_end_event = torch.cuda.Event(enable_timing=True)

    init_start_event.record()
    for i in range(100):
        a = torch.randn(size=(1024, 1024), device="cuda")
        b = torch.randn(size=(1024, 1024), device="cuda")
        out = torch.add(a, b)
        out = torch.matmul(a, b)
        out = torch.matmul(a, b)
        out = torch.matmul(a, b)
        out = torch.matmul(a, b)
    init_end_event.record()

    # print("init_end_event.query(): ", init_end_event.query()) # False
    # # RuntimeError: CUDA error: device not ready
    # print(
    #     f"CUDA event elapsed time: {init_start_event.elapsed_time(init_end_event) / 1000}sec"
    # )

    # OK
    init_end_event.synchronize()
    print("init_end_event.query(): ", init_end_event.query())
    print(
        f"CUDA event elapsed time: {init_start_event.elapsed_time(init_end_event) / 1000}sec"
    )
```


