### PR TITLE
Unbreak tutorials CI: pin katex + fastapi, keep Cayley init on SO(3)

### DIFF
--- a/.ci/docker/common/install_docs_reqs.sh
+++ b/.ci/docker/common/install_docs_reqs.sh
@@ -13,7 +13,9 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 
 apt-get update
 apt-get install -y --no-install-recommends yarn
-yarn global add katex --prefix /usr/local
+# Pin katex: 0.18.5 switched to commander@^15, which requires Node >= 22.12
+# while this image installs Node 20, and yarn enforces engines strictly.
+yarn global add katex@0.18.4 --prefix /usr/local
 
 sudo apt-get -y install doxygen
 

--- a/.ci/docker/requirements.txt
+++ b/.ci/docker/requirements.txt
@@ -22,7 +22,10 @@ pytorch_sphinx_theme2==0.4.9
 tqdm==4.66.1
 numpy==1.24.4
 pydantic>=2.10
-fastapi
+# Pin fastapi: 0.139.2 made router route building thread-safe by adding an
+# _effective_routes_lock (threading.Lock) to APIRouter, which ray[serve]'s
+# @serve.ingress cannot cloudpickle. ray declares fastapi unbounded.
+fastapi<0.139.2
 matplotlib
 librosa
 torch==2.13

--- a/intermediate_source/parametrizations.py
+++ b/intermediate_source/parametrizations.py
@@ -321,8 +321,15 @@ layer_orthogonal.weight = X
 print(torch.dist(layer_orthogonal.weight, X))  # layer_orthogonal.weight == X
 
 ###############################################################################
-# This initialization step can be written more succinctly as
-layer_orthogonal.weight = nn.init.orthogonal_(layer_orthogonal.weight)
+# This initialization step can be written more succinctly by sampling straight
+# into ``layer_orthogonal.weight``. The determinant correction is still needed:
+# ``nn.init.orthogonal_`` samples from ``O(3)``, and when ``det(A) = -1`` the
+# matrix has an eigenvalue at ``-1``, which makes the ``A + I`` that
+# ``CayleyMap.right_inverse`` inverts singular.
+X = nn.init.orthogonal_(layer_orthogonal.weight)
+if X.det() < 0.:
+    X[0].neg_()
+layer_orthogonal.weight = X
 
 ###############################################################################
 # The name of this method comes from the fact that we would often expect


### PR DESCRIPTION
Three fixes for the tutorials CI. Together with #3960 (merged) these clear every failure currently blocking #3959.

## 1. Docker image build -- pin katex to 0.18.4

Any PR that touches the docker context rebuilds the image, and the rebuild fails:

```
error commander@15.0.0: The engine "node" is incompatible with this module.
      Expected version ">=22.12.0". Got "20.20.2"
error Found incompatible module.
```

`install_docs_reqs.sh` installs **Node 20** and then runs an unpinned `yarn global add katex`:

| katex | published | commander |
| --- | --- | --- |
| 0.18.4 | 2026-08-10 | `^8.3.0` |
| **0.18.5** | **2026-08-31** | **`^15.0.0`** |

`commander@15.0.0` declares `engines: { node: ">=22.12.0" }` and yarn enforces `engines` strictly. Pinned to `katex@0.18.4`, the last release on `commander@^8`.

This is the same commit as in #3959 -- it is needed here too, because fix 2 below edits `requirements.txt` and so triggers a rebuild. The longer-term fix is bumping the image from `setup_20.x` to `setup_22.x`; worth a separate PR so the Node bump gets reviewed on its own blast radius.

## 2. `serving_tutorial.py` -- pin fastapi below 0.139.2

```
File "beginner_source/serving_tutorial.py", line 116, in <module>
    class MNISTClassifier:
  ray/serve/api.py:377  pickle_dumps(app, error_msg="Failed to serialize the ASGI app.")
TypeError: Failed to serialize the ASGI app.:
  !!! FAIL serialization: cannot pickle '_thread.lock' object
```

**fastapi 0.139.2** (2026-07-16) landed *"Refactor router route building to make it thread-safe"*, adding to `fastapi/routing.py`:

```python
_effective_routes_lock: Any = field(
    default_factory=threading.Lock, repr=False, compare=False
)
```

`@serve.ingress(app)` cloudpickles the FastAPI app, and a `threading.Lock` is not picklable. `ray` declares `fastapi` with **no upper bound** (`fastapi; extra == "serve"`), and `requirements.txt` left it unpinned, so any image rebuild picks it up. It does not reproduce on `main` today only because that image was last built 2026-07-08, before the release.

Bisected in a venv with `ray[serve]==2.55.0`, reproducing the tutorial's `@serve.deployment` / `@serve.ingress` / `@serve.batch` structure:

| fastapi | starlette | result |
| --- | --- | --- |
| 0.139.0 | 0.50.0 | OK |
| 0.139.1 | 0.50.0 | OK |
| **0.139.2** | 0.50.0 | **FAIL** |
| 0.140.0 | 0.50.0 | FAIL |
| 0.141.1 | 1.6.0 | FAIL |
| 0.139.1 | **1.6.0** | **OK** |

The last row matters: starlette 1.6.0 is fine with fastapi 0.139.1, so despite the concurrent starlette 0.x -> 1.x major bump, **starlette is not implicated** and needs no pin.

A stopgap -- the real fix is upstream in ray, either excluding the lock from the pickled state or not pickling the app. Revisit when ray supports fastapi >= 0.139.2.

## 3. `parametrizations.py` -- keep the Cayley initialization on SO(3)

```
File "intermediate_source/parametrizations.py", line 325, in <module>
    layer_orthogonal.weight = nn.init.orthogonal_(layer_orthogonal.weight)
  parametrizations.py:310  return torch.linalg.solve(A + self.Id, self.Id - A)
torch._C._LinAlgError: torch.linalg.solve: The solver failed because the input matrix is singular.
```

`nn.init.orthogonal_` samples from `O(3)`, not `SO(3)`. For an odd dimension, `det(A) = -1` forces an eigenvalue at `-1`, so `A + I` is exactly singular -- and that is the matrix `CayleyMap.right_inverse` inverts. The block a few lines above already corrects the determinant; the "more succinctly" rewrite dropped it. This applies the same correction there, and says why inline.

200 trials with distinct seeds on torch 2.14.0+cpu, reproducing the tutorial's `Skew` and `CayleyMap` verbatim:

| | succeeded |
| --- | --- |
| current | 185 / 200 |
| with the determinant correction | **200 / 200** |

No seed is set anywhere in the file, which is why this surfaces as a flaky failure rather than a consistent one.

AI assistance (Claude) was used for this change.