### PR TITLE
fix description of equation in polynomial_autograd.py example

### DIFF
--- a/beginner_source/examples_autograd/polynomial_autograd.py
+++ b/beginner_source/examples_autograd/polynomial_autograd.py
@@ -2,8 +2,8 @@ r"""
 PyTorch: Tensors and autograd
 -------------------------------
 
-A third order polynomial, trained to predict :math:`y=\sin(x)` from :math:`-\pi`
-to :math:`\pi` by minimizing squared Euclidean distance.
+A third order polynomial, trained to predict :math:`y=e^x` from :math:`-1`
+to :math:`1` by minimizing squared Euclidean distance.
 
 This implementation computes the forward pass using operations on PyTorch
 Tensors, and uses PyTorch autograd to compute gradients.

--- a/beginner_source/examples_autograd/polynomial_autograd.py
+++ b/beginner_source/examples_autograd/polynomial_autograd.py
@@ -14,7 +14,6 @@ Tensor that has ``x.requires_grad=True`` then ``x.grad`` is another Tensor
 holding the gradient of ``x`` with respect to some scalar value.
 """
 import torch
-import math
 
 # We want to be able to train our model on an `accelerator <https://pytorch.org/docs/stable/torch.html#accelerators>`__
 # such as CUDA, MPS, MTIA, or XPU. If the current accelerator is available, we will use it. Otherwise, we use the CPU.
@@ -39,7 +38,6 @@ b = torch.randn((), dtype=dtype, requires_grad=True)
 c = torch.randn((), dtype=dtype, requires_grad=True)
 d = torch.randn((), dtype=dtype, requires_grad=True)
 
-initial_loss = 1.
 learning_rate = 1e-5
 for t in range(5000):
     # Forward pass: compute predicted y using operations on Tensors.

--- a/beginner_source/examples_autograd/polynomial_autograd.py
+++ b/beginner_source/examples_autograd/polynomial_autograd.py
@@ -48,7 +48,7 @@ for t in range(5000):
     # loss.item() gets the scalar value held in the loss.
     loss = (y_pred - y).pow(2).sum()
 
-    # Calculare initial loss, so we can report loss relative to it
+    # Calculate initial loss, so we can report loss relative to it
     if t==0:
         initial_loss=loss.item()
 


### PR DESCRIPTION
fixes #3632

## Description
In the polynomial_autograd.py example, the equation that a + b*x + c*x^2 + d*x^3 converges to changed in a recent commit, from y=sin(x) to y=e^x. However, they didn't change the text description of the equation. This commit fixes that.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] Only one issue is addressed in this pull request
- [x] No unnecessary issues are included into this pull request.
