### PR TITLE
Updated equations of gradients and y_pred

### DIFF
--- a/beginner_source/examples_tensor/polynomial_tensor.py
+++ b/beginner_source/examples_tensor/polynomial_tensor.py
@@ -18,8 +18,8 @@ a PyTorch Tensor can run on either CPU or GPU. To run operations on the GPU,
 just cast the Tensor to a cuda datatype.
 """
 
-import torch
 import math
+import torch
 
 
 dtype = torch.float
@@ -39,7 +39,7 @@ d = torch.randn((), device=device, dtype=dtype)
 learning_rate = 1e-6
 for t in range(2000):
     # Forward pass: compute predicted y
-    y_pred = a + b * x + c * x ** 2 + d * x ** 3
+    y_pred = a + (b * x) + (c * x.pow(2)) + (d * x.pow(3))
 
     # Compute and print loss
     loss = (y_pred - y).pow(2).sum().item()
@@ -47,11 +47,11 @@ for t in range(2000):
         print(t, loss)
 
     # Backprop to compute gradients of a, b, c, d with respect to loss
-    grad_y_pred = 2.0 * (y_pred - y)
+    grad_y_pred = -2.0 * (y - y_pred)
     grad_a = grad_y_pred.sum()
-    grad_b = (grad_y_pred * x).sum()
-    grad_c = (grad_y_pred * x ** 2).sum()
-    grad_d = (grad_y_pred * x ** 3).sum()
+    grad_b = torch.matmul(input=grad_y_pred, other=x).sum()
+    grad_c = torch.matmul(input=grad_y_pred, other=x.pow(2)).sum()
+    grad_d = torch.matmul(input=grad_y_pred, other=x.pow(3)).sum()
 
     # Update weights using gradient descent
     a -= learning_rate * grad_a


### PR DESCRIPTION
# Refactor Backpropagation Equations for Readability and Mathematical Clarity

## Summary
This PR updates the manual backpropagation logic in `polynomial_tensor.py` to use dot products (`torch.matmul`) for gradient calculations, making the implementation more mathematically intuitive and readable.

## Changes
- **Backpropagation**: Replaced element-wise multiplication with `torch.matmul` for `grad_b`, `grad_c`, and `grad_d`. This better represents the dot product operation in the gradient equations.
- **Forward Pass**: Minor refactoring of the `y_pred` equation for improved clarity.

## Rationale
Using `matmul` for these gradients aligns the code closer to standard linear algebra notation, making the tutorial easier to interpret for users learning manual gradient computation.
