### PR TITLE
fix(optimization_tutorial): bullet list indentation in colab

### DIFF
--- a/beginner_source/basics/optimization_tutorial.py
+++ b/beginner_source/basics/optimization_tutorial.py
@@ -76,9 +76,10 @@ model = NeuralNetwork()
 # (`read more <https://pytorch.org/tutorials/beginner/hyperparameter_tuning_tutorial.html>`__ about hyperparameter tuning)
 #
 # We define the following hyperparameters for training:
-#  - **Number of Epochs** - the number of times to iterate over the dataset
-#  - **Batch Size** - the number of data samples propagated through the network before the parameters are updated
-#  - **Learning Rate** - how much to update models parameters at each batch/epoch. Smaller values yield slow learning speed, while large values may result in unpredictable behavior during training.
+#
+# - **Number of Epochs** - the number of times to iterate over the dataset
+# - **Batch Size** - the number of data samples propagated through the network before the parameters are updated
+# - **Learning Rate** - how much to update models parameters at each batch/epoch. Smaller values yield slow learning speed, while large values may result in unpredictable behavior during training.
 #
 
 learning_rate = 1e-3
@@ -95,8 +96,9 @@ epochs = 5
 # iteration of the optimization loop is called an **epoch**.
 #
 # Each epoch consists of two main parts:
-#  - **The Train Loop** - iterate over the training dataset and try to converge to optimal parameters.
-#  - **The Validation/Test Loop** - iterate over the test dataset to check if model performance is improving.
+#
+# - **The Train Loop** - iterate over the training dataset and try to converge to optimal parameters.
+# - **The Validation/Test Loop** - iterate over the test dataset to check if model performance is improving.
 #
 # Let's briefly familiarize ourselves with some of the concepts used in the training loop. Jump ahead to
 # see the :ref:`full-impl-label` of the optimization loop.
@@ -134,9 +136,10 @@ optimizer = torch.optim.SGD(model.parameters(), lr=learning_rate)
 
 #####################################
 # Inside the training loop, optimization happens in three steps:
-#  * Call ``optimizer.zero_grad()`` to reset the gradients of model parameters. Gradients by default add up; to prevent double-counting, we explicitly zero them at each iteration.
-#  * Backpropagate the prediction loss with a call to ``loss.backward()``. PyTorch deposits the gradients of the loss w.r.t. each parameter.
-#  * Once we have our gradients, we call ``optimizer.step()`` to adjust the parameters by the gradients collected in the backward pass.
+#
+# - Call ``optimizer.zero_grad()`` to reset the gradients of model parameters. Gradients by default add up; to prevent double-counting, we explicitly zero them at each iteration.
+# - Backpropagate the prediction loss with a call to ``loss.backward()``. PyTorch deposits the gradients of the loss w.r.t. each parameter.
+# - Once we have our gradients, we call ``optimizer.step()`` to adjust the parameters by the gradients collected in the backward pass.
 
 
 ########################################


### PR DESCRIPTION
Fixes #3939

## Description

Bullet lists under "Hyperparameters", "Optimization Loop", and "Inside the training loop" sections in `optimization_tutorial.py` were rendering as inline text or blockquotes in the generated Jupyter notebook.

**Root cause:** Two issues in the sphinx-gallery to pypandoc pipeline:

1. The list items used `#   -` (3 spaces after `#`). After sphinx-gallery strips `# `, the dash was not at column 0, causing pandoc to treat the list as a block quote.
2. There was no blank line between the preceding paragraph and the list, so pandoc joined everything into one run-on sentence.

**Fix:** Changed the indentation to `# -` (dash at column 0 after stripping) and added a blank `#` line before each list — matching the convention used by dozens of other tutorials in this repo.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [x] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.

## Testing

1. Built the tutorial locally
```
GALLERY_PATTERN="optimization_tutorial.py" sphinx-build -D plot_gallery=0 -b html . _build/html
```
2. Uploaded `_build/html/_downloads/.../optimization_tutorial.ipynb` to Colab.

Colab link - https://colab.research.google.com/drive/1pTyCPUD8WJmRs1x54V2GpF4c2ke1DlQf?usp=sharing

### SS

<img width="1851" height="815" alt="image" src="https://github.com/user-attachments/assets/eccdab10-d5fd-47e3-bde8-0d82b68480d6" />
