### PR TITLE
 Fix: Align forward and backward arguments in cpp_extension tutorial

### DIFF
--- a/advanced_source/cpp_extension.rst
+++ b/advanced_source/cpp_extension.rst
@@ -1147,7 +1147,7 @@ on it:
     auto d_old_h = d_X.slice(/*dim=*/1, 0, state_size);
     auto d_input = d_X.slice(/*dim=*/1, state_size);
 
-    return {d_old_h, d_input, d_weights, d_bias, d_old_cell, d_gates};
+    return {d_old_h, d_input, d_weights, d_bias, d_old_cell};
   }
 
 


### PR DESCRIPTION
This PR fixes a bug in the `lltm_cuda_kernel.cu` example by aligning the return values of the `lltm_cuda_backward` function with the Python backward interface.

In `cpp_extension.rst` line 1150:

```cpp
return {d_old_h, d_input, d_weights, d_bias, d_old_cell, d_gates};
```

the original `lltm_cuda_backward` function returned six values.

However, the corresponding Python backward interface(line 470) only expects five values to be returned, as it corresponds to the number of input tensors to the forward function:

```python
d_old_h, d_input, d_weights, d_bias, d_old_cell = outputs
```

This mismatch causes the example to fail at runtime.

This change corrects the `lltm_cuda_backward` function to return only the five required gradient tensors, bringing it into alignment with the Python side. The `d_gates` tensor is no longer returned, as its gradient is not needed by the caller.

**Before this change:** The example code would throw `ValueError: too many values to unpack (expected 5)`.

**After this change:** The example will run successfully, providing a correct and functional demonstration of a custom CUDA extension.