### PR TITLE
Fix Transforms tutorial: unify target_transform and ToTensor prose

### DIFF
--- a/beginner_source/basics/transforms_tutorial.py
+++ b/beginner_source/basics/transforms_tutorial.py
@@ -30,12 +30,18 @@ import torch
 from torchvision import datasets
 from torchvision.transforms import ToTensor, Lambda
 
+target_transform = Lambda(
+    lambda y: torch.zeros(10, dtype=torch.float32).scatter_(
+        dim=0, index=torch.tensor(y), value=1
+    )
+)
+
 ds = datasets.FashionMNIST(
     root="data",
     train=True,
     download=True,
     transform=ToTensor(),
-    target_transform=Lambda(lambda y: torch.zeros(10, dtype=torch.float).scatter_(0, torch.tensor(y), value=1))
+    target_transform=target_transform,
 )
 
 #################################################
@@ -43,7 +49,7 @@ ds = datasets.FashionMNIST(
 # -------------------------------
 #
 # `ToTensor <https://pytorch.org/vision/stable/transforms.html#torchvision.transforms.ToTensor>`_
-# converts a PIL image or NumPy ``ndarray`` into a ``FloatTensor``. and scales
+# converts a PIL image or NumPy ``ndarray`` into a ``FloatTensor`` and scales
 # the image's pixel intensity values in the range [0., 1.]
 #
 
@@ -51,14 +57,11 @@ ds = datasets.FashionMNIST(
 # Lambda Transforms
 # -------------------------------
 #
-# Lambda transforms apply any user-defined lambda function. Here, we define a function
-# to turn the integer into a one-hot encoded tensor.
-# It first creates a zero tensor of size 10 (the number of labels in our dataset) and calls
-# `scatter_ <https://pytorch.org/docs/stable/generated/torch.Tensor.scatter_.html>`_ which assigns a
-# ``value=1`` on the index as given by the label ``y``.
-
-target_transform = Lambda(lambda y: torch.zeros(
-    10, dtype=torch.float).scatter_(dim=0, index=torch.tensor(y), value=1))
+# Lambda transforms apply any user-defined callable. Above, ``target_transform`` wraps a
+# small lambda that turns each label ``y`` into a one-hot encoded tensor: it allocates a
+# length-10 zero vector and uses
+# `scatter_ <https://pytorch.org/docs/stable/generated/torch.Tensor.scatter_.html>`_ to write
+# ``value=1`` at index ``y``.
 
 ######################################################################
 # --------------


### PR DESCRIPTION
Fixes #3822

## Summary
The Transforms tutorial defined `target_transform` twice with slightly different `scatter_` call styles, and the second definition did not change the `FashionMNIST` instance already built above—only the prose matched the second form. This updates the page to a single, consistent definition and fixes a small grammar issue in the ToTensor section.

## Changes
- Define `target_transform` once using `scatter_(dim=0, index=..., value=1)` and `float32`, and pass it into `FashionMNIST`.
- Replace the duplicate executable `target_transform = ...` block with narrative text that refers to the definition above.
- Fix wording: “FloatTensor and scales” (remove stray period after `FloatTensor`).

## Notes
Issue #3822 did not spell out a specific bug; this addresses concrete clarity/correctness problems in the published tutorial source. If maintainers expected a different fix (e.g. download output on the rendered page), happy to follow up.

## Checklist
- [x] The issue that is being fixed is referred in the description (see above "Fixes #3822")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request *(none on #3822 — leaving for maintainers)*
- [x] No unnecessary issues are included into this pull request.