### PR TITLE
Update index.rst - missing cheatsheet?

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -769,7 +769,7 @@ Additional Resources
 .. customcalloutitem::
    :header: PyTorch Cheat Sheet
    :description: Quick overview to essential PyTorch elements.
-   :button_link: beginner/ptcheat.html
+   :button_link: https://www.mad.tf.fau.de/files/2019/07/pytorch-cheatsheet-en.pdf
    :button_text: Open
 
 .. customcalloutitem::


### PR DESCRIPTION
This commit is less to suggest the linked cheatsheet but instead to point out there is no ptcheat.html in the repo and wasn't sure if there was a suggested one already.

I checked in these repos for "cheat" and nothing came up: Pytorch, examples, tutorials, torchrec.

Fixes #ISSUE_NUMBER

## Description
linked to another cheatsheet

## Checklist
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
