### PR TITLE
Add warning about inactive NJT development to related tutorials

### DIFF
--- a/intermediate_source/transformer_building_blocks.py
+++ b/intermediate_source/transformer_building_blocks.py
@@ -79,6 +79,10 @@ contains a `gym of masks <https://github.com/meta-pytorch/attention-gym>`_.
 # sequence lengths. They eliminate the need for the bug-prone practices of explicit
 # padding and masking (think ``key_padding_mask`` in ``nn.MultiHeadAttention``).
 #
+# ```{warning}
+# Nested tensors are not currently under active development. Use at your own risk.
+# ```
+#
 # * `scaled_dot_product_attention <https://pytorch.org/tutorials/intermediate/scaled_dot_product_attention_tutorial.html>`_
 #
 # ``scaled_dot_product_attention`` is a primitive for

--- a/unstable_source/nestedtensor.py
+++ b/unstable_source/nestedtensor.py
@@ -3,6 +3,8 @@
 Getting Started with Nested Tensors
 ===============================================================
 
+**Warning: Nested tensors are not currently under active development. Use at your own risk.**
+
 Nested tensors generalize the shape of regular dense tensors, allowing for representation
 of ragged-sized data.
 
@@ -21,8 +23,6 @@ for operating on sequential data of varying lengths with a real-world example. I
 they are invaluable for building transformers that can efficiently operate on ragged sequential
 inputs. Below, we present an implementation of multi-head attention using nested tensors that,
 combined usage of ``torch.compile``, out-performs operating naively on tensors with padding.
-
-Nested tensors are currently a prototype feature and are subject to change.
 """
 
 import numpy as np


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #3724

Context: https://github.com/pytorch/pytorch/issues/112398#issuecomment-3745637813