### PR TITLE
Move to stable binaries 2.13

### DIFF
--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -32,6 +32,8 @@ torchdata
 networkx
 PyHamcrest
 bs4
+# Pin setuptools: awscliv2==2.1.1 imports pkg_resources, which setuptools>=81 removed.
+setuptools<81
 awscliv2==2.1.1
 flask
 spacy==3.7.1  # Keep this version consistent with the model version in .jenkins/build.sh

--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -37,6 +37,8 @@ setuptools<81
 awscliv2==2.1.1
 flask
 spacy==3.7.1  # Keep this version consistent with the model version in .jenkins/build.sh
+# Pin protobuf: ray[serve]==2.55.0 uses FieldDescriptor.label, removed in protobuf>=6.
+protobuf<6
 ray[serve,train,tune]==2.55.0
 tiktoken
 tensorboard

--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -25,7 +25,7 @@ pydantic>=2.10
 fastapi
 matplotlib
 librosa
-torch==2.12
+torch==2.13
 cuda-bindings>=13.1.0  # Required for CUDA graph annotations tutorial
 torchvision
 torchdata


### PR DESCRIPTION
Move the tutorials CI to the stable PyTorch 2.13 binaries for the 2.13 release, mirroring #3891 (which moved to 2.12).

- `.ci/docker/requirements.txt`: `torch==2.12` -> `torch==2.13`

AI assistance (Claude) was used for this change.