### PR TITLE
[CI] Upgrade sphinx-gallery 0.11.1 -> 0.17.1

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -2,7 +2,7 @@
 # Refer to ./jenkins/build.sh for tutorial build instructions
 
 sphinx==5.3.0
-sphinx-gallery==0.11.1
+sphinx-gallery==0.17.1
 sphinx-reredirects==0.1.4
 sphinx-design==0.4.0
 docutils==0.16
@@ -31,7 +31,8 @@ pytorch-lightning
 torchx
 torchrl==0.7.2
 tensordict==0.7.2
-ax-platform>=0.4.0
+# For ax_multiobjective_nas_tutorial.py
+ax-platform>=0.4.0,<0.5.0
 nbformat>=5.9.2
 datasets
 transformers

--- a/custom_directives.py
+++ b/custom_directives.py
@@ -88,7 +88,8 @@ class GalleryItemDirective(Directive):
             if 'intro' in self.options:
                 intro = self.options['intro'][:195] + '...'
             else:
-                _, blocks = sphinx_gallery.gen_rst.split_code_and_text_blocks(abs_fname)
+                block_parser = sphinx_gallery.gen_rst.BlockParser(abs_fname, {"filetype_parsers": {}})
+                _, blocks, _ = block_parser.split_code_and_text_blocks(abs_fname)
                 intro, _ = sphinx_gallery.gen_rst.extract_intro_and_title(abs_fname, blocks[0][1])
 
             thumbnail_rst = ''


### PR DESCRIPTION
The isolated subprocess build was preventing errors from surfacing, but upgrading to 0.17.1 (which has its own parallelization with joblib) makes it surface correctly

I only found 1 failure which was `ax_multiobjective_nas_tutorial` and it was because the `ax-platform` package got a new version that removed something it was using, so I pinned that too

We are also using `split_code_and_text_blocks`, which got moved somewhere else, so I changed that too, hopefully it is correct

Testing: on a different PR, I raised runtimeerror in one of the tutorials and saw that the error was surfaced