### PR TITLE
Fix autogradyt tutorial: use_device replaces removed use_cuda kwarg

### DIFF
--- a/beginner_source/introyt/autogradyt_tutorial.py
+++ b/beginner_source/introyt/autogradyt_tutorial.py
@@ -490,7 +490,7 @@ x = torch.randn(2, 3, requires_grad=True)
 y = torch.rand(2, 3, requires_grad=True)
 z = torch.ones(2, 3, requires_grad=True)
 
-with torch.autograd.profiler.profile(use_cuda=run_on_gpu) as prf:
+with torch.autograd.profiler.profile(use_device="cuda" if run_on_gpu else None) as prf:
     for _ in range(1000):
         z = (z / x) * y
 


### PR DESCRIPTION
Fixes: https://github.com/pytorch/tutorials/issues/3816

`beginner_source/introyt/autogradyt_tutorial.py` fails on torch 2.14:

```
File "beginner_source/introyt/autogradyt_tutorial.py", line 493, in <module>
    with torch.autograd.profiler.profile(use_cuda=run_on_gpu) as prf:
TypeError: profile.__init__() got an unexpected keyword argument 'use_cuda'
```

`use_cuda` was the deprecated alias for `use_device` and has been removed in 2.14:

| ref | `profile.__init__` |
| --- | --- |
| `v2.13.0` | `use_cuda=False,  # Deprecated` alongside `use_device=None` |
| `v2.14.0-rc10` | `use_cuda` gone entirely; `use_device=None` remains |

Switch to the supported spelling:

```diff
-with torch.autograd.profiler.profile(use_cuda=run_on_gpu) as prf:
+with torch.autograd.profiler.profile(use_device="cuda" if run_on_gpu else None) as prf:
```

`run_on_gpu` is already computed a few lines above from `torch.cuda.is_available()`, so behaviour is unchanged on both CPU and GPU runners.

## Where this is failing

Surfaced by the nightly lane once #3955 moved it from 2.13.0 to 2.14.0 -- [failing run](https://github.com/pytorch/tutorials/actions/runs/33655943733/job/100334388632). `build-tutorials-nightly.yml` sets `USE_NIGHTLY=1`, so `.jenkins/build.sh` installs `torch==2.14.0` from the test channel.

It will also start failing on the regular PR/push gate once #3959 lands, since that moves `.ci/docker/requirements.txt` from `torch==2.13` to `torch==2.14`. `.jenkins/get_files_to_run.py` shards every tutorial across the workers, so this file runs on every build.

Standalone so it can land ahead of, and independently of, #3955 / #3959.

## Note on the trailing katex traceback

The `sphinxcontrib.katex` `FileNotFoundError: '/tmp/tmp...'` at the end of that log is secondary -- Sphinx raises the gallery `ExtensionError` first, then the katex `build-finished` handler trips over an already-removed temp dir while unwinding. It should disappear with this fix. It is unrelated to the `yarn global add katex` pin in #3959.

AI assistance (Claude) was used for this change.