### PR TITLE
Fix dangling sentence and stray parenthesis in SDPA tutorial

### DIFF
--- a/intermediate_source/scaled_dot_product_attention_tutorial.py
+++ b/intermediate_source/scaled_dot_product_attention_tutorial.py
@@ -374,11 +374,12 @@ print(lower_right_bias)
 # This only has an impact when the attention scores matrix is not square, which is common for decoding use cases.
 # Another way of thinking about this concept is that when you use upper left bias,
 # the 0th token in the query is aligned to the 0th token in the key, while for lower right bias,
+# the last token in the query is aligned to the last token in the key.
 # Assuming the attention score matrix is two dimensional, ``attn_score[0][0]`` is the attention score
 # between the 0th token in the query and the 0th token in the key.
 # For lower right bias, the sequence of q is aligned so that the last token in q is aligned to the last token in k
-# (for example, ``attn_score[-1][-1])`` is all True since the last token in q is at the same position as the last token in k
-# even if the sequence length of q and k are different.
+# (for example, ``attn_score[-1][-1]`` is True since the last token in q is at the same position as the last token in k,
+# even if the sequence lengths of q and k are different).
 
 # These objects are intended to be used with sdpa
 out_upper_left = F.scaled_dot_product_attention(query, key, value, upper_left_bias)


### PR DESCRIPTION
## Description
The sentence ending in "while for lower right bias," was cut off, so this PR completes it. It also moves the stray closing parenthesis in ``attn_score[-1][-1])`` in the same paragraph. Comments only. No issue has been raised for this, so none is referenced.

## Checklist
<!--- Make sure to add `x` to all items in the following checklist: -->
- [ ] The issue that is being fixed is referred in the description (see above "Fixes #ISSUE_NUMBER")
- [x] Only one issue is addressed in this pull request
- [ ] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.
