### PR TITLE
Move to stable binaries 2.14

### DIFF
--- a/.ci/docker/common/install_docs_reqs.sh
+++ b/.ci/docker/common/install_docs_reqs.sh
@@ -13,7 +13,9 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 
 apt-get update
 apt-get install -y --no-install-recommends yarn
-yarn global add katex --prefix /usr/local
+# Pin katex: 0.18.5 switched to commander@^15, which requires Node >= 22.12
+# while this image installs Node 20, and yarn enforces engines strictly.
+yarn global add katex@0.18.4 --prefix /usr/local
 
 sudo apt-get -y install doxygen
 

--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -25,7 +25,7 @@ pydantic>=2.10
 fastapi
 matplotlib
 librosa
-torch==2.13
+torch==2.14
 cuda-bindings>=13.1.0  # Required for CUDA graph annotations tutorial
 torchvision
 torchdata


### PR DESCRIPTION
Move the tutorials CI to the stable PyTorch **2.14** binaries for the 2.14 release, mirroring #3933 (which moved to 2.13).

- `.ci/docker/requirements.txt`: `torch==2.13` -> `torch==2.14`

`torch==2.14.0` is published on PyPI and is the current latest release, so the unpinned `torchvision` / `torchdata` in the same file resolve against it.

The `setuptools<81` and `protobuf<6` pins that #3933 carried alongside its version bump are already on `main` and need no update.

## Also: unblock the docker build (katex pin)

The first CI run never reached the torch install -- the image build fails two steps earlier, in `install_docs_reqs.sh`:

```
error commander@15.0.0: The engine "node" is incompatible with this module.
      Expected version ">=22.12.0". Got "20.20.2"
error Found incompatible module.
```

This is upstream dependency drift, not a change in this PR. `install_docs_reqs.sh` installs **Node 20** and then runs an unpinned `yarn global add katex`:

| katex | published | commander |
| --- | --- | --- |
| 0.18.4 | 2026-08-10 | `^8.3.0` |
| **0.18.5** | **2026-08-31** | **`^15.0.0`** |

`commander@15.0.0` declares `engines: { node: ">=22.12.0" }`, and yarn enforces `engines` strictly, so any build picking up katex 0.18.5 on this image fails. It affects every PR and `main`, not just this one.

Pinned to `katex@0.18.4` -- the last release on `commander@^8` -- to unblock CI now. The longer-term fix is bumping the image from `setup_20.x` to `setup_22.x` (Node 20 reaches EOL in April 2026 anyway); worth a separate PR so the Node bump can be reviewed on its own blast radius.

AI assistance (Claude) was used for this change.