### PR TITLE
Fix typo in the model parameters doc section in Update buildmodel_tutorial.py

### DIFF
--- a/beginner_source/basics/buildmodel_tutorial.py
+++ b/beginner_source/basics/buildmodel_tutorial.py
@@ -182,7 +182,7 @@ pred_probab = softmax(logits)
 print(f"Model structure: {model}\n\n")
 
 for name, param in model.named_parameters():
-    print(f"Layer: {name} | Size: {param.size()} | Values : {param[:2]} \n")
+    print(f"Layer: {name} | Size: {param.size()} | Values: {param[:2]} \n")
 
 ######################################################################
 # --------------


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

## Description
The PR fixes typo in the model parameters section in Update buildmodel_tutorial.py

## Checklist
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
