### PR TITLE
Fix gallery pattern regex?

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -263,8 +263,9 @@ if os.getenv("GALLERY_PATTERN"):
     # ignore_pattern also skips parsing.
     # See https://github.com/sphinx-gallery/sphinx-gallery/issues/721
     # for a more detailed description of the issue.
+    # GALLERY_PATTERN should be a regular expression.
     sphinx_gallery_conf["ignore_pattern"] = (
-        r"/(?!" + re.escape(os.getenv("GALLERY_PATTERN")) + r")[^/]+$"
+        r"^(?!.*" + os.getenv("GALLERY_PATTERN") + r")"
     )
 
 for i in range(len(sphinx_gallery_conf["examples_dirs"])):


### PR DESCRIPTION
Regex was generated by chatgpt, I haven't figured out lookaheads/behinds yet


also briefly checked with hyperparameter tuning tutorial (didn't run the entire thing so idk about the rest of the tutorial generation but I did check that it probably didn't run anything else)

shangdi reported the old pattern wasn't working, but this one seems to
