### PR TITLE
intermediate/rpc_tutorial: fix REINFORCE return calculation across observers

### DIFF
--- a/intermediate_source/rpc_tutorial.rst
+++ b/intermediate_source/rpc_tutorial.rst
@@ -253,11 +253,18 @@ Hence, we skip describing its contents.
     class Agent:
         ...
         def finish_episode(self):
-          # joins probs and rewards from different observers into lists
-          R, probs, rewards = 0, [], []
+          # joins probs and per-observer discounted returns into flat lists;
+          # returns are computed per observer so trajectories from different
+          # observers don't bleed into each other through the reverse cumulative sum
+          probs, returns = [], []
           for ob_id in self.rewards:
+              R = 0
+              ob_returns = []
+              for r in self.rewards[ob_id][::-1]:
+                  R = r + args.gamma * R
+                  ob_returns.insert(0, R)
+              returns.extend(ob_returns)
               probs.extend(self.saved_log_probs[ob_id])
-              rewards.extend(self.rewards[ob_id])
 
           # use the minimum observer reward to calculate the running reward
           min_reward = min([sum(self.rewards[ob_id]) for ob_id in self.rewards])
@@ -268,10 +275,7 @@ Hence, we skip describing its contents.
               self.rewards[ob_id] = []
               self.saved_log_probs[ob_id] = []
 
-          policy_loss, returns = [], []
-          for r in rewards[::-1]:
-              R = r + args.gamma * R
-              returns.insert(0, R)
+          policy_loss = []
           returns = torch.tensor(returns)
           returns = (returns - returns.mean()) / (returns.std() + self.eps)
           for log_prob, R in zip(probs, returns):


### PR DESCRIPTION
## Description

The `finish_episode` code block in [`intermediate/rpc_tutorial`](https://docs.pytorch.org/tutorials/intermediate/rpc_tutorial.html) merges every observer's rewards into one flat list before doing the reverse discounted sum. Because `R` never gets reset between observers, the early steps of observer 1's trajectory end up with observer 2's whole return tacked onto their tail. Those rewards came from an independent environment, which is conceptually wrong in many levels.

The fix: compute the discounted return per observer, then concatenate. Everything around it (running reward, buffer clear, normalization, loss, optimizer step) stays the same. Single-observer behavior is unchanged.

Same change is going up against the mirrored runnable code in pytorch/examples: http://github.com/pytorch/examples/pull/1422.

## Checklist

- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.