### PR TITLE
Add download instructions for pretrained model in dynamic quantization tutorial

### DIFF
--- a/advanced_source/dynamic_quantization_tutorial.py
+++ b/advanced_source/dynamic_quantization_tutorial.py
@@ -133,10 +133,6 @@ corpus = Corpus(model_data_filepath + 'wikitext-2')
 # 3. Load the pretrained model
 # -----------------------------
 #
-######################################################################
-# 3. Load the pretrained model
-# -----------------------------
-#
 # This is a tutorial on dynamic quantization, a quantization technique
 # that is applied after a model has been trained. Therefore, we'll simply
 # load some pretrained weights into this model architecture; these

--- a/advanced_source/dynamic_quantization_tutorial.py
+++ b/advanced_source/dynamic_quantization_tutorial.py
@@ -145,7 +145,7 @@ corpus = Corpus(model_data_filepath + 'wikitext-2')
 #
 # **Note:** Before running this tutorial, download the required pretrained model:
 #
-# .. code::
+# .. code-block:: bash
 #
 #     wget https://s3.amazonaws.com/pytorch-tutorial-assets/word_language_model_quantize.pth
 #

--- a/advanced_source/dynamic_quantization_tutorial.py
+++ b/advanced_source/dynamic_quantization_tutorial.py
@@ -133,11 +133,23 @@ corpus = Corpus(model_data_filepath + 'wikitext-2')
 # 3. Load the pretrained model
 # -----------------------------
 #
+######################################################################
+# 3. Load the pretrained model
+# -----------------------------
+#
 # This is a tutorial on dynamic quantization, a quantization technique
-# that is applied after a model has been trained. Therefore, we'll simply load some
-# pretrained weights into this model architecture; these weights were obtained
-# by training for five epochs using the default settings in the word language model
-# example.
+# that is applied after a model has been trained. Therefore, we'll simply
+# load some pretrained weights into this model architecture; these
+# weights were obtained by training for five epochs using the default
+# settings in the word language model example.
+#
+# **Note:** Before running this tutorial, download the required pretrained model:
+#
+# .. code::
+#
+#     wget https://s3.amazonaws.com/pytorch-tutorial-assets/word_language_model_quantize.pth
+#
+# Place the downloaded file in the data directory or update the model_data_filepath accordingly.
 
 ntokens = len(corpus.dictionary)
 

--- a/advanced_source/dynamic_quantization_tutorial.py
+++ b/advanced_source/dynamic_quantization_tutorial.py
@@ -139,7 +139,7 @@ corpus = Corpus(model_data_filepath + 'wikitext-2')
 # weights were obtained by training for five epochs using the default
 # settings in the word language model example.
 #
-# **Note:** Before running this tutorial, download the required pretrained model:
+# Before running this tutorial, download the required pre-trained model:
 #
 # .. code-block:: bash
 #


### PR DESCRIPTION
Fixes #3254
- Added wget command to download word_language_model_quantize.pth
- Included note about file placement  
- Improved tutorial usability by providing missing download information
- Referenced official Makefile download method

## Description
This PR addresses issue #3254 by adding clear download instructions for the pretrained model file `word_language_model_quantize.pth` required by the dynamic quantization tutorial. The tutorial previously assumed users already had the model file without explaining where to download it.

The fix adds a clear note with a wget command using the same trusted URL found in the repository's Makefile (lines 65-66: https://github.com/pytorch/tutorials/blob/main/Makefile#L65), along with guidance on file placement. This ensures users get the same reliable download method that the official build system uses.

## Checklist
- [x] The issue that is being fixed is referred in the description (see above "Fixes #3254")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.