### PR TITLE
Remove JIT tracing section in onnx tutorial

### DIFF
--- a/beginner_source/onnx/export_control_flow_model_to_onnx_tutorial.py
+++ b/beginner_source/onnx/export_control_flow_model_to_onnx_tutorial.py
@@ -96,19 +96,6 @@ try:
 except Exception as e:
     print(e)
 
-###############################################################################
-# Using :func:`torch.onnx.export` with JIT Tracing
-# ----------------------------------------
-#
-# When exporting the model using :func:`torch.onnx.export` with the dynamo=True
-# argument, the exporter defaults to using JIT tracing. This fallback allows
-# the model to export, but the resulting ONNX graph may not faithfully represent
-# the original model logic due to the limitations of tracing.
-
-
-onnx_program = torch.onnx.export(model, (x,), dynamo=True) 
-print(onnx_program.model)
-
 
 ###############################################################################
 # Suggested Patch: Refactoring with :func:`torch.cond`


### PR DESCRIPTION
## Description
The JIT strategy was removed and is thus no longer usable. Removing the section.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.

Fixes https://github.com/pytorch/tutorials/issues/3563

cc @titaiwangms @xadupre