### PR TITLE
Correct typo in example code

### DIFF
--- a/beginner_source/examples_autograd/polynomial_autograd.py
+++ b/beginner_source/examples_autograd/polynomial_autograd.py
@@ -1,4 +1,4 @@
-r"""
+"""
 PyTorch: Tensors and autograd
 -------------------------------
 


### PR DESCRIPTION
Fixes None

## Description
<!--- Describe your changes in detail -->
https://docs.pytorch.org/tutorials/beginner/pytorch_with_examples.html#autograd
<img width="972" height="848" alt="image" src="https://github.com/user-attachments/assets/2fea4d63-39a6-40d7-9905-ecb2cf3f0c37" />


similar to https://github.com/pytorch/tutorials/pull/1744

## Checklist
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
