### PR TITLE
fix broken URL

### DIFF
--- a/beginner_source/hyperparameter_tuning_tutorial.py
+++ b/beginner_source/hyperparameter_tuning_tutorial.py
@@ -184,7 +184,7 @@ class Net(nn.Module):
 #         inputs, labels = inputs.to(device), labels.to(device)
 #
 # The code now supports training on CPUs, on a single GPU, and on multiple GPUs. Notably, Ray
-# also supports `fractional GPUs <https://docs.ray.io/en/master/using-ray-with-gpus.html#fractional-gpus>`_
+# also supports `fractional GPUs <https://docs.ray.io/en/latest/ray-core/scheduling/accelerators.html#fractional-accelerators>`_
 # so we can share GPUs among trials, as long as the model still fits on the GPU memory. We'll come back
 # to that later.
 #


### PR DESCRIPTION
fix broken URL:
https://docs.ray.io/en/master/ray-core/using-ray-with-gpus.html#fractional-gpus ->
https://docs.ray.io/en/latest/ray-core/scheduling/accelerators.html#fractional-accelerators

based on the archived copy of the original link here: https://web.archive.org/web/20220313114338/https://docs.ray.io/en/master/ray-core/using-ray-with-gpus.html#fractional-gpus

it looks like the new link is referring to the same content

Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.


cc @svekars @sekyondaMeta @AlannaBurke