### PR TITLE
[CI] Upgrade ca-certificates in build.sh

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -16,6 +16,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 sudo apt-get update
 sudo apt-get install -y pandoc
 
+# Upgrade ca-certificates to avoid SSL errors
+sudo apt-get upgrade -y ca-certificates
+
 # NS: Path to python runtime should already be part of docker container
 # export PATH=/opt/conda/bin:$PATH
 


### PR DESCRIPTION
I am seeing failures like 
```
    urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1007)>

```

https://github.com/pytorch/tutorials/actions/runs/16330370250/job/46131197559#step:9:6283

Chatgpt says to update the certificates

ca-certificates is installed in the docker container, but the docker container might be old, so do it in build.sh too