### PR TITLE
Update hyper params and set seeds

### DIFF
--- a/intermediate_source/reinforcement_q_learning.py
+++ b/intermediate_source/reinforcement_q_learning.py
@@ -91,6 +91,16 @@ device = torch.device(
     "cpu"
 )
 
+# set the seeds for reproducibility
+seed = 42
+random.seed(seed)
+torch.manual_seed(seed)
+env.reset(seed=seed)
+env.action_space.seed(seed)
+env.observation_space.seed(seed)
+if torch.cuda.is_available(): 
+    torch.cuda.manual_seed(seed)
+
 
 ######################################################################
 # Replay Memory
@@ -253,13 +263,14 @@ class DQN(nn.Module):
 # EPS_DECAY controls the rate of exponential decay of epsilon, higher means a slower decay
 # TAU is the update rate of the target network
 # LR is the learning rate of the ``AdamW`` optimizer
+
 BATCH_SIZE = 128
 GAMMA = 0.99
-EPS_START = 0.9
-EPS_END = 0.05
-EPS_DECAY = 1000
+EPS_START = 1
+EPS_END = 0.01
+EPS_DECAY = 2500
 TAU = 0.005
-LR = 1e-4
+LR = 5e-4
 
 # Get number of actions from gym action space
 n_actions = env.action_space.n


### PR DESCRIPTION
Fixes #3080 

## Description
- This PR updates the hyper parameters for the `CartPole-v1` environment in the DQN tutorial to better match the results shown in the reference image (only the tutorial file is modified).
- A fixed seed has been added to ensure reproducibility of training behavior and evaluation outcomes.


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #3080")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
