### PR TITLE
Modernize data tutorial to torchvision v2 API

### DIFF
--- a/beginner_source/basics/data_tutorial.py
+++ b/beginner_source/basics/data_tutorial.py
@@ -48,7 +48,7 @@ Datasets & DataLoaders
 import torch
 from torch.utils.data import Dataset
 from torchvision import datasets
-from torchvision.transforms import ToTensor
+from torchvision.transforms import v2
 import matplotlib.pyplot as plt
 
 
@@ -56,14 +56,14 @@ training_data = datasets.FashionMNIST(
     root="data",
     train=True,
     download=True,
-    transform=ToTensor()
+    transform=v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])
 )
 
 test_data = datasets.FashionMNIST(
     root="data",
     train=False,
     download=True,
-    transform=ToTensor()
+    transform=v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])
 )
 
 


### PR DESCRIPTION
Fixes ##3852

## Description
Replace deprecated ToTensor() with v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)]) in both the training and test FashionMNIST splits, and switch the import to the v2 namespace. 

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.


cc @subramen