### PR TITLE
Replace deprecated PyTorch Anaconda channel install instructions

### DIFF
--- a/advanced_source/sharding.rst
+++ b/advanced_source/sharding.rst
@@ -16,16 +16,10 @@ We highly recommend CUDA when using torchRec. If using CUDA: - cuda >=
 
 .. code:: python
 
-    # install conda to make installying pytorch with cudatoolkit 11.3 easier. 
-    !sudo rm Miniconda3-py37_4.9.2-Linux-x86_64.sh Miniconda3-py37_4.9.2-Linux-x86_64.sh.*
-    !sudo wget https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh
-    !sudo chmod +x Miniconda3-py37_4.9.2-Linux-x86_64.sh
-    !sudo bash ./Miniconda3-py37_4.9.2-Linux-x86_64.sh -b -f -p /usr/local
-
-.. code:: python
-
-    # install pytorch with cudatoolkit 11.3
-    !sudo conda install pytorch cudatoolkit=11.3 -c pytorch-nightly -y
+    # Install nightly PyTorch (TorchRec nightly requires PyTorch nightly).
+    # See https://pytorch.org/get-started/locally/ and select "Preview (Nightly)"
+    # for the right command for your platform / CUDA version. For Colab with CUDA 12.1:
+    !pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu121
 
 Installing torchRec will also install
 `FBGEMM <https://github.com/pytorch/fbgemm>`__, a collection of CUDA

--- a/beginner_source/introyt/captumyt.py
+++ b/beginner_source/introyt/captumyt.py
@@ -106,20 +106,14 @@ Before you get started, you need to have a Python environment with:
 -  Matplotlib version 3.3.4, since Captum currently uses a Matplotlib
    function whose arguments have been renamed in later versions
 
-To install Captum in an Anaconda or pip virtual environment, use the
-appropriate command for your environment below:
-
-With ``conda``:
-
-.. code-block:: sh
-
-    conda install pytorch torchvision captum flask-compress matplotlib=3.3.4 -c pytorch
-
-With ``pip``:
+To set up the environment for this tutorial, install PyTorch and
+TorchVision following the instructions at
+`pytorch.org/get-started/locally <https://pytorch.org/get-started/locally/>`__,
+then install the remaining dependencies with ``pip``:
 
 .. code-block:: sh
 
-    pip install torch torchvision captum matplotlib==3.3.4 Flask-Compress
+    pip install captum matplotlib==3.3.4 Flask-Compress
 
 Restart this notebook in the environment you set up, and you’re ready to
 go!

--- a/beginner_source/introyt/captumyt.py
+++ b/beginner_source/introyt/captumyt.py
@@ -107,7 +107,7 @@ Before you get started, you need to have a Python environment with:
    function whose arguments have been renamed in later versions
 
 To set up the environment for this tutorial, install PyTorch and
-TorchVision following the instructions at
+torchvision following the instructions at
 `pytorch.org/get-started/locally <https://pytorch.org/get-started/locally/>`__,
 then install the remaining dependencies with ``pip``:
 

--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -24,18 +24,13 @@ Before You Start
 To run this tutorial, you’ll need to install PyTorch, TorchVision,
 Matplotlib, and TensorBoard.
 
-With ``conda``:
+Install PyTorch and TorchVision following the instructions at
+`pytorch.org/get-started/locally <https://pytorch.org/get-started/locally/>`__.
+Then install the remaining dependencies with ``pip``:
 
 .. code-block:: sh
 
-    conda install pytorch torchvision -c pytorch
-    conda install matplotlib tensorboard
-
-With ``pip``:
-
-.. code-block:: sh
-
-    pip install torch torchvision matplotlib tensorboard
+    pip install matplotlib tensorboard
 
 Once the dependencies are installed, restart this notebook in the Python
 environment where you installed them.

--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -21,10 +21,10 @@ Follow along with the video below or on `youtube <https://www.youtube.com/watch?
 Before You Start
 ----------------
 
-To run this tutorial, you’ll need to install PyTorch, TorchVision,
+To run this tutorial, you’ll need to install PyTorch, torchvision,
 Matplotlib, and TensorBoard.
 
-Install PyTorch and TorchVision following the instructions at
+Install PyTorch and torchvision following the instructions at
 `pytorch.org/get-started/locally <https://pytorch.org/get-started/locally/>`__.
 Then install the remaining dependencies with ``pip``:
 

--- a/recipes_source/recipes/tensorboard_with_pytorch.py
+++ b/recipes_source/recipes/tensorboard_with_pytorch.py
@@ -9,16 +9,12 @@ basic usage with PyTorch, and how to visualize data you logged in TensorBoard UI
 
 Installation
 ----------------------
-PyTorch should be installed to log models and metrics into TensorBoard log 
-directory. The following command will install PyTorch 1.4+ via 
-Anaconda (recommended):
+PyTorch should be installed to log models and metrics into TensorBoard log
+directory. Install PyTorch following the instructions at
+`pytorch.org/get-started/locally <https://pytorch.org/get-started/locally/>`__,
+which provides up-to-date conda, pip, and wheel install options for every platform.
 
-.. code-block:: sh
-
-   $ conda install pytorch torchvision -c pytorch 
-   
-
-or pip
+A typical pip install:
 
 .. code-block:: sh
 

--- a/recipes_source/recipes/tensorboard_with_pytorch.py
+++ b/recipes_source/recipes/tensorboard_with_pytorch.py
@@ -12,7 +12,7 @@ Installation
 PyTorch should be installed to log models and metrics into TensorBoard log
 directory. Install PyTorch following the instructions at
 `pytorch.org/get-started/locally <https://pytorch.org/get-started/locally/>`__,
-which provides up-to-date conda, pip, and wheel install options for every platform.
+which provides up-to-date ``pip`` install options for every platform.
 
 A typical pip install:
 


### PR DESCRIPTION
Fixes #3428 

## Description
Both the `pytorch` and `pytorch-nightly` Anaconda channels stopped receiving updates past PyTorch 2.5 (see pytorch/pytorch#138506). This PR removes the four remaining tutorial pages that still recommend them.

## Files changed                                                                                                                           

- `beginner_source/introyt/tensorboardyt_tutorial.py`                                                                                        
- `recipes_source/recipes/tensorboard_with_pytorch.py`
- `beginner_source/introyt/captumyt.py`                                                                                                      
- `advanced_source/sharding.rst`                                                                                                             

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
