### PR TITLE
Update trainingyt.py

### DIFF
--- a/beginner_source/introyt/trainingyt.py
+++ b/beginner_source/introyt/trainingyt.py
@@ -70,11 +70,13 @@ import torchvision.transforms as transforms
 # PyTorch TensorBoard support
 from torch.utils.tensorboard import SummaryWriter
 from datetime import datetime
-
-
-transform = transforms.Compose(
-    [transforms.ToTensor(),
-    transforms.Normalize((0.5,), (0.5,))])
+# v2 transforms API (torchvision >= 0.18)
+from torchvision.transforms import v2
+transform = v2.Compose([
+   v2.ToImage(),
+   v2.ToDtype(torch.float32, scale=True),
+   v2.Normalize((0.5,), (0.5,))
+])
 
 # Create datasets for training & validation, download if necessary
 training_set = torchvision.datasets.FashionMNIST('./data', train=True, transform=transform, download=True)


### PR DESCRIPTION
Fixes #3858

## Description


Replaced deprecated transforms.ToTensor() with v2.ToImage() and v2.ToDtype()
Updated Compose and Normalize to v2 namespace
Added import for torchvision.transforms.v2

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x ] Only one issue is addressed in this pull request
- [ x] Labels from the issue that this PR is fixing are added to this pull request
- [ x] No unnecessary issues are included into this pull request.


cc @subramen