### PR TITLE
Fix missing .html extension in compilers_index.rst

### DIFF
--- a/compilers_index.rst
+++ b/compilers_index.rst
@@ -166,7 +166,7 @@ control, as well as third-party backend solutions.
    :header: Building a Convolution/Batch Norm fuser in FX
    :card_description: Build a simple FX pass that fuses batch norm into convolution to improve performance during inference.
    :image: _static/img/thumbnails/cropped/Deploying-PyTorch-in-Python-via-a-REST-API-with-Flask.png
-   :link: intermediate/torch_compile_conv_bn_fuser
+   :link: intermediate/torch_compile_conv_bn_fuser.html
    :tags: FX
 
 .. customcarditem::


### PR DESCRIPTION
Fixes #3886 

## Description
The compiler tutorials index page contains an incorrect tutorial link that should be fixed.
Line 155 :link: intermediate/torch_compile_conv_bn_fuser -> :link: intermediate/torch_compile_conv_bn_fuser.html

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
