### PR TITLE
Fix plt.show() display issue in data_tutorial.py

### DIFF
--- a/beginner_source/basics/data_tutorial.py
+++ b/beginner_source/basics/data_tutorial.py
@@ -234,6 +234,7 @@ print(f"Labels batch shape: {train_labels.size()}")
 img = train_features[0].squeeze()
 label = train_labels[0]
 plt.imshow(img, cmap="gray")
+plt.axis("off")
 plt.show()
 print(f"Label: {label}")
 


### PR DESCRIPTION
Add plt.axis('off') before plt.show() to ensure the plot displays correctly in environments like Windows 11 with WSL and PyCharm Pro. This is a known matplotlib issue where an explicit axis operation is needed to trigger the display properly.

The axis('off') call also improves the visualization by hiding the axis ticks and labels, making the image cleaner.

Fixes #3497

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
