### PR TITLE
Fix backpropagation steps order in basics/quickstart_tutorial.py

### DIFF
--- a/beginner_source/basics/quickstart_tutorial.py
+++ b/beginner_source/basics/quickstart_tutorial.py
@@ -140,15 +140,16 @@ def train(dataloader, model, loss_fn, optimizer):
     model.train()
     for batch, (X, y) in enumerate(dataloader):
         X, y = X.to(device), y.to(device)
-
+        
+        # Zero the gradients for batch
+        optimizer.zero_grad()
         # Compute prediction error
         pred = model(X)
         loss = loss_fn(pred, y)
-
         # Backpropagation
         loss.backward()
+        # Optimizer step
         optimizer.step()
-        optimizer.zero_grad()
 
         if batch % 100 == 0:
             loss, current = loss.item(), (batch + 1) * len(X)


### PR DESCRIPTION
Fixes #3904 

## Description
The backpropagation steps are reordered to follow the correct order in `basics/quickstart_tutorial.py`

The reordered set of steps are as follows:
```
        # Zero the gradients for batch
        optimizer.zero_grad()
        # Compute prediction error
        pred = model(X)
        loss = loss_fn(pred, y)
        # Backpropagation
        loss.backward()
        # Optimizer step
        optimizer.step()
```

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [X] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [X] Only one issue is addressed in this pull request
- [X] Labels from the issue that this PR is fixing are added to this pull request
- [X] No unnecessary issues are included into this pull request.
