### PR TITLE
docs: add descriptive labels to PyTorch resource links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # PyTorch Tutorials
 
 
-All the tutorials are now presented as sphinx style documentation at:
-
-## [https://pytorch.org/tutorials](https://pytorch.org/tutorials)
+All the tutorials are now presented as sphinx style documentation on the official [PyTorch Tutorials website](https://pytorch.org/tutorials)
 
 # Asking a question
 
-If you have a question about a tutorial, post in https://dev-discuss.pytorch.org/ rather than creating an issue in this repo. Your question will be answered much faster on the dev-discuss forum.
+If you have a question about a tutorial, post in the [PyTorch Dev Discussions forum](https://dev-discuss.pytorch.org/) rather than creating an issue in this repo. Your question will be answered much faster on the dev-discuss forum.
 
 # Submitting an issue
 


### PR DESCRIPTION
## Description

This PR improves the README by replacing two bare URLs with descriptive link text, making the document easier to scan and more user-friendly.

## Changes

- `https://dev-discuss.pytorch.org/` → "PyTorch Dev-Discussions forum"
- `https://docs.pytorch.org/tutorials/` → "Official PyTorch Tutorials website"

## Motivation

- Bare URLs in documentation can be harder to read and don't convey what the link actually points to at a glance. Adding short descriptive text gives readers context before they click.

## Type of change

- [x] Documentation update

