### PR TITLE
Updated deprecated use_cuda profiler argument to use_device

### DIFF
--- a/beginner_source/introyt/autogradyt_tutorial.py
+++ b/beginner_source/introyt/autogradyt_tutorial.py
@@ -473,16 +473,14 @@ print(y)
 # 
 
 device = torch.device('cpu')
-run_on_gpu = False
 if torch.cuda.is_available():
     device = torch.device('cuda')
-    run_on_gpu = True
-    
+
 x = torch.randn(2, 3, requires_grad=True)
 y = torch.rand(2, 3, requires_grad=True)
 z = torch.ones(2, 3, requires_grad=True)
 
-with torch.autograd.profiler.profile(use_cuda=run_on_gpu) as prf:
+with torch.autograd.profiler.profile(use_device=device.type) as prf:
     for _ in range(1000):
         z = (z / x) * y
         


### PR DESCRIPTION
Fixes #3816

## Description
Original tutorial used the to-be deprecated `use_cuda` argument in `torch.autograd.profiler.profile`. This PR updates to the `use_device` argument, setting it to `device.type` (either "cpu" or "cuda") to preserve existing behaviour.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
