### PR TITLE
Fix missing import for Dataset in custom dataset tutorial

### DIFF
--- a/beginner_source/basics/data_tutorial.py
+++ b/beginner_source/basics/data_tutorial.py
@@ -121,6 +121,7 @@ plt.show()
 import os
 import pandas as pd
 from torchvision.io import read_image
+from torch.utils.data import Dataset  # ✅ FIXED
 
 class CustomImageDataset(Dataset):
     def __init__(self, annotations_file, img_dir, transform=None, target_transform=None):


### PR DESCRIPTION
Fixes #152518

## Description
<This PR addresses the missing import in the "Creating a Custom Dataset" section of the PyTorch tutorials.

The class `CustomImageDataset` inherits from `Dataset`, but the `Dataset` class was not imported in that specific code block. This causes a `NameError` if the user runs the code independently.

Added the following line above the custom class definition:
```python
from torch.utils.data import Dataset>

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
