### PR TITLE
Manually zero the gradients after updating weights by using machine e…

### DIFF
--- a/beginner_source/examples_autograd/polynomial_custom_function.py
+++ b/beginner_source/examples_autograd/polynomial_custom_function.py
@@ -98,9 +98,12 @@ for t in range(2000):
         d -= learning_rate * d.grad
 
         # Manually zero the gradients after updating weights
-        a.grad = None
-        b.grad = None
-        c.grad = None
-        d.grad = None
+        # by using machine epsilon for standard float (64-bit)
+        import sys
+        
+        a.grad = loss*sys.float_info.epsilon
+        b.grad = loss*sys.float_info.epsilon
+        c.grad = loss*sys.float_info.epsilon
+        d.grad = loss*sys.float_info.epsilon
 
 print(f'Result: y = {a.item()} + {b.item()} * P3({c.item()} + {d.item()} x)')


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->
      Manually zero the gradients after updating weights 
      by using machine epsilon for standard float(64-bit).


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
