### PR TITLE
Update deprecated conda install instructions

### DIFF
--- a/beginner_source/introyt/captumyt.py
+++ b/beginner_source/introyt/captumyt.py
@@ -106,16 +106,7 @@ Before you get started, you need to have a Python environment with:
 -  Matplotlib version 3.3.4, since Captum currently uses a Matplotlib
    function whose arguments have been renamed in later versions
 
-To install Captum in an Anaconda or pip virtual environment, use the
-appropriate command for your environment below:
-
-With ``conda``:
-
-.. code-block:: sh
-
-    conda install pytorch torchvision captum flask-compress matplotlib=3.3.4 -c conda-forge or pip install torch torchvision captum matplotlib==3.3.4 Flask-Compress
-
-With ``pip``:
+To install Captum in a virtual environment, use:
 
 .. code-block:: sh
 

--- a/beginner_source/introyt/captumyt.py
+++ b/beginner_source/introyt/captumyt.py
@@ -113,7 +113,7 @@ With ``conda``:
 
 .. code-block:: sh
 
-    conda install pytorch torchvision captum flask-compress matplotlib=3.3.4 -c pytorch
+    conda install pytorch torchvision captum flask-compress matplotlib=3.3.4 -c conda-forge or pip install torch torchvision captum matplotlib==3.3.4 Flask-Compress
 
 With ``pip``:
 

--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -24,13 +24,6 @@ Before You Start
 To run this tutorial, you’ll need to install PyTorch, TorchVision,
 Matplotlib, and TensorBoard.
 
-With ``conda``:
-
-.. code-block:: sh
-
-    conda install pytorch torchvision -c conda-forge or pip install torch torchvision
-    conda install matplotlib tensorboard
-
 With ``pip``:
 
 .. code-block:: sh

--- a/beginner_source/introyt/tensorboardyt_tutorial.py
+++ b/beginner_source/introyt/tensorboardyt_tutorial.py
@@ -28,7 +28,7 @@ With ``conda``:
 
 .. code-block:: sh
 
-    conda install pytorch torchvision -c pytorch
+    conda install pytorch torchvision -c conda-forge or pip install torch torchvision
     conda install matplotlib tensorboard
 
 With ``pip``:

--- a/recipes_source/recipes/tensorboard_with_pytorch.py
+++ b/recipes_source/recipes/tensorboard_with_pytorch.py
@@ -15,7 +15,7 @@ Anaconda (recommended):
 
 .. code-block:: sh
 
-   $ conda install pytorch torchvision -c pytorch 
+   $ conda install pytorch torchvision -c conda-forge or pip install torch torchvision
    
 
 or pip

--- a/recipes_source/recipes/tensorboard_with_pytorch.py
+++ b/recipes_source/recipes/tensorboard_with_pytorch.py
@@ -9,20 +9,12 @@ basic usage with PyTorch, and how to visualize data you logged in TensorBoard UI
 
 Installation
 ----------------------
-PyTorch should be installed to log models and metrics into TensorBoard log 
-directory. The following command will install PyTorch 1.4+ via 
-Anaconda (recommended):
+PyTorch should be installed to log models and metrics into the TensorBoard log
+directory. Install PyTorch with:
 
 .. code-block:: sh
 
-   $ conda install pytorch torchvision -c conda-forge or pip install torch torchvision
-   
-
-or pip
-
-.. code-block:: sh
-
-   $ pip install torch torchvision
+   pip install torch torchvision
 
 """
 


### PR DESCRIPTION
Fixes #3428 

## Description
Updates outdated tutorial install commands that still use the deprecated pytorch conda channel by replacing them with conda-forge and pip install

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ ] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [ ] No unnecessary issues are included into this pull request.
