### PR TITLE
Enable nightly build to test 2.14

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -30,14 +30,14 @@ sudo apt-get install -y pandoc
 # Install PyTorch Nightly for test.
 if [ "${USE_NIGHTLY:-0}" -eq 1 ]; then
   sudo pip uninstall -y torch torchvision torchaudio
-  pip3 install torch==2.13.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu130
+  pip3 install torch==2.14.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu130
   pip show torch
 fi
 
 # Nightly - pip install --pre torch torchvision torchaudio -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
-# Install 2.13 to merge all 2.13 PRs - uncomment to install nightly binaries (update the version as needed).
+# Install 2.14 to merge all 2.14 PRs - uncomment to install nightly binaries (update the version as needed).
 # sudo pip uninstall -y torch torchvision torchaudio torchtext torchdata
-# pip3 install torch==2.13.0 torchvision torchaudio --no-cache-dir --index-url https://download.pytorch.org/whl/test/cu130
+# pip3 install torch==2.14.0 torchvision torchaudio --no-cache-dir --index-url https://download.pytorch.org/whl/test/cu130
 # Install two language tokenizers for Translation with TorchText tutorial
 # Note: keep this version consistent with the spacy version in requirements.txt
 pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl


### PR DESCRIPTION
## Summary

Branch-cut step to start testing the **2.14** release in tutorials. Mirrors #3929 ("Enable nightly build to test 2.13").

- **`.jenkins/build.sh`**: pin `torch==2.14.0` (from the `test` channel, cu130) on the `USE_NIGHTLY` path and the commented reference line; update the `2.13 -> 2.14` comment.

Unlike #3929, **no workflow change is needed**: the `push` on `main` trigger in `.github/workflows/build-tutorials-nightly.yml` is still enabled from the 2.13 cycle, so the nightly tutorials build already runs on `main` and will pick up the 2.14 RC binaries with this pin.

`.ci/docker/requirements.txt` is intentionally left at `torch==2.13` — that gets bumped to 2.14 at the later "move to stable binaries" step, once 2.14 is released.

## Verification

`torch==2.14.0+cu130` is published on the test channel, so the pin resolves:

```
https://download.pytorch.org/whl/test/cu130/torch/
  torch-2.14.0+cu130-cp312-cp312-manylinux_2_28_x86_64.whl
  torch-2.14.0+cu130-cp312-cp312-manylinux_2_28_aarch64.whl
```

cu130 remains the right channel for 2.14: CUDA 13.0 is the stable CUDA version in the 2.14 release matrix.

## Release playbook reference (2.13 -> 2.14)

| step | 2.13 | 2.14 |
| --- | --- | --- |
| enable nightly build to test the RC | #3929 | this PR |
| move to stable binaries after release | (2.13 equivalent) | follow-up |
