### PR TITLE
fix line wrapping

### DIFF
--- a/intermediate_source/dist_tuto.rst
+++ b/intermediate_source/dist_tuto.rst
@@ -252,7 +252,7 @@ PyTorch. Here are a few supported collectives.
    from all processes to ``tensor_list``, on all processes.
 -  ``dist.barrier(group)``: Blocks all processes in `group` until each one has entered this function.
 -  ``dist.all_to_all(output_tensor_list, input_tensor_list, group)``: Scatters list of input tensors to all processes in
-a group and return gathered list of tensors in output list.
+   a group and return gathered list of tensors in output list.
 
 The full list of supported collectives can be found by looking at the latest documentation for PyTorch Distributed
 `(link) <https://pytorch.org/docs/stable/distributed.html>`__.


### PR DESCRIPTION
Fixes an invalid line wrapping leading to:

![snapshot_6](https://github.com/user-attachments/assets/e8f5e6ad-37ed-4a76-9b7e-6d453b8c26b7)


cc @svekars @brycebortree @AlannaBurke