### PR TITLE
Fix dead link for compiler troubleshooting

### DIFF
--- a/intermediate_source/inductor_debug_cpu.py
+++ b/intermediate_source/inductor_debug_cpu.py
@@ -20,7 +20,7 @@ Inductor CPU backend debugging and profiling
 # Meanwhile, you may also find related tutorials about ``torch.compile`` 
 # around `basic usage <https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html>`_, 
 # comprehensive `troubleshooting <https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html>`_ 
-# and GPU-specific knowledge like `GPU performance profiling <https://github.com/pytorch/pytorch/blob/main/docs/source/compile/profiling_torch_compile.rst>`_.
+# and GPU-specific knowledge like `GPU performance profiling <https://pytorch.org/docs/stable/torch.compiler_inductor_profiling.html>`_.
 #
 # We will start debugging with a motivating example that triggers compilation issues and accuracy problems 
 # by demonstrating the process of debugging to pinpoint the problems.

--- a/intermediate_source/inductor_debug_cpu.py
+++ b/intermediate_source/inductor_debug_cpu.py
@@ -19,7 +19,7 @@ Inductor CPU backend debugging and profiling
 #
 # Meanwhile, you may also find related tutorials about ``torch.compile`` 
 # around `basic usage <https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html>`_, 
-# comprehensive `troubleshooting <https://pytorch.org/docs/stable/dynamo/troubleshooting.html>`_ 
+# comprehensive `troubleshooting <https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html>`_
 # and GPU-specific knowledge like `GPU performance profiling <https://github.com/pytorch/pytorch/blob/main/docs/source/compile/profiling_torch_compile.rst>`_.
 #
 # We will start debugging with a motivating example that triggers compilation issues and accuracy problems 
@@ -343,7 +343,7 @@ def forward2(self, arg0_1):
     return (neg,)
 
 ######################################################################
-# For more usage details about Minifier, please refer to `Troubleshooting <https://pytorch.org/docs/stable/dynamo/troubleshooting.html>`_.
+# For more usage details about Minifier, please refer to `Troubleshooting <https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html>`_.
 
 
 ######################################################################

--- a/intermediate_source/inductor_debug_cpu.py
+++ b/intermediate_source/inductor_debug_cpu.py
@@ -19,7 +19,7 @@ Inductor CPU backend debugging and profiling
 #
 # Meanwhile, you may also find related tutorials about ``torch.compile`` 
 # around `basic usage <https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html>`_, 
-# comprehensive `troubleshooting <https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html>`_
+# comprehensive `troubleshooting <https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html>`_ 
 # and GPU-specific knowledge like `GPU performance profiling <https://github.com/pytorch/pytorch/blob/main/docs/source/compile/profiling_torch_compile.rst>`_.
 #
 # We will start debugging with a motivating example that triggers compilation issues and accuracy problems 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

Original link (https://pytorch.org/docs/stable/dynamo/troubleshooting.html) is dead, use (https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html) instead.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.


cc @svekars @brycebortree @sekyondaMeta @AlannaBurke