### PR TITLE
Convert computational graph diagrams to Mermaid

### DIFF
--- a/beginner_source/understanding_leaf_vs_nonleaf_tutorial.py
+++ b/beginner_source/understanding_leaf_vs_nonleaf_tutorial.py
@@ -90,7 +90,7 @@ loss = F.mse_loss(y_pred, y)              # scalar loss
 # .. mermaid::
 #
 #    graph TD
-
+#
 #        x["x<br/>is_leaf=True<br/>requires_grad=False<br/>retains_grad=False<br/>grad=None"]
 #        W["W<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
 #        b["b<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
@@ -99,7 +99,7 @@ loss = F.mse_loss(y_pred, y)              # scalar loss
 #        relu["y_pred = relu(z)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
 #        y["y<br/>is_leaf=True<br/>requires_grad=False<br/>retains_grad=False<br/>grad=None"]
 #        loss["loss = mse(y_pred, y)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
-
+#
 #        x --> matmul
 #        W --> matmul
 #        matmul --> z
@@ -278,22 +278,24 @@ print(f"{loss.grad=}")
 # .. mermaid::
 #
 #    graph TD
-
-#         x["x<br/>is_leaf=True<br/>requires_grad=False<br/>retains_grad=False<br/>grad=None"]
-#         W["W<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=torch.Tensor"]
-#         b["b<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=torch.Tensor"]
-#         matmul["x @ W"]
-#         z["z = x @ W + b<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=True<br/>grad=torch.Tensor"]
-#         relu["y_pred = relu(z)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=True<br/>grad=torch.Tensor"]
-#         y["y<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
-#         loss["loss = mse(y_pred, y)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=True<br/>grad=torch.Tensor"]
-#         x --> matmul
-#         W --> matmul
-#         matmul --> z
-#         b --> z
-#         z --> relu
-#         relu --> loss
-#         y --> loss
+#
+#        x["x<br/>is_leaf=True<br/>requires_grad=False<br/>retains_grad=False<br/>grad=None"]
+#        W["W<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=torch.Tensor"]
+#        b["b<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=torch.Tensor"]
+#        matmul["x @ W"]
+#        z["z = x @ W + b<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=True<br/>grad=torch.Tensor"]
+#        relu["y_pred = relu(z)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=True<br/>grad=torch.Tensor"]
+#        y["y<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
+#        loss["loss = mse(y_pred, y)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=True<br/>grad=torch.Tensor"]
+#
+#        x --> matmul
+#        W --> matmul
+#        matmul --> z
+#        b --> z
+#        z --> relu
+#        relu --> loss
+#        y --> loss
+#
 # If you call ``retain_grad()`` on a leaf tensor, it results in a no-op
 # since leaf tensors already retain their gradients by default (when
 # ``requires_grad=True``).

--- a/beginner_source/understanding_leaf_vs_nonleaf_tutorial.py
+++ b/beginner_source/understanding_leaf_vs_nonleaf_tutorial.py
@@ -87,11 +87,26 @@ loss = F.mse_loss(y_pred, y)              # scalar loss
 #    \cdots \cdot
 #    \frac{\partial \mathbf{f}_1}{\partial \mathbf{x}}
 #
-# .. figure:: /_static/img/understanding_leaf_vs_nonleaf/comp-graph-1.png
-#    :alt: Computational graph after forward pass
+# .. mermaid::
 #
-#    Computational graph after forward pass
-#
+#    graph TD
+
+#        x["x<br/>is_leaf=True<br/>requires_grad=False<br/>retains_grad=False<br/>grad=None"]
+#        W["W<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
+#        b["b<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
+#        matmul["x @ W"]
+#        z["z = x @ W + b<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
+#        relu["y_pred = relu(z)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
+#        y["y<br/>is_leaf=True<br/>requires_grad=False<br/>retains_grad=False<br/>grad=None"]
+#        loss["loss = mse(y_pred, y)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
+
+#        x --> matmul
+#        W --> matmul
+#        matmul --> z
+#        b --> z
+#        z --> relu
+#        relu --> loss
+#        y --> loss
 # PyTorch considers a node to be a *leaf* if it is not the result of a
 # tensor operation with at least one input having ``requires_grad=True``
 # (e.g. ``x``, ``W``, ``b``, and ``y``), and everything else to be
@@ -260,11 +275,25 @@ print(f"{loss.grad=}")
 # convention, this attribute will print ``False`` for any leaf node, even
 # if it requires its gradient.
 #
-# .. figure:: /_static/img/understanding_leaf_vs_nonleaf/comp-graph-2.png
-#    :alt: Computational graph after backward pass
+# .. mermaid::
 #
-#    Computational graph after backward pass
-#
+#    graph TD
+
+#         x["x<br/>is_leaf=True<br/>requires_grad=False<br/>retains_grad=False<br/>grad=None"]
+#         W["W<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=torch.Tensor"]
+#         b["b<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=torch.Tensor"]
+#         matmul["x @ W"]
+#         z["z = x @ W + b<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=True<br/>grad=torch.Tensor"]
+#         relu["y_pred = relu(z)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=True<br/>grad=torch.Tensor"]
+#         y["y<br/>is_leaf=True<br/>requires_grad=True<br/>retains_grad=False<br/>grad=None"]
+#         loss["loss = mse(y_pred, y)<br/>is_leaf=False<br/>requires_grad=True<br/>retains_grad=True<br/>grad=torch.Tensor"]
+#         x --> matmul
+#         W --> matmul
+#         matmul --> z
+#         b --> z
+#         z --> relu
+#         relu --> loss
+#         y --> loss
 # If you call ``retain_grad()`` on a leaf tensor, it results in a no-op
 # since leaf tensors already retain their gradients by default (when
 # ``requires_grad=True``).


### PR DESCRIPTION
Fixes #3580

## Description
- corrected requires_grad value for z in computational graph
- recreated both computational graph diagrams using Mermaid
forward computation:
<img width="1286" height="926" alt="image" src="https://github.com/user-attachments/assets/6964f713-550f-4120-998a-335efc4c1edb" />
backward computation:
<img width="1642" height="917" alt="image" src="https://github.com/user-attachments/assets/3e68827d-d2b0-4177-84d1-0f41d9414a0d" />


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
