### PR TITLE
Update torchvision transforms in quickstart tutorial

### DIFF
--- a/beginner_source/basics/quickstart_tutorial.py
+++ b/beginner_source/basics/quickstart_tutorial.py
@@ -26,7 +26,7 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader
 from torchvision import datasets
-from torchvision.transforms import ToTensor
+from torchvision.transforms import v2
 
 ######################################################################
 # PyTorch offers domain-specific libraries such as `TorchText <https://pytorch.org/text/stable/index.html>`_,
@@ -43,7 +43,7 @@ training_data = datasets.FashionMNIST(
     root="data",
     train=True,
     download=True,
-    transform=ToTensor(),
+    transform=v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)]),
 )
 
 # Download test data from open datasets.
@@ -51,7 +51,7 @@ test_data = datasets.FashionMNIST(
     root="data",
     train=False,
     download=True,
-    transform=ToTensor(),
+    transform=v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)]),
 )
 
 ######################################################################


### PR DESCRIPTION
Fixes #3851

## Description

Replaced all instances of `from torchvision.transforms import ToTensor` with `from torchvision.transforms import v2` - line 29

Replaced all instances of `transform=ToTensor(),` with `transform=v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)]),` - line 46 & 54


## Checklist

- [X] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [X] Only one issue is addressed in this pull request
- [X] Labels from the issue that this PR is fixing are added to this pull request
- [X] No unnecessary issues are included into this pull request.


cc @subramen