### PR TITLE
Enable nightly build to test 2.13

### DIFF
--- a/.github/workflows/build-tutorials-nightly.yml
+++ b/.github/workflows/build-tutorials-nightly.yml
@@ -18,9 +18,9 @@ on:
   # pull_request:
 
   # Comment out the below line to disable on the main branch
-  # push:
-  #   branches:
-  #    - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -30,14 +30,14 @@ sudo apt-get install -y pandoc
 # Install PyTorch Nightly for test.
 if [ "${USE_NIGHTLY:-0}" -eq 1 ]; then
   sudo pip uninstall -y torch torchvision torchaudio
-  pip3 install torch==2.12.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu130
+  pip3 install torch==2.13.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu130
   pip show torch
 fi
 
 # Nightly - pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
-# Install 2.12 to merge all 2.12 PRs - uncomment to install nightly binaries (update the version as needed).
+# Install 2.13 to merge all 2.13 PRs - uncomment to install nightly binaries (update the version as needed).
 # sudo pip uninstall -y torch torchvision torchaudio torchtext torchdata
-# pip3 install torch==2.12.0 torchvision torchaudio --no-cache-dir --index-url https://download.pytorch.org/whl/test/cu130
+# pip3 install torch==2.13.0 torchvision torchaudio --no-cache-dir --index-url https://download.pytorch.org/whl/test/cu130
 # Install two language tokenizers for Translation with TorchText tutorial
 # Note: keep this version consistent with the spacy version in requirements.txt
 pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl


### PR DESCRIPTION
## Summary

Branch-cut step to start testing the **2.13** release in tutorials. Mirrors #3831 ("Enable nightly build to test 2.12").

- **`.github/workflows/build-tutorials-nightly.yml`**: re-enable the `push` on `main` trigger so the nightly tutorials build runs against the 2.13 RC binaries.
- **`.jenkins/build.sh`**: pin `torch==2.13.0` (from the `test` channel, cu130) on the `USE_NIGHTLY` path and the commented reference line; update the `2.12 -> 2.13` comment.

`.ci/docker/requirements.txt` is intentionally left at `torch==2.12` — that gets bumped to 2.13 at the later "move to stable binaries" step (the #3891 equivalent), once 2.13 is released.

## Release playbook reference (2.12 -> 2.13)
| Step | 2.12 PR | 2.13 |
|------|---------|------|
| Enable nightly build to test the RC | #3831 | **this PR** |
| Move to stable binaries (requirements.txt) | #3891 | follow-up at release |

## Test plan
- `bash -n .jenkins/build.sh` passes.
- After merge, the nightly tutorials build runs on `main` and installs `torch==2.13.0` from `https://download.pytorch.org/whl/test/cu130` (2.13.0 test wheels are published).
