### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/MonthlyLinkCheck.yml
+++ b/.github/workflows/MonthlyLinkCheck.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Check Links

--- a/.github/workflows/_build-tutorials-base.yml
+++ b/.github/workflows/_build-tutorials-base.yml
@@ -52,7 +52,7 @@ jobs:
               docker exec -it $(docker container ps --format '{{.ID}}') bash
 
       - name: Checkout Tutorials
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -130,7 +130,7 @@ jobs:
               docker exec -it $(docker container ps --format '{{.ID}}') bash
 
       - name: Checkout Tutorials
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-redirects.yml
+++ b/.github/workflows/check-redirects.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docathon-label-sync.yml
+++ b/.github/workflows/docathon-label-sync.yml
@@ -12,11 +12,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Check if PR mentions an issue and get labels
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install dependencies

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
           github-secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Linux
         uses: pytorch/test-infra/.github/actions/setup-linux@main

--- a/.github/workflows/link_checkPR.yml
+++ b/.github/workflows/link_checkPR.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -22,7 +22,7 @@ jobs:
 
       - name: Check for Skip Label
         id: skip-label
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const labels = await github.rest.issues.listLabelsOnIssue({

--- a/.github/workflows/lintrunner.yml
+++ b/.github/workflows/lintrunner.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tutorials
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Check for skip label and get changed files
         id: check-files
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let skipCheck = false;
@@ -48,7 +48,7 @@ jobs:
             core.setOutput('files', changedFiles.join('\n'));
             core.setOutput('is-pr', (context.eventName === 'pull_request').toString());
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check-files.outputs.skip != 'true'
         with:
           fetch-depth: 0
@@ -83,7 +83,7 @@ jobs:
             echo "$FILES"
           fi
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: |
           steps.check-files.outputs.skip != 'true' &&
           steps.check.outputs.skip != 'true'


### PR DESCRIPTION
GitHub is deprecating Node.js 20 for GitHub Actions. Actions will be forced to run on Node.js 24 starting June 2, 2026, and Node.js 20 will be removed from runners on September 16, 2026. Example [warning](https://github.com/pytorch/tutorials/actions/runs/24339682714/job/71109101345?pr=3826):
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v3, nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482, pytorch/test-infra/.github/actions/setup-ssh@main. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

This PR updates all actions in this repo to versions that support Node.js 22+:

- actions/checkout: v2/v3/v4 → v6
- actions/setup-python: v2/v4 → v5
- actions/github-script: v6 → v7
