### PR TITLE
[doc] fix flight recorder tutorial

### DIFF
--- a/prototype_source/flight_recorder_tutorial.rst
+++ b/prototype_source/flight_recorder_tutorial.rst
@@ -214,7 +214,6 @@ For demonstration purposes, we named this program ``crash.py``.
    complexities.
 
 .. code:: python
-  :caption: A crashing example
 
   import torch
   import torch.distributed as dist


### PR DESCRIPTION
Summary:
The small example code isn't rendering on the page. 

Remove caption string as this seems to be the problem.

Test Plan:
Tested locally and on sandbox.
Without the fix: note missing code after "Note".
Broken screenshot:
<img width="887" alt="Screenshot 2024-12-17 at 2 43 06 PM" src="https://github.com/user-attachments/assets/e904769c-18ae-4a16-8c1c-f5cc78313364" />
Broken link here:
https://pytorch.org/tutorials/prototype/flight_recorder_tutorial.html#an-end-to-end-example


After the fix:
Fixed screenshot:
<img width="908" alt="Screenshot 2024-12-17 at 2 42 03 PM" src="https://github.com/user-attachments/assets/bad21c01-adb2-43ab-bdbb-3b78e3229d35" />
Sandbox link here: 
https://docs-preview.pytorch.org/pytorch/tutorials/3189/prototype/flight_recorder_tutorial.html#an-end-to-end-example


## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
