### PR TITLE
remove obsolete encoding headers

### DIFF
--- a/beginner_source/blitz/autograd_tutorial.py
+++ b/beginner_source/blitz/autograd_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 A Gentle Introduction to ``torch.autograd``
 ===========================================

--- a/beginner_source/blitz/cifar10_tutorial.py
+++ b/beginner_source/blitz/cifar10_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Training a Classifier
 =====================

--- a/beginner_source/blitz/neural_networks_tutorial.py
+++ b/beginner_source/blitz/neural_networks_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Neural Networks
 ===============

--- a/beginner_source/chatbot_tutorial.py
+++ b/beginner_source/chatbot_tutorial.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Chatbot Tutorial
 ================

--- a/beginner_source/data_loading_tutorial.py
+++ b/beginner_source/data_loading_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Writing Custom Datasets, DataLoaders and Transforms
 ===================================================

--- a/beginner_source/dcgan_faces_tutorial.py
+++ b/beginner_source/dcgan_faces_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 DCGAN Tutorial
 ==============

--- a/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
+++ b/beginner_source/deploy_seq2seq_hybrid_frontend_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Deploying a Seq2Seq Model with TorchScript
 ==================================================

--- a/beginner_source/examples_nn/dynamic_net.py
+++ b/beginner_source/examples_nn/dynamic_net.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 PyTorch: Control Flow + Weight Sharing
 --------------------------------------

--- a/beginner_source/examples_nn/polynomial_module.py
+++ b/beginner_source/examples_nn/polynomial_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 PyTorch: Custom nn Modules
 --------------------------

--- a/beginner_source/examples_nn/polynomial_nn.py
+++ b/beginner_source/examples_nn/polynomial_nn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 PyTorch: nn
 -----------

--- a/beginner_source/examples_nn/polynomial_optim.py
+++ b/beginner_source/examples_nn/polynomial_optim.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 PyTorch: optim
 --------------

--- a/beginner_source/examples_tensor/polynomial_numpy.py
+++ b/beginner_source/examples_tensor/polynomial_numpy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Warm-up: numpy
 --------------

--- a/beginner_source/examples_tensor/polynomial_tensor.py
+++ b/beginner_source/examples_tensor/polynomial_tensor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 PyTorch: Tensors
 ----------------

--- a/beginner_source/fgsm_tutorial.py
+++ b/beginner_source/fgsm_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Adversarial Example Generation
 ==============================

--- a/beginner_source/flava_finetuning_tutorial.py
+++ b/beginner_source/flava_finetuning_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 TorchMultimodal Tutorial: Finetuning FLAVA
 ============================================

--- a/beginner_source/hybrid_frontend/learning_hybrid_frontend_through_example_tutorial.py
+++ b/beginner_source/hybrid_frontend/learning_hybrid_frontend_through_example_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Learning Hybrid Frontend Syntax Through Example
 ===============================================

--- a/beginner_source/hyperparameter_tuning_tutorial.py
+++ b/beginner_source/hyperparameter_tuning_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Hyperparameter tuning with Ray Tune
 ===================================

--- a/beginner_source/knowledge_distillation_tutorial.py
+++ b/beginner_source/knowledge_distillation_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Knowledge Distillation Tutorial
 ===============================

--- a/beginner_source/nlp/advanced_tutorial.py
+++ b/beginner_source/nlp/advanced_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Advanced: Making Dynamic Decisions and the Bi-LSTM CRF
 ======================================================

--- a/beginner_source/nlp/deep_learning_tutorial.py
+++ b/beginner_source/nlp/deep_learning_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Deep Learning with PyTorch
 **************************

--- a/beginner_source/nlp/pytorch_tutorial.py
+++ b/beginner_source/nlp/pytorch_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Introduction to PyTorch
 ***********************

--- a/beginner_source/nlp/sequence_models_tutorial.py
+++ b/beginner_source/nlp/sequence_models_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Sequence Models and Long Short-Term Memory Networks
 ===================================================

--- a/beginner_source/nlp/word_embeddings_tutorial.py
+++ b/beginner_source/nlp/word_embeddings_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 r"""
 Word Embeddings: Encoding Lexical Semantics
 ===========================================

--- a/beginner_source/nn_tutorial.py
+++ b/beginner_source/nn_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 What is `torch.nn` *really*?
 ============================

--- a/beginner_source/onnx/export_control_flow_model_to_onnx_tutorial.py
+++ b/beginner_source/onnx/export_control_flow_model_to_onnx_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 `Introduction to ONNX <intro_onnx.html>`_ ||
 `Exporting a PyTorch model to ONNX <export_simple_model_to_onnx_tutorial.html>`_ ||

--- a/beginner_source/onnx/export_simple_model_to_onnx_tutorial.py
+++ b/beginner_source/onnx/export_simple_model_to_onnx_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 `Introduction to ONNX <intro_onnx.html>`_ ||
 **Exporting a PyTorch model to ONNX** ||

--- a/beginner_source/onnx/onnx_registry_tutorial.py
+++ b/beginner_source/onnx/onnx_registry_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 `Introduction to ONNX <intro_onnx.html>`_ ||
 `Exporting a PyTorch model to ONNX <export_simple_model_to_onnx_tutorial.html>`_ ||

--- a/beginner_source/saving_loading_models.py
+++ b/beginner_source/saving_loading_models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Saving and Loading Models
 =========================

--- a/beginner_source/template_tutorial.py
+++ b/beginner_source/template_tutorial.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Template Tutorial
 =================

--- a/beginner_source/transfer_learning_tutorial.py
+++ b/beginner_source/transfer_learning_tutorial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Transfer Learning for Computer Vision Tutorial
 ==============================================


### PR DESCRIPTION
header "# -- coding: utf-8 --" is only needed for Python 2.x.

Since Python 3.x default encoding is utf-8 and coding header is not necessary.

this patch removes those headers not to confuse newcomers