### PR TITLE
Fix links to executorch and tiatoolbox

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -803,24 +803,24 @@ Welcome to PyTorch Tutorials
    :tags: Edge
 
 .. customcarditem::
-   :header: Using the ExecuTorch SDK to Profile a Model
+   :header: Using the ExecuTorch Developer Tools to Profile a Model
    :card_description: Explore how to use the ExecuTorch SDK to profile, debug, and visualize ExecuTorch models
    :image: _static/img/ExecuTorch-Logo-cropped.svg
-   :link: https://pytorch.org/executorch/stable/tutorials/sdk-integration-tutorial.html
+   :link: https://pytorch.org/executorch/stable/tutorials/devtools-integration-tutorial.html
    :tags: Edge
 
 .. customcarditem::
-   :header: Building an ExecuTorch iOS Demo App
-   :card_description: Explore how to set up the ExecuTorch iOS Demo App, which uses the MobileNet v3 model to process live camera images leveraging three different backends: XNNPACK, Core ML, and Metal Performance Shaders (MPS).
+   :header: Using ExecuTorch on iOS
+   :card_description: Learn how to use ExecuTorch on iOS and macOS with Objective-C, Swift, and C++.
    :image: _static/img/ExecuTorch-Logo-cropped.svg
-   :link: https://pytorch.org/executorch/stable/demo-apps-ios.html
+   :link: https://pytorch.org/executorch/stable/using-executorch-ios.html
    :tags: Edge
 
 .. customcarditem::
-   :header: Building an ExecuTorch Android Demo App
-   :card_description: Learn how to set up the ExecuTorch Android Demo App for image segmentation tasks using the DeepLab v3 model and XNNPACK FP32 backend.
+   :header: Using ExecuTorch on Android
+   :card_description: Learn how use ExecuTorch on Android with Java and Kotlin API bindings.
    :image: _static/img/ExecuTorch-Logo-cropped.svg
-   :link: https://pytorch.org/executorch/stable/demo-apps-android.html
+   :link: https://pytorch.org/executorch/stable/using-executorch-android.html
    :tags: Edge
 
 .. customcarditem::

--- a/intermediate_source/tiatoolbox_tutorial.rst
+++ b/intermediate_source/tiatoolbox_tutorial.rst
@@ -348,7 +348,7 @@ The PatchPredictor class runs a CNN-based classifier written in PyTorch.
 -  Alternatively, you can pass ``pretrained_model`` as a string
    argument. This specifies the CNN model that performs the prediction,
    and it must be one of the models listed
-   `here <https://tia-toolbox.readthedocs.io/en/latest/usage.html?highlight=pretrained%20models#tiatoolbox.models.architecture.get_pretrained_model>`__.
+   `here <https://tia-toolbox.readthedocs.io/en/latest/_autosummary/tiatoolbox.models.architecture.get_pretrained_model.html#tiatoolbox.models.architecture.get_pretrained_model>`__.
    The command will look like this:
    ``predictor = PatchPredictor(pretrained_model='resnet18-kather100k', pretrained_weights=weights_path, batch_size=32)``.
 -  ``pretrained_weights``: When using a ``pretrained_model``, the
@@ -621,7 +621,7 @@ results. Here are the arguments and their descriptions:
    which is equivalent to level 0. In general, this is the level of
    greatest resolution. In this particular case, the image has only one
    level. More information can be found in the
-   `documentation <https://tia-toolbox.readthedocs.io/en/latest/usage.html?highlight=WSIReader.read_rect#tiatoolbox.wsicore.wsireader.WSIReader.read_rect>`__.
+   `documentation <https://tia-toolbox.readthedocs.io/en/latest/_autosummary/tiatoolbox.wsicore.wsireader.WSIReader.html#tiatoolbox.wsicore.wsireader.WSIReader.read_rect>`__.
 -  ``masks``: A list of paths corresponding to the masks of WSIs in the
    ``imgs`` list. These masks specify the regions in the original WSIs
    from which we want to extract patches. If the mask of a particular


### PR DESCRIPTION
Fixes https://github.com/pytorch/tutorials/issues/3347

## Description
This PR updates the links to executorch docs. For iOS and Android demos were moved to GitHub repos, so this PR directly links to to https://pytorch.org/executorch/stable/using-executorch-ios.html and https://pytorch.org/executorch/stable/using-executorch-android.html which will link to the demo.

I'm not sure why `recipes_source/deployment_with_flask.rst` is failing, that should be ignored from here:

https://github.com/pytorch/tutorials/blob/b6b5c2115180d0a8eae1e0ddcfe62441c6763c8f/.lycheeignore#L16-L17

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
