### PR TITLE
Update links to recipes_index

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -24,7 +24,7 @@ Welcome to PyTorch Tutorials
 .. customcalloutitem::
    :description: Bite-size, ready-to-deploy PyTorch code examples.
    :header: PyTorch Recipes
-   :button_link: recipes/recipes_index.html
+   :button_link: recipes_index.html
    :button_text: Explore Recipes
 
 .. End of callout item section

--- a/recipes_source/README.txt
+++ b/recipes_source/README.txt
@@ -2,6 +2,6 @@ Recipes
 ------------------
 1. recipes/* and recipes_index.rst
 	   PyTorch Recipes
-	   https://pytorch.org/tutorials/recipes/recipes_index.html
+	   https://pytorch.org/tutorials/recipes_index.html
 	   
 


### PR DESCRIPTION
https://docs.pytorch.org/tutorials/recipes/recipes_index.html  is broken.

This PR replaces the old bad link with https://docs.pytorch.org/tutorials/recipes_index.html 
