### PR TITLE
(manually) update zero gradients after updating the weights

### DIFF
--- a/beginner_source/examples_autograd/polynomial_autograd.py
+++ b/beginner_source/examples_autograd/polynomial_autograd.py
@@ -67,9 +67,10 @@ for t in range(2000):
         d -= learning_rate * d.grad
 
         # Manually zero the gradients after updating weights
-        a.grad = None
-        b.grad = None
-        c.grad = None
-        d.grad = None
+        #a.grad = None
+        #b.grad = None
+        #c.grad = None
+        #d.grad = None
+        a.grad, b.grad, c.grad, d.grad = 0. , 0. , 0. , 0.
 
 print(f'Result: y = {a.item()} + {b.item()} x + {c.item()} x^2 + {d.item()} x^3')


### PR DESCRIPTION
Fixes #ISSUE_NUMBER : PyTorch Docathon H1 2025 #153952

file location: https://github.com/pytorch/tutorials/blob/main/beginner_source/examples_autograd/polynomial_autograd.py

## Description
<!--- Describe your changes in detail -->
Previous version:
a.grad, b.grad, c.grad, d.grad = None, None, None, None

Proposed version:
Deletion on that code snippet or at least put a comment on that code snippet. It eventually runs successfully with verified numerical outputs.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
