### PR TITLE
fix(optimization_tutorial): replace deprecated ToTensor with v2 transforms

### DIFF
--- a/beginner_source/basics/optimization_tutorial.py
+++ b/beginner_source/basics/optimization_tutorial.py
@@ -28,20 +28,20 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader
 from torchvision import datasets
-from torchvision.transforms import ToTensor
+from torchvision.transforms import v2
 
 training_data = datasets.FashionMNIST(
     root="data",
     train=True,
     download=True,
-    transform=ToTensor()
+    transform=v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])
 )
 
 test_data = datasets.FashionMNIST(
     root="data",
     train=False,
     download=True,
-    transform=ToTensor()
+    transform=v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])
 )
 
 train_dataloader = DataLoader(training_data, batch_size=64)


### PR DESCRIPTION
Fixes #3854 

## Description
- Replace deprecated `torchvision.transforms.ToTensor()` with `v2.Compose([v2.ToImage(), v2.ToDtype(torch.float32, scale=True)])` in `beginner_source/basics/optimization_tutorial.py`
- Aligns the tutorial with the supported torchvision v2 transforms API (ToTensor deprecated since torchvision 0.16)

## Checklist
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.

cc @subramen @svekars 