### PR TITLE
docs(captum): fix in/is typo in Layer Attribution

### DIFF
--- a/beginner_source/introyt/captumyt.py
+++ b/beginner_source/introyt/captumyt.py
@@ -48,7 +48,7 @@ Captum:
    the review is an example of feature attribution.
 -  **Layer Attribution** examines the activity of a model’s hidden layer
    subsequent to a particular input. Examining the spatially-mapped
-   output of a convolutional layer in response to an input image in an
+   output of a convolutional layer in response to an input image is an
    example of layer attribution.
 -  **Neuron Attribution** is analagous to layer attribution, but focuses
    on the activity of a single neuron.


### PR DESCRIPTION
Fixes #3905

## Description

## Summary

Closes #3905. The Captum intro tutorial (`beginner_source/introyt/captumyt.py:51`) ended its Layer Attribution definition with "...an input image in an example of layer attribution" - "in" where "is" was intended. Replace with `is`. The reporter caught this on the rendered docs page (https://docs.pytorch.org/tutorials/beginner/introyt/captumyt.html#id1).

## Why this matters

The bullet two lines above defines Feature Attribution using the parallel construction "...is an example of feature attribution," so the surrounding text already signals what the intended phrasing should be. The typo turns the Layer Attribution sentence into a non-sentence, which trips readers who are otherwise following the intuition Sphinx Gallery is trying to build.

## How to test

```
$ grep -n "an input image is an" beginner_source/introyt/captumyt.py
51:   output of a convolutional layer in response to an input image is an
$ grep -n "an input image in an" beginner_source/introyt/captumyt.py
(empty)
```

`make html-noplot GALLERY_PATTERN="captumyt.py"` builds clean as a quick Sphinx structure validation (no GPU needed).

## Checklist

- [x] The issue that is being fixed is referred in the description (see above "Fixes #3905")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.

AI-assisted.
