### PR TITLE
Remove pytorch checklist and link to github

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -767,18 +767,6 @@ Additional Resources
    :button_text: Check Out Examples
 
 .. customcalloutitem::
-   :header: PyTorch Cheat Sheet
-   :description: Quick overview to essential PyTorch elements.
-   :button_link: beginner/ptcheat.html
-   :button_text: Open
-
-.. customcalloutitem::
-   :header: Tutorials on GitHub
-   :description: Access PyTorch Tutorials from GitHub.
-   :button_link: https://github.com/pytorch/tutorials
-   :button_text: Go To GitHub
-
-.. customcalloutitem::
    :header: Run Tutorials on Google Colab
    :description: Learn how to copy tutorial data into Google Drive so that you can run tutorials on Google Colab.
    :button_link: beginner/colab.html


### PR DESCRIPTION
- ptcheat doesn't exist anymore
- we have a button that goes to github so don't really need it.

