### PR TITLE
Fix Monarch tutorial links

### DIFF
--- a/intermediate_source/monarch_distributed_tutorial.rst
+++ b/intermediate_source/monarch_distributed_tutorial.rst
@@ -22,7 +22,7 @@ Monarch is an actor framework designed to streamline the development of distribu
 - **Flexible resource management**: Support for multiple cluster schedulers including SLURM, Kubernetes, custom host management, and local processes
 - **Integrated monitoring**: Stream logs from remote processes back to your client for easy debugging and aggregation
 
-For more details, see the `Monarch documentation <https://meta-pytorch.org/monarch/generated/examples/getting_started.html>`_.
+For more details, see the `Monarch documentation <https://meta-pytorch.org/monarch/v0.4.0/generated/examples/getting_started.html>`_.
 
 Why Use Monarch?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -224,7 +224,7 @@ but here is some pseudocode with common usages:
         pass
 
 Remote actor endpoints can also utilize Python native breakpoints, enabling interactive debugging sessions.
-For a complete deep-dive into Monarch debuggers, please `refer to the documentation <https://meta-pytorch.org/monarch/generated/examples/debugging.html>`_.
+For a complete deep-dive into Monarch debuggers, please `refer to the documentation <https://meta-pytorch.org/monarch/v0.4.0/generated/examples/debugging.html>`_.
 
 .. code-block:: python
 

--- a/intermediate_source/monarch_distributed_tutorial.rst
+++ b/intermediate_source/monarch_distributed_tutorial.rst
@@ -22,7 +22,7 @@ Monarch is an actor framework designed to streamline the development of distribu
 - **Flexible resource management**: Support for multiple cluster schedulers including SLURM, Kubernetes, custom host management, and local processes
 - **Integrated monitoring**: Stream logs from remote processes back to your client for easy debugging and aggregation
 
-For more details, see the `Monarch documentation <https://meta-pytorch.org/monarch/v0.4.0/generated/examples/getting_started.html>`_.
+For more details, see the `Monarch documentation <https://meta-pytorch.org/monarch/stable/generated/examples/getting_started.html>`_.
 
 Why Use Monarch?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -224,7 +224,7 @@ but here is some pseudocode with common usages:
         pass
 
 Remote actor endpoints can also utilize Python native breakpoints, enabling interactive debugging sessions.
-For a complete deep-dive into Monarch debuggers, please `refer to the documentation <https://meta-pytorch.org/monarch/v0.4.0/generated/examples/debugging.html>`_.
+For a complete deep-dive into Monarch debuggers, please `refer to the documentation <https://meta-pytorch.org/monarch/stable/generated/examples/debugging.html>`_.
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixes #3811 

## Description
Fixed two broken links in the Monarch tutorial: `intermediate_source/monarch_distributed_tutorial.rst`.

On Mar 31, 2026, the Monarch documentation migrated to a multi-version structure (see Monarch PRs #3328, #3333). This removed the root-level `/generated/` paths, causing the original links in the tutorial to 404.

I have updated the links to the latest stable version v0.4.0, which I have verified to work now. 
I checked for a `/stable/` or `/latest/` alias, but the upstream repo hasn't implemented these redirects yet; I will communicate with the Monarch maintainers and update accordingly once those aliases become available. 

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.