### PR TITLE
Add import os to example code block

### DIFF
--- a/intermediate_source/ddp_tutorial.rst
+++ b/intermediate_source/ddp_tutorial.rst
@@ -311,6 +311,7 @@ Let's still use the Toymodel example and create a file named ``elastic_ddp.py``.
 
 .. code:: python
 
+    import os
     import torch
     import torch.distributed as dist
     import torch.nn as nn


### PR DESCRIPTION
Fixes #3288

## Description
Added `import os` to the documentation since it was missing

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @wconstab @osalpekar @H-Huang @kwen2501