### PR TITLE
fix: Fix broken nn.Flatten doc link in buildmodel_tutorial

### DIFF
--- a/beginner_source/basics/buildmodel_tutorial.py
+++ b/beginner_source/basics/buildmodel_tutorial.py
@@ -104,7 +104,7 @@ print(input_image.size())
 ##################################################
 # nn.Flatten
 # ^^^^^^^^^^^^^^^^^^^^^^
-# We initialize the `nn.Flatten  <https://pytorch.org/docs/stable/generated/torch.nn.Flatten.html>`_
+# We initialize the `nn.Flatten  <https://docs.pytorch.org/docs/stable/generated/torch.nn.modules.flatten.Flatten.html>`_
 # layer to convert each 2D 28x28 image into a contiguous array of 784 pixel values (
 # the minibatch dimension (at dim=0) is maintained).
 


### PR DESCRIPTION

Fixes #3948

Description

Update the nn.Flatten documentation link in beginner_source/basics/buildmodel_tutorial.py. The previous URL (https://pytorch.org/docs/stable/generated/torch.nn.Flatten.html) returns 404. Replace with the correct stable reference: https://docs.pytorch.org/docs/stable/generated/torch.nn.modules.flatten.Flatten.html.

Checklist

- [x] The issue that is being fixed is referred in the description (see above "Fixes #3948")
- [x] Only one issue is addressed in this pull request
- [x] Labels from the issue that this PR is fixing are added to this pull request
- [x] No unnecessary issues are included into this pull request.