### PR TITLE
Fix shape tuple syntax in tensorqs_tutorial.py

### DIFF
--- a/beginner_source/basics/tensorqs_tutorial.py
+++ b/beginner_source/basics/tensorqs_tutorial.py
@@ -63,7 +63,7 @@ print(f"Random Tensor: \n {x_rand} \n")
 #
 # ``shape`` is a tuple of tensor dimensions. In the functions below, it determines the dimensionality of the output tensor.
 
-shape = (2,3,)
+shape = (2,3)
 rand_tensor = torch.rand(shape)
 ones_tensor = torch.ones(shape)
 zeros_tensor = torch.zeros(shape)


### PR DESCRIPTION
removed unnecessary coma from the 'shape' tuple ;)


## Description
removed an unnecessary coma from a tuple, no issue has been raised for this so I didn't reference any.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
