### PR TITLE
Fix the AOTI example

### DIFF
--- a/intermediate_source/torch_export_tutorial.py
+++ b/intermediate_source/torch_export_tutorial.py
@@ -995,7 +995,7 @@ print(res)
 #    with torch.no_grad():
 #        pt2_path = torch._inductor.aoti_compile_and_package(ep)
 #
-#    # Load and run the .so file in Python.
+#    # Load and run the .pt2 file in Python.
 #    # To load and run it in a C++ environment, see:
 #    # https://pytorch.org/docs/main/torch.compiler_aot_inductor.html
 #    aoti_compiled = torch._inductor.aoti_load_package(pt2_path)

--- a/recipes_source/torch_export_aoti_python.py
+++ b/recipes_source/torch_export_aoti_python.py
@@ -176,7 +176,7 @@ import torch._inductor
 model_path = os.path.join(os.getcwd(), "resnet18.pt2")
 
 compiled_model = torch._inductor.aoti_load_package(model_path)
-example_inputs = (torch.randn(2, 3, 224, 224, device=device),)
+example_inputs = torch.randn(2, 3, 224, 224, device=device)
 
 with torch.inference_mode():
     output = compiled_model(example_inputs)
@@ -238,11 +238,11 @@ def timed(fn):
 
 torch._dynamo.reset()
 
-model = torch._inductor.aoti_load_package(model_path)
-example_inputs = (torch.randn(1, 3, 224, 224, device=device),)
+compiled_model = torch._inductor.aoti_load_package(model_path)
+example_inputs = torch.randn(1, 3, 224, 224, device=device)
 
 with torch.inference_mode():
-    _, time_taken = timed(lambda: model(example_inputs))
+    _, time_taken = timed(lambda: compiled_model(example_inputs))
     print(f"Time taken for first inference for AOTInductor is {time_taken:.2f} ms")
 
 


### PR DESCRIPTION
## Description
The compiled model run takes the same input as Eager. No need to explicitly compose args as a tuple.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
