### PR TITLE
fix: use torch.as_tensor for Mask-RCNN labels to support multiple classes

### DIFF
--- a/intermediate_source/torchvision_tutorial.py
+++ b/intermediate_source/torchvision_tutorial.py
@@ -173,7 +173,7 @@ class PennFudanDataset(torch.utils.data.Dataset):
         boxes = masks_to_boxes(masks)
 
         # there is only one class
-        labels = torch.ones((num_objs,), dtype=torch.int64)
+        labels = torch.as_tensor(obj_ids, dtype=torch.int64)
 
         image_id = idx
         area = (boxes[:, 3] - boxes[:, 1]) * (boxes[:, 2] - boxes[:, 0])


### PR DESCRIPTION
Fixes #960

Change `labels = torch.ones((num_objs,), dtype=torch.int64)` to `labels = torch.as_tensor(obj_ids, dtype=torch.int64)` in the Mask-RCNN tutorial.

This fix correctly maps object IDs to labels, supporting datasets with more than two object instance types instead of assigning all labels to 1.