### PR TITLE
docs: add fallback for torch.compile in torch_logs tutorial (#137285)

### DIFF
--- a/recipes_source/torch_logs.py
+++ b/recipes_source/torch_logs.py
@@ -32,17 +32,22 @@ import logging
 
 import torch
 
-# exit cleanly if we are on a device that doesn't support torch.compile
-if torch.cuda.get_device_capability() < (7, 0):
-    print("Skipping because torch.compile is not supported on this device.")
-else:
-    @torch.compile()
+# Use torch.compile if supported, fallback to eager mode otherwise
+try:
+    @torch.compile
+    def fn(x, y):
+        z = x + y
+        return z + 2
+        
+    inputs = (torch.ones(2, 2, device="cuda"), torch.zeros(2, 2, device="cuda"))
+except (RuntimeError, AssertionError):
+    print("⚠️  torch.compile is not supported on this system. Falling back to eager mode.")
+
     def fn(x, y):
         z = x + y
         return z + 2
 
-
-    inputs = (torch.ones(2, 2, device="cuda"), torch.zeros(2, 2, device="cuda"))
+    inputs = (torch.ones(2, 2), torch.zeros(2, 2))
 
 
 # print separator and reset dynamo


### PR DESCRIPTION
This PR addresses [issue #137285](https://github.com/pytorch/tutorials/issues/137285), where the torch_logs tutorial would skip execution entirely on unsupported devices (e.g., CPUs or older GPUs). 

Changes:
- Wraps `@torch.compile` usage in a `try-except` block
- Adds a CPU fallback using eager execution
- Preserves the original structure and logging demonstrations

This ensures the tutorial runs meaningfully across a broader range of environments without significant restructuring.

cc @PaliC @ezyang @bdhirsh

