### PR TITLE
Update introyt model tutorial APIs

### DIFF
--- a/beginner_source/introyt/modelsyt_tutorial.py
+++ b/beginner_source/introyt/modelsyt_tutorial.py
@@ -48,12 +48,12 @@ import torch
 class TinyModel(torch.nn.Module):
     
     def __init__(self):
-        super(TinyModel, self).__init__()
+        super().__init__()
         
         self.linear1 = torch.nn.Linear(100, 200)
         self.activation = torch.nn.ReLU()
         self.linear2 = torch.nn.Linear(200, 10)
-        self.softmax = torch.nn.Softmax()
+        self.softmax = torch.nn.Softmax(dim=1)
     
     def forward(self, x):
         x = self.linear1(x)
@@ -150,7 +150,7 @@ import torch.nn.functional as F
 class LeNet(torch.nn.Module):
 
     def __init__(self):
-        super(LeNet, self).__init__()
+        super().__init__()
         # 1 input image channel (black & white), 6 output channels, 5x5 square convolution
         # kernel
         self.conv1 = torch.nn.Conv2d(1, 6, 5)
@@ -249,7 +249,7 @@ class LeNet(torch.nn.Module):
 class LSTMTagger(torch.nn.Module):
 
     def __init__(self, embedding_dim, hidden_dim, vocab_size, tagset_size):
-        super(LSTMTagger, self).__init__()
+        super().__init__()
         self.hidden_dim = hidden_dim
 
         self.word_embeddings = torch.nn.Embedding(vocab_size, embedding_dim)


### PR DESCRIPTION
Fixes #3856

## Description
Updates the Building Models tutorial to use the current PyTorch API style:

- specifies `dim=1` for the `TinyModel` softmax layer
- replaces Python 2-style `super(...)` calls with `super().__init__()`

## Verification
- [x] `python3 -m py_compile beginner_source/introyt/modelsyt_tutorial.py`
- [x] `MPLBACKEND=Agg /tmp/docathon-torch-venv/bin/python beginner_source/introyt/modelsyt_tutorial.py`

## Checklist
- [x] The issue that is being fixed is referred in the description
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.

cc @subramen