### PR TITLE
docs: Fix incorrect usage description of ctx.save_for_backward

### DIFF
--- a/beginner_source/examples_autograd/polynomial_custom_function.py
+++ b/beginner_source/examples_autograd/polynomial_custom_function.py
@@ -34,7 +34,7 @@ class LegendrePolynomial3(torch.autograd.Function):
         In the forward pass we receive a Tensor containing the input and return
         a Tensor containing the output. ctx is a context object that can be used
         to stash information for backward computation. You can cache tensors for
-        use in the backward pass using the ctx.save_for_backward method. Other
+        use in the backward pass using the ``ctx.save_for_backward`` method. Other
         objects can be stored directly as attributes on the ctx object, such as 
         ctx.my_object = my_object.
         """

--- a/beginner_source/examples_autograd/polynomial_custom_function.py
+++ b/beginner_source/examples_autograd/polynomial_custom_function.py
@@ -36,7 +36,7 @@ class LegendrePolynomial3(torch.autograd.Function):
         to stash information for backward computation. You can cache tensors for
         use in the backward pass using the ``ctx.save_for_backward`` method. Other
         objects can be stored directly as attributes on the ctx object, such as
-        ctx.my_object = my_object. Check out `Extending torch.autograd <https://docs.pytorch.org/docs/stable/notes/extending.html#extending-torch-autograd>`_
+        ``ctx.my_object = my_object``. Check out `Extending torch.autograd <https://docs.pytorch.org/docs/stable/notes/extending.html#extending-torch-autograd>`_
         for further details.
         """
         ctx.save_for_backward(input)

--- a/beginner_source/examples_autograd/polynomial_custom_function.py
+++ b/beginner_source/examples_autograd/polynomial_custom_function.py
@@ -35,8 +35,9 @@ class LegendrePolynomial3(torch.autograd.Function):
         a Tensor containing the output. ctx is a context object that can be used
         to stash information for backward computation. You can cache tensors for
         use in the backward pass using the ``ctx.save_for_backward`` method. Other
-        objects can be stored directly as attributes on the ctx object, such as 
-        ctx.my_object = my_object.
+        objects can be stored directly as attributes on the ctx object, such as
+        ctx.my_object = my_object. Check out `Extending torch.autograd <https://docs.pytorch.org/docs/stable/notes/extending.html#extending-torch-autograd>`_
+        for further details.
         """
         ctx.save_for_backward(input)
         return 0.5 * (5 * input ** 3 - 3 * input)

--- a/beginner_source/examples_autograd/polynomial_custom_function.py
+++ b/beginner_source/examples_autograd/polynomial_custom_function.py
@@ -33,8 +33,10 @@ class LegendrePolynomial3(torch.autograd.Function):
         """
         In the forward pass we receive a Tensor containing the input and return
         a Tensor containing the output. ctx is a context object that can be used
-        to stash information for backward computation. You can cache arbitrary
-        objects for use in the backward pass using the ctx.save_for_backward method.
+        to stash information for backward computation. You can cache tensors for
+        use in the backward pass using the ctx.save_for_backward method. Other
+        objects can be stored directly as attributes on the ctx object, such as 
+        ctx.my_object = my_object.
         """
         ctx.save_for_backward(input)
         return 0.5 * (5 * input ** 3 - 3 * input)


### PR DESCRIPTION
Fixes #2797

## Description
- This PR corrects the misleading explanation of `ctx.save_for_backward` in the `two_layer_net_custom_function.py` tutorial. The original text incorrectly stated that arbitrary objects can be cached using `ctx.save_for_backward`, whereas only tensors are supported.
- The updated docstring now accurately reflects PyTorch’s autograd API.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @albanD @jbschlosser