### PR TITLE
Update device selection to use torch.accelerator for device-agnostic code

### DIFF
--- a/beginner_source/blitz/tensor_tutorial.py
+++ b/beginner_source/blitz/tensor_tutorial.py
@@ -106,6 +106,8 @@ print(f"Device tensor is stored on: {tensor.device}")
 
 # We move our tensor to the GPU if available
 device = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else 'cpu'
+tensor = tensor.to(device)
+print(f"Device tensor is stored on: {tensor.device}")
 
 
 ######################################################################

--- a/beginner_source/blitz/tensor_tutorial.py
+++ b/beginner_source/blitz/tensor_tutorial.py
@@ -105,9 +105,7 @@ print(f"Device tensor is stored on: {tensor.device}")
 #
 
 # We move our tensor to the GPU if available
-if torch.cuda.is_available():
-  tensor = tensor.to('cuda')
-  print(f"Device tensor is stored on: {tensor.device}")
+device = torch.accelerator.current_accelerator().type if torch.accelerator.is_available() else 'cpu'
 
 
 ######################################################################


### PR DESCRIPTION
Fixes #3876

## Description
Updates suboptimal `torch.cuda.is_available()`, that checks only for CUDA while ignoring other accelerators, with device-agnostic `torch.accelerator.current_accelerator().type`.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
