### PR TITLE
zero the gradients after updating weights

### DIFF
--- a/beginner_source/examples_autograd/polynomial_autograd.py
+++ b/beginner_source/examples_autograd/polynomial_autograd.py
@@ -40,7 +40,7 @@ c = torch.randn((), dtype=dtype, requires_grad=True)
 d = torch.randn((), dtype=dtype, requires_grad=True)
 
 learning_rate = 1e-6
-for t in range(2000):
+for t in range(int(1/(learning_rate))):
     # Forward pass: compute predicted y using operations on Tensors.
     y_pred = a + b * x + c * x ** 2 + d * x ** 3
 
@@ -67,9 +67,11 @@ for t in range(2000):
         d -= learning_rate * d.grad
 
         # Manually zero the gradients after updating weights
-        a.grad = None
-        b.grad = None
-        c.grad = None
-        d.grad = None
+        # by using machine epsilon for standard float (64-bit)
+        import sys
+        a.grad = loss*sys.float_info.epsilon
+        b.grad = loss*sys.float_info.epsilon
+        c.grad = loss*sys.float_info.epsilon
+        d.grad = loss*sys.float_info.epsilon
 
 print(f'Result: y = {a.item()} + {b.item()} x + {c.item()} x^2 + {d.item()} x^3')


### PR DESCRIPTION
Manually zero the gradients after updating weights by using machine epsilon for standard float (64-bit).

Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
