### PR TITLE
Add non-linearity to hidden state in char-RNN generation tutorial

### DIFF
--- a/intermediate_source/char_rnn_generation_tutorial.py
+++ b/intermediate_source/char_rnn_generation_tutorial.py
@@ -139,7 +139,10 @@ print(unicodeToAscii("O'Néàl"))
 # letter.
 #
 # I added a second linear layer ``o2o`` (after combining hidden and
-# output) to give it more muscle to work with. There's also a dropout
+# output) to give it more muscle to work with. The hidden state is also
+# passed through a ``tanh`` non-linearity before being carried to the
+# next time step, since otherwise it would just be a linear combination
+# of the previous hidden state and the current input. There's also a dropout
 # layer, which `randomly zeros parts of its
 # input <https://arxiv.org/abs/1207.0580>`__ with a given probability
 # (here 0.1) and is usually used to fuzz inputs to prevent overfitting.
@@ -162,12 +165,13 @@ class RNN(nn.Module):
         self.i2h = nn.Linear(n_categories + input_size + hidden_size, hidden_size)
         self.i2o = nn.Linear(n_categories + input_size + hidden_size, output_size)
         self.o2o = nn.Linear(hidden_size + output_size, output_size)
+        self.tanh = nn.Tanh()
         self.dropout = nn.Dropout(0.1)
         self.softmax = nn.LogSoftmax(dim=1)
 
     def forward(self, category, input, hidden):
         input_combined = torch.cat((category, input, hidden), 1)
-        hidden = self.i2h(input_combined)
+        hidden = self.tanh(self.i2h(input_combined))
         output = self.i2o(input_combined)
         output_combined = torch.cat((hidden, output), 1)
         output = self.o2o(output_combined)


### PR DESCRIPTION
Fixes #3953

## Problem

The `RNN.forward()` in this tutorial passed the hidden state straight
through a linear layer with no activation:

```python
hidden = self.i2h(input_combined)
```

This makes `h_t` a linear combination of `h_{t-1}`, the input, and the
category tensor at every timestep — `nn.LogSoftmax` on the output was
the only non-linear operation anywhere in the recurrence.

## Fix

Added a `nn.Tanh()` on the hidden path:

```python
self.tanh = nn.Tanh()
...
hidden = self.tanh(self.i2h(input_combined))
```

This is a minimal, targeted fix for the specific issue raised — it
doesn't change `i2o`, `o2o`, or dropout, so the rest of the
architecture and surrounding explanation stay valid. Also added one
sentence to the "Creating the Network" section explaining why the
non-linearity is there.

## Testing

Ran the tutorial locally for the full 100,000 iterations. Loss trends
down as expected (starts ~2.98, settles in the 1.4–2.4 range with
normal SGD noise), and sampled names after training look reasonable
(e.g. `Rovakin`, `Sarana`, `Chan`), confirming the change doesn't
break training.