### PR TITLE
Fix broken deployment link in Flask REST API tutorial

### DIFF
--- a/intermediate_source/flask_rest_api_tutorial.py
+++ b/intermediate_source/flask_rest_api_tutorial.py
@@ -321,9 +321,9 @@ with open("../_static/img/sample_file.jpeg", 'rb') as f:
 #   for deploying a Flask server in production.
 #
 # - You can also add a UI by creating a page with a form which takes the image and
-#   displays the prediction. Check out the `demo <https://pytorch-imagenet.herokuapp.com/>`_
-#   of a similar project and its `source code <https://github.com/avinassh/pytorch-flask-api-heroku>`_.
-#
+#   displays the prediction. You can deploy your own demo using this 
+#   `Heroku template <https://dashboard.heroku.com/new?template=https%3A%2F%2Fgithub.com%2Favinassh%2Fpytorch-flask-api-heroku>`_
+#   or check out the `source code <https://github.com/avinassh/pytorch-flask-api-heroku>`_.
 # - In this tutorial, we only showed how to build a service that could return predictions for
 #   a single image at a time. We could modify our service to be able to return predictions for
 #   multiple images at once. In addition, the `service-streamer <https://github.com/ShannonAI/service-streamer>`_


### PR DESCRIPTION
Fixes #3044

## Description
Fixed the broken example deployment link in the "Deploying PyTorch in Python via a REST API with Flask" tutorial. The previous link was no longer accessible, so I updated it with a working Heroku template URL according to suggestions from @harshaljanjani

## Checklist
- [x] The issue that is being fixed is referred in the description (see above "Fixes #3044")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.