### PR TITLE
fix: fix 'Shard' capital letter for distributed device mesh recipe

### DIFF
--- a/recipes_source/distributed_device_mesh.rst
+++ b/recipes_source/distributed_device_mesh.rst
@@ -164,7 +164,7 @@ DeviceMesh allows users to slice child mesh from the parent mesh and re-use the 
 
     # Users can access the underlying process group thru `get_group` API.
     replicate_group = hsdp_mesh["replicate"].get_group()
-    shard_group = hsdp_mesh["Shard"].get_group()
+    shard_group = hsdp_mesh["shard"].get_group()
     tp_group = tp_mesh.get_group()
 
 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

## Description
Fix the placement from 'Shard' to 'shard'

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
