### PR TITLE
Fix invalid escape sequence in saving_loading_models tutorial

### DIFF
--- a/beginner_source/saving_loading_models.py
+++ b/beginner_source/saving_loading_models.py
@@ -18,7 +18,7 @@ functions to be familiar with:
    objects can be saved using this function.
 
 2) `torch.load <https://pytorch.org/docs/stable/torch.html?highlight=torch%20load#torch.load>`__:
-   Uses `pickle <https://docs.python.org/3/library/pickle.html>`__\ ’s
+   Uses `pickle <https://docs.python.org/3/library/pickle.html>`__ 's
    unpickling facilities to deserialize pickled object files to memory.
    This function also facilitates the device to load the data into (see
    `Saving & Loading Model Across


### PR DESCRIPTION
Fixes #3790

While running `saving_loading_models.py`, Python raised a SyntaxWarning due to an invalid escape sequence in the documentation string

this PR removes the unnecessary escape character to avoid the warning in newer Python versions. The change does not affect the tutorial functionality

Fixes #ISSUE_NUMBER

## Description
<!--- Describe your changes in detail -->

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
