### PR TITLE
Fix typo `size` to `world_size`

### DIFF
--- a/intermediate_source/dist_tuto.rst
+++ b/intermediate_source/dist_tuto.rst
@@ -72,7 +72,7 @@ the following template.
             mp.get_context("spawn")
         else:
             mp.set_start_method("spawn")
-        for rank in range(size):
+        for rank in range(world_size):
             p = mp.Process(target=init_process, args=(rank, world_size, run))
             p.start()
             processes.append(p)


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.


cc @wconstab @osalpekar @H-Huang @kwen2501