### PR TITLE
Fix ResNet18 preprocessing in Captum tutorial

### DIFF
--- a/beginner_source/introyt/captumyt.py
+++ b/beginner_source/introyt/captumyt.py
@@ -143,7 +143,8 @@ from matplotlib.colors import LinearSegmentedColormap
 # now.
 # 
 
-model = models.resnet18(weights='IMAGENET1K_V1')
+weights = models.ResNet18_Weights.IMAGENET1K_V1
+model = models.resnet18(weights=weights)
 model = model.eval()
 
 
@@ -166,9 +167,10 @@ plt.show()
 # folder as well.
 # 
 
-# model expects 224x224 3-color image
+# The model's weights resize the shorter side to 256 pixels before
+# center-cropping to the expected 224x224 3-color image.
 transform = transforms.Compose([
- transforms.Resize(224),
+ transforms.Resize(256),
  transforms.CenterCrop(224),
  transforms.ToTensor()
 ])


### PR DESCRIPTION
Fixes #3936

The Captum tutorial resized images directly to 224 pixels before center cropping. This differs from the preprocessing associated with ResNet18_Weights.IMAGENET1K_V1, which resizes the shorter side to 256 pixels before cropping to 224.

This change uses the explicit weights enum and updates the resize step while preserving the tutorial's existing unnormalized image for Captum visualizations.

### Validation

- python3 -m py_compile beginner_source/introyt/captumyt.py
- Verified the manual preprocessing matches ResNet18_Weights.IMAGENET1K_V1.transforms()
- git diff --check