### PR TITLE
docs: Fix broken link in Tuning Guide (#3912)

### DIFF
--- a/recipes_source/recipes/tuning_guide.py
+++ b/recipes_source/recipes/tuning_guide.py
@@ -116,7 +116,7 @@ for param in model.parameters():
 #
 # Setting gradient to ``None`` has a slightly different numerical behavior than
 # setting it to zero, for more details refer to the
-# `documentation <https://pytorch.org/docs/master/optim.html#torch.optim.Optimizer.zero_grad>`_.
+# `documentation <https://pytorch.org/docs/master/generated/torch.optim.Optimizer.zero_grad.html>`_.
 #
 # Alternatively, call ``model`` or
 # ``optimizer.zero_grad(set_to_none=True)``.


### PR DESCRIPTION
Fixes #3912

## Description

The file `/recipes_source/recipes/tuning_guide.py` contains a link to the documentation for `torch.optim.Optimizer.zero_grad()`, but this link does not work for me.

Proposed change:

* Current link: https://pytorch.org/docs/master/optim.html#torch.optim.Optimizer.zero_grad
* New link: https://pytorch.org/docs/master/generated/torch.optim.Optimizer.zero_grad.html


## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [ x] Only one issue is addressed in this pull request
- [ x] Labels from the issue that this PR is fixing are added to this pull request
- [ x] No unnecessary issues are included into this pull request.
