### PR TITLE
Test Mosaic Tutorial Post 2.11

### DIFF
--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -39,7 +39,7 @@ NOT_RUN = [
     "intermediate_source/tensorboard_profiler_tutorial", # reenable after 2.0 release.
     "advanced_source/semi_structured_sparse", # reenable after 3303 is fixed.
     "intermediate_source/torchrec_intro_tutorial.py", #failing with 2.8 reenable after 3498
-    "beginner_source/mosaic_memory_profiling_tutorial.py",  # failing with 2.11 issue #3774
+    #"beginner_source/mosaic_memory_profiling_tutorial.py",  # failing with 2.11 issue #3774
 ]
 
 def tutorial_source_dirs() -> List[Path]:

--- a/.jenkins/validate_tutorials_built.py
+++ b/.jenkins/validate_tutorials_built.py
@@ -39,7 +39,7 @@ NOT_RUN = [
     "intermediate_source/tensorboard_profiler_tutorial", # reenable after 2.0 release.
     "advanced_source/semi_structured_sparse", # reenable after 3303 is fixed.
     "intermediate_source/torchrec_intro_tutorial.py", #failing with 2.8 reenable after 3498
-    #"beginner_source/mosaic_memory_profiling_tutorial.py",  # failing with 2.11 issue #3774
+    #"beginner_source/mosaic_memory_profiling_tutorial.py",  # failing with 2.11 RC issue #3774
 ]
 
 def tutorial_source_dirs() -> List[Path]:

--- a/beginner_source/mosaic_memory_profiling_tutorial.py
+++ b/beginner_source/mosaic_memory_profiling_tutorial.py
@@ -306,7 +306,13 @@ def run_training_ac(
 
     # Load model
     print(f"Loading GPT-2 (activation_checkpointing={activation_checkpointing})...")
-    model = GPT2LMHeadModel.from_pretrained("gpt2")
+    # Disable dropout to avoid PyTorch 2.11 checkpoint recomputation bug (#3774).
+    # _VF.dropout returns NULL without setting an exception during backward
+    # recomputation of GPT2Block. Dropout is irrelevant to memory profiling.
+    # Original: model = GPT2LMHeadModel.from_pretrained("gpt2")
+    model = GPT2LMHeadModel.from_pretrained(
+        "gpt2", resid_pdrop=0, attn_pdrop=0, embd_pdrop=0
+    )
 
     if activation_checkpointing:
         model.gradient_checkpointing_enable()

--- a/beginner_source/mosaic_memory_profiling_tutorial.py
+++ b/beginner_source/mosaic_memory_profiling_tutorial.py
@@ -309,9 +309,7 @@ def run_training_ac(
     model = GPT2LMHeadModel.from_pretrained("gpt2")
 
     if activation_checkpointing:
-        model.gradient_checkpointing_enable(
-            gradient_checkpointing_kwargs={"use_reentrant": False}
-        )
+        model.gradient_checkpointing_enable()
         print("Activation checkpointing is ENABLED")
     else:
         print("Activation checkpointing is DISABLED")

--- a/beginner_source/mosaic_memory_profiling_tutorial.py
+++ b/beginner_source/mosaic_memory_profiling_tutorial.py
@@ -309,7 +309,9 @@ def run_training_ac(
     model = GPT2LMHeadModel.from_pretrained("gpt2")
 
     if activation_checkpointing:
-        model.gradient_checkpointing_enable()
+        model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs={"use_reentrant": False}
+        )
         print("Activation checkpointing is ENABLED")
     else:
         print("Activation checkpointing is DISABLED")


### PR DESCRIPTION
Test mosaic tutorial post 2.11 release

Disabled GPT-2 dropout (resid_pdrop=0, attn_pdrop=0, embd_pdrop=0) in run_training_ac() to work around a PyTorch 2.11 bug where the CUDA dropout kernel crashes during gradient checkpointing recomputation (#3774). Dropout has no impact on this tutorial's purpose of memory profiling with Mosaic.




cc @basilwong