### PR TITLE
remove obsolete encoding headers

### DIFF
--- a/beginner_source/examples_autograd/polynomial_autograd.py
+++ b/beginner_source/examples_autograd/polynomial_autograd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 PyTorch: Tensors and autograd
 -------------------------------

--- a/beginner_source/examples_autograd/polynomial_custom_function.py
+++ b/beginner_source/examples_autograd/polynomial_custom_function.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 PyTorch: Defining New autograd Functions
 ----------------------------------------


### PR DESCRIPTION
header "# -*- coding: utf-8 -*-" is only needed for Python 2.x.

Since Python 3.x default encoding is utf-8 and is header is not necessary. It gets displayed in the tutorials here: https://docs.pytorch.org/tutorials/beginner/pytorch_with_examples.html

and could confuse newcomers who might think that encoding header is necessary
