### PR TITLE
Run tutorials on g5

### DIFF
--- a/.github/workflows/build-tutorials.yml
+++ b/.github/workflows/build-tutorials.yml
@@ -22,15 +22,15 @@ jobs:
           - { shard: 4, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
           - { shard: 5, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
           - { shard: 6, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
-          - { shard: 7, num_shards: 15, runner: "linux.4xlarge.nvidia.gpu" }
-          - { shard: 8, num_shards: 15, runner: "linux.4xlarge.nvidia.gpu" }
-          - { shard: 9, num_shards: 15, runner: "linux.4xlarge.nvidia.gpu" }
-          - { shard: 10, num_shards: 15, runner: "linux.4xlarge.nvidia.gpu" }
-          - { shard: 11, num_shards: 15, runner: "linux.4xlarge.nvidia.gpu" }
-          - { shard: 12, num_shards: 15, runner: "linux.4xlarge.nvidia.gpu" }
-          - { shard: 13, num_shards: 15, runner: "linux.4xlarge.nvidia.gpu" }
-          - { shard: 14, num_shards: 15, runner: "linux.4xlarge.nvidia.gpu" }
-          - { shard: 15, num_shards: 15, runner: "linux.4xlarge.nvidia.gpu" }
+          - { shard: 7, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
+          - { shard: 8, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
+          - { shard: 9, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
+          - { shard: 10, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
+          - { shard: 11, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
+          - { shard: 12, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
+          - { shard: 13, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
+          - { shard: 14, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
+          - { shard: 15, num_shards: 15, runner: "linux.g5.4xlarge.nvidia.gpu" }
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
Why we're making this change
-------------------------------
PR authors are frustrated with `torch.compile` tutorials, which aren't supported on our older workers. As more tutorials adopt `torch.compile`, users must constantly update `metadata.json` to ensure their tutorials run on compatible workers.

This PR moves these tutorials to G5 instances, providing a consistent environment that supports `torch.compile` out of the box, eliminating the need for manual configuration and improving the overall developer experience. This change should also help to make the whole tutorial build faster.

Cons: Less and less tutorials are actually runnable on Colab, which still serves only T4 machines in their free tier