### PR TITLE
Use reusable Claude Code workflow from test-infra

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -6,15 +6,14 @@ on:
   issues:
     types: [opened]
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
-
 jobs:
   claude-code:
     uses: pytorch/test-infra/.github/workflows/_claude-code.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
     secrets: inherit
     with:
       setup_script: |


### PR DESCRIPTION
## Summary
Replaces the inline Claude Code workflow with the centralized reusable workflow from `pytorch/test-infra`.

### What changes
- Drops the hardcoded pilot user allowlist (20 users) in favor of `author_association` checks + API-level write access verification
- Removes `pull_request_review_comment` trigger (security fix, per pytorch/pytorch#176652)
- Passes lintrunner install via `setup_script` input (preserving the existing setup)

### What stays the same
- Same security model (org gate, write access check, bot allowlist)
- Same lintrunner setup (`pip install lintrunner==0.12.5 && lintrunner init`)
- Same model, settings, and usage metrics upload

Depends on https://github.com/pytorch/test-infra/pull/7810 which added the reusable workflow.

## Test plan
- [x] Reusable workflow tested end-to-end on pytorch/ciforge
- [ ] Verify `@claude` triggers correctly after merge