### PR TITLE
Remove unnecessary character from beginner's autograd example

### DIFF
--- a/beginner_source/examples_autograd/polynomial_autograd.py
+++ b/beginner_source/examples_autograd/polynomial_autograd.py
@@ -1,4 +1,4 @@
-r"""
+"""
 PyTorch: Tensors and autograd
 -------------------------------
 


### PR DESCRIPTION
## Description
In the "Learning PyTorch with Examples" tutorial, the autograd code block started with `rimport`. This PR fixed the typo by removing `r`.

