### PR TITLE
Fixup typo add required newline

### DIFF
--- a/intermediate_source/pipelining_tutorial.rst
+++ b/intermediate_source/pipelining_tutorial.rst
@@ -145,6 +145,7 @@ we are splitting before the before 4th transformer decoder layer, mirroring the 
 we can retrieve a ``PipelineStage`` by calling ``build_stage`` after this splitting is done.
 
 .. code:: python
+
    def tracer_model_split(model, example_input_microbatch) -> PipelineStage:
       pipe = pipeline(
          module=model,


### PR DESCRIPTION
## Description

The code block following the added newline is not rendering in the GitHub preview nor the tutorials website at [here](https://docs.pytorch.org/tutorials/intermediate/pipelining_tutorial.html#:~:text=The%20second%20method,splitting%20is%20done.). Adding the newline would make it render/showup in the GitHub preview and probably (not tested) in the tutorials website.

## Checklist
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @svekars @sekyondaMeta @AlannaBurke