### PR TITLE
Clarify the Extending PyTorch sidebar by making differences more obvious

### DIFF
--- a/advanced_source/python_custom_ops.py
+++ b/advanced_source/python_custom_ops.py
@@ -3,7 +3,7 @@
 """
 .. _python-custom-ops-tutorial:
 
-Python Custom Operators
+Custom Python Operators
 =======================
 
 .. grid:: 2

--- a/index.rst
+++ b/index.rst
@@ -397,14 +397,14 @@ Welcome to PyTorch Tutorials
    :tags: Frontend-APIs,C++
 
 .. customcarditem::
-   :header: Python Custom Operators Landing Page
+   :header: PyTorch Custom Operators Landing Page
    :card_description: This is the landing page for all things related to custom operators in PyTorch.
    :image: _static/img/thumbnails/cropped/Custom-Cpp-and-CUDA-Extensions.png
    :link: advanced/custom_ops_landing_page.html
    :tags: Extending-PyTorch,Frontend-APIs,C++,CUDA
 
 .. customcarditem::
-   :header: Python Custom Operators
+   :header: Custom Python Operators
    :card_description: Create Custom Operators in Python. Useful for black-boxing a Python function for use with torch.compile.
    :image: _static/img/thumbnails/cropped/Custom-Cpp-and-CUDA-Extensions.png
    :link: advanced/python_custom_ops.html


### PR DESCRIPTION
Before:
<img width="626" alt="image" src="https://github.com/user-attachments/assets/73ef8f11-bbf4-4a3c-b195-ce95771d32a9" />

This confused me everytime cuz PyTorch and Python were too similar, so changing "Python Custom Operators" to "Custom Python Operators" to be super obvious. This is step 0 in updating this section of the tutorials in general, as several pieces of this sidebar are outdated. The plan for the bigger update is in a few weeks when Core does BE week.

After:
<img width="368" alt="image" src="https://github.com/user-attachments/assets/c93cef86-965c-461e-8090-4fd9906d3a22" />


