### PR TITLE
Fix invalid page links in tutorial

### DIFF
--- a/intermediate_source/inductor_debug_cpu.py
+++ b/intermediate_source/inductor_debug_cpu.py
@@ -19,8 +19,8 @@ Inductor CPU backend debugging and profiling
 #
 # Meanwhile, you may also find related tutorials about ``torch.compile`` 
 # around `basic usage <https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html>`_, 
-# comprehensive `troubleshooting <https://pytorch.org/docs/stable/dynamo/troubleshooting.html>`_ 
-# and GPU-specific knowledge like `GPU performance profiling <https://github.com/pytorch/pytorch/blob/main/docs/source/compile/profiling_torch_compile.rst>`_.
+# comprehensive `troubleshooting <https://pytorch.org/docs/stable/torch.compiler_troubleshooting.html>`_ 
+# and GPU-specific knowledge like `GPU performance profiling <https://pytorch.org/docs/stable/torch.compiler_inductor_profiling.html>`_.
 #
 # We will start debugging with a motivating example that triggers compilation issues and accuracy problems 
 # by demonstrating the process of debugging to pinpoint the problems.


### PR DESCRIPTION
Links in the tutorial [Inductor CPU backend debugging and profiling
](https://pytorch.org/tutorials/intermediate/inductor_debug_cpu.html) is invalid, and leading to 404 pages.

Change `troubleshooting` and `GPU performance profiling` to valid url address

**Test Result**

**Before**
![image](https://github.com/user-attachments/assets/4a5a9723-220e-4bed-a450-8d1f0a8a835a)

![image](https://github.com/user-attachments/assets/374ae08f-1a67-40e3-83d8-2f61fb0966a9)


**After**
![image](https://github.com/user-attachments/assets/802a5cb6-193a-4268-9c10-26bc2821c3b7)

![image](https://github.com/user-attachments/assets/6c26fff0-bb5f-47bd-aa87-f68edd3b9718)

cc @svekars @brycebortree @sekyondaMeta @AlannaBurke @jgong5 

