### PR TITLE
Change train/test split ratio from 80/20 to 85/15

### DIFF
--- a/intermediate_source/char_rnn_classification_tutorial.py
+++ b/intermediate_source/char_rnn_classification_tutorial.py
@@ -205,7 +205,7 @@ print(f"loaded {len(alldata)} items of data")
 print(f"example = {alldata[0]}")
 
 #########################
-#Using the dataset object allows us to easily split the data into train and test sets. Here we create a 80/20
+#Using the dataset object allows us to easily split the data into train and test sets. Here we create a 85/15
 # split but the ``torch.utils.data`` has more useful utilities. Here we specify a generator since we need to use the
 #same device as PyTorch defaults to above.
 


### PR DESCRIPTION
Typo in text

I skipped the standard process because this change is so small. I do believe it's still meaningful, as a typo in a tutorial can confuse and / or dissuade learners.

Happy to go through full testing procedure if required, but that will take more time.

Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
