### PR TITLE
Fix typo in torch_compile_caching_tutorial.rst

### DIFF
--- a/recipes_source/torch_compile_caching_tutorial.rst
+++ b/recipes_source/torch_compile_caching_tutorial.rst
@@ -23,7 +23,7 @@ Before starting this recipe, make sure that you have the following:
 Inductor Cache Settings
 ----------------------------
 
-Most of these caches are in-memory, only used within the same process, and are transparent to the user. An exception are caches tha stores compiled FX graphs (FXGraphCache, AOTAutogradCache). These caches allow Inductor to avoid recompilation across process boundaries when it encounters the same graph with the same Tensor input shapes (and the same configuration). The default implementation stores compiled artifacts in the system temp directory. An optional feature also supports sharing those artifacts within a cluster by storing them in a Redis database.
+Most of these caches are in-memory, only used within the same process, and are transparent to the user. An exception is caches that store compiled FX graphs (FXGraphCache, AOTAutogradCache). These caches allow Inductor to avoid recompilation across process boundaries when it encounters the same graph with the same Tensor input shapes (and the same configuration). The default implementation stores compiled artifacts in the system temp directory. An optional feature also supports sharing those artifacts within a cluster by storing them in a Redis database.
 
 There are a few settings relevant to caching and to FX graph caching in particular.
 The settings are accessible via environment variables listed below or can be hard-coded in Inductor’s config file.


### PR DESCRIPTION
Follow up on https://github.com/pytorch/tutorials/pull/3177

cc @brycebortree @sekyondaMeta @AlannaBurke